### PR TITLE
preprocessor - add tsconfig support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# test-init.sh junk
+tests/button/tsconfig.json
+tests/simple/tsconfig.json

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
-// Except a small part of the code, all of the code here is taken from 
+// Except a small part of the code, all of the code here is taken from
 // https://github.com/evanw/node-source-map-support
 
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var path = require('path');
 var fs = require('fs');
 var tsc = require('typescript');
+var getTSConfigFromFile = require('./lib/get-tsconfig');
 
 // Only install once if called multiple times
 var errorFormatterInstalled = false;
@@ -505,11 +506,9 @@ exports.install = function (options) {
 };
 
 function getTSConfig() {
-  // if a global __TS_CONFIG__ is set, update the compiler options based on that
-  var config = __TS_CONFIG__ || {};
-  config.module = config.module || tsc.ModuleKind.CommonJS;
-  config.jsx = config.jsx || tsc.JsxEmit.React;
-  config.inlineSourceMap = true;
+  var compilerOptions = getTSConfigFromFile({ rootDir: process.cwd() })
+    .compilerOptions;
+  compilerOptions.inlineSourceMap = true;
 
-  return tsc.convertCompilerOptionsFromJson(config).options;
+  return tsc.convertCompilerOptionsFromJson(compilerOptions).options;
 }

--- a/lib/get-tsconfig.js
+++ b/lib/get-tsconfig.js
@@ -36,7 +36,6 @@ module.exports = ({ config }) => {
     if (path.isAbsolute(customTsCfgPath)) {
       tsConfig = getTsCfgOrThrow(customTsCfgPath);
     } else {
-      const customTsCfgRelPath = path.resolve(rootDir, customTsCfgPath);
       tsConfig = getTsCfgOrThrow(
         path.resolve(rootDir, customTsCfgPath)
       );

--- a/lib/get-tsconfig.js
+++ b/lib/get-tsconfig.js
@@ -21,7 +21,7 @@ const getTsCfgOrThrow = (tsCfgPath) => {
 
 module.exports = ({ config }) => {
   const { rootDir } = config;
-  // Look for "ts-jest" in package.json
+  // Look for "tsJest" in package.json
   const pkg = require(path.resolve(rootDir, 'package.json'));
   // Access tsConfig prop if exist
   const customTsCfgPath = objectPath.get(pkg, [

--- a/lib/get-tsconfig.js
+++ b/lib/get-tsconfig.js
@@ -1,0 +1,52 @@
+/**
+ * Try to get tsconfig from package.json
+ * Under key
+ * "tsJest" : {
+ *   "tsconfig": "my-tsconfig.json"
+ * }
+ * Supports relative or absolute path
+ * Will fallback to "<rootDir>/tsconfig.json"
+ */
+const path = require('path');
+const objectPath = require('object-path');
+
+const getTsCfgOrThrow = (tsCfgPath) => {
+  try {
+    return require(tsCfgPath);
+  } catch (er) {
+    console.log('Failed to require tsconfig', tsCfgPath);
+    throw er;
+  }
+};
+
+module.exports = ({ config }) => {
+  const { rootDir } = config;
+  // Look for "ts-jest" in package.json
+  const pkg = require(path.resolve(rootDir, 'package.json'));
+  // Access tsConfig prop if exist
+  const customTsCfgPath = objectPath.get(pkg, [
+    'tsJest',
+    'tsconfig'
+  ]);
+
+  let tsConfig;
+  // If exist
+  if (customTsCfgPath && customTsCfgPath.length > 0) {
+    // Handle absolute or relative paths
+    if (path.isAbsolute(customTsCfgPath)) {
+      tsConfig = getTsCfgOrThrow(customTsCfgPath);
+    } else {
+      const customTsCfgRelPath = path.resolve(rootDir, customTsCfgPath);
+      tsConfig = getTsCfgOrThrow(
+        path.resolve(rootDir, customTsCfgPath)
+      );
+    }
+  } else {
+    // Try default tsconfig if none was provided
+    tsConfig = getTsCfgOrThrow(
+      path.resolve(rootDir, 'tsconfig.json')
+    );
+  }
+
+  return tsConfig;
+};

--- a/lib/get-tsconfig.js
+++ b/lib/get-tsconfig.js
@@ -19,8 +19,7 @@ const getTsCfgOrThrow = (tsCfgPath) => {
   }
 };
 
-module.exports = ({ config }) => {
-  const { rootDir } = config;
+module.exports = ({ rootDir }) => {
   // Look for "tsJest" in package.json
   const pkg = require(path.resolve(rootDir, 'package.json'));
   // Access tsConfig prop if exist

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "typescript": "^2.0.3"
   },
   "devDependencies": {
+    "object-path": "^0.11.2",
     "react": "^15.3.2",
     "react-test-renderer": "^15.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     ]
   },
   "dependencies": {
+    "object-path": "^0.11.2",
     "source-map": "^0.5.6",
     "typescript": "^2.0.3"
   },
   "devDependencies": {
-    "object-path": "^0.11.2",
     "react": "^15.3.2",
     "react-test-renderer": "^15.3.2"
   }

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -13,7 +13,7 @@ module.exports = {
       const transpiled = tsc.transpileModule(
         src,
         {
-          compilerOptions: getTsCompilerOptions(getTSConfig({ config })),
+          compilerOptions: getTsCompilerOptions(getTSConfig({ rootDir: config.rootDir })),
           fileName: path
         });
 

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -1,4 +1,11 @@
 const tsc = require('typescript');
+const getTSConfig = require('./lib/get-tsconfig');
+
+const getTsCompilerOptions = (tsConfig) => {
+  return tsc
+    .convertCompilerOptionsFromJson(tsConfig.compilerOptions)
+    .options;
+};
 
 module.exports = {
   process(src, path, config) {
@@ -6,7 +13,7 @@ module.exports = {
       const transpiled = tsc.transpileModule(
         src,
         {
-          compilerOptions: getTSConfig(config.globals),
+          compilerOptions: getTsCompilerOptions(getTSConfig({ config })),
           fileName: path
         });
 
@@ -18,11 +25,3 @@ module.exports = {
     return src;
   }
 };
-
-function getTSConfig(globals) {
-  const config = globals.__TS_CONFIG__ || {};
-  config.module = config.module || tsc.ModuleKind.CommonJS;
-  config.jsx = config.jsx || tsc.JsxEmit.React;
-
-  return tsc.convertCompilerOptionsFromJson(config).options;
-}

--- a/test-init.sh
+++ b/test-init.sh
@@ -6,8 +6,9 @@
 #
 # This node_modules directory is in turn symlinked to by all the tests
 
-mkdir -p node_modules/ts-jest
+mkdir -p node_modules/ts-jest/lib
 ln -sf $(pwd)/preprocessor.js $(pwd)/node_modules/ts-jest/
+ln -sf $(pwd)/lib/get-tsconfig.js $(pwd)/node_modules/ts-jest/lib
 ln -sf $(pwd)/index.js $(pwd)/node_modules/ts-jest/
 
 ln -sf $(pwd)/node_modules $(pwd)/tests/simple/

--- a/test-init.sh
+++ b/test-init.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-# This script creates a mock ts-jest package in the node_modules 
+# This script creates a mock ts-jest package in the node_modules
 # directory. The contents of this directory are symlinks to index.js and
 # preprocessor.js
 #
 # This node_modules directory is in turn symlinked to by all the tests
 
-mkdir node_modules/ts-jest
-ln -s $(pwd)/preprocessor.js $(pwd)/node_modules/ts-jest/
-ln -s $(pwd)/index.js $(pwd)/node_modules/ts-jest/
+mkdir -p node_modules/ts-jest
+ln -sf $(pwd)/preprocessor.js $(pwd)/node_modules/ts-jest/
+ln -sf $(pwd)/index.js $(pwd)/node_modules/ts-jest/
 
-ln -s $(pwd)/node_modules $(pwd)/tests/simple/
+ln -sf $(pwd)/node_modules $(pwd)/tests/simple/
+
+# link tsconfig
+ln -sf $(pwd)/tsconfig.json $(pwd)/tests/simple/
+ln -sf $(pwd)/tsconfig.json $(pwd)/tests/button/


### PR DESCRIPTION
In response to [issue 8](https://github.com/kulshekhar/ts-jest/issues/8).
- Moved `getTSConfig` to it's own file.
- This branch does not use `global` in `package.json` any longer.

The logic is:
1. Try to read from `package.json` under key `ts-jest` -> `tsConfig`.
If it exist it will try to require the file and throw error if not found.
2. Fallback to project dir and locate `tsconfig.json`.
3 . Error if the first 2 did not work.

The rest is what it was.

Also updated `test-init.sh` to link `tsconfig` since when running jest like that it changes `rootDir` of jest and `tsconfig.json` needs to be in root if there is no `package.json -> ts-jest -> tsConfig` property.

Tests passes.

I have not updated `index.js` to get the new tsconfig.json yet. Maybe need to revert to use global again...do you have any suggestions?