### PR TITLE
Fixing tsconfig issues.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -504,10 +504,10 @@ exports.install = function (options) {
     }
   }
 };
-declare var __TS_CONFIG__: any;
+
 function addSourceMapToTSConfig() {
   // if a global __TS_CONFIG__ is set, update the compiler setting to include inline SourceMap
-  var config = getTSConfig({ __TS_CONFIG__: __TS_CONFIG__ });
+  var config = getTSConfig({ __TS_CONFIG__: global['__TS_CONFIG__'] });
   config.inlineSourceMap = true;
 
   return config;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,15 +2,14 @@ import * as tsc from 'typescript';
 import * as path from 'path';
 
 export function getTSConfig(globals) {
-  let config = globals && globals.__TS_CONFIG__;
+  let config = (globals && globals.__TS_CONFIG__) ? globals.__TS_CONFIG__ : undefined;
   if (config === undefined) {
-    config = require(path.resolve('tsconfig.json')).compilerOptions;
+    config = 'tsconfig.json';
   }
   if (typeof config === 'string') {
     config = require(path.resolve(config)).compilerOptions;
   }
   config.module = config.module || tsc.ModuleKind.CommonJS;
   config.jsx = config.jsx || tsc.JsxEmit.React;
-  
   return tsc.convertCompilerOptionsFromJson(config, undefined).options;
 }

--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -11,7 +11,7 @@ describe('get default ts config', () => {
   });
 
   it('should correctly read tsconfig.json', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig();
 
     expect(result).toEqual ({
@@ -24,7 +24,7 @@ describe('get default ts config', () => {
   });
 
   it('should not read my-tsconfig.json', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig();
 
     expect(result).not.toEqual ({
@@ -37,13 +37,29 @@ describe('get default ts config', () => {
   });
 
   it('should not read inline tsconfig options', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig();
 
     expect(result).not.toEqual ({
       'module': 1,
       'jsx': 2
     });
+  });
+
+  it('should be same results for null/undefined/etc.', () => {
+    const {getTSConfig} = require('../../src/utils');
+    const result = getTSConfig();
+    const resultUndefinedParam = getTSConfig(undefined);
+    const resultNullParam = getTSConfig(null);
+    const resultEmptyParam = getTSConfig({});
+    const resultUndefinedContent = getTSConfig({ __TS_CONFIG__: undefined });
+    const resultNullContent = getTSConfig({ __TS_CONFIG__: null });
+
+    expect(result).toEqual(resultUndefinedParam);
+    expect(result).toEqual(resultNullParam);
+    expect(result).toEqual(resultEmptyParam);
+    expect(result).toEqual(resultUndefinedContent);
+    expect(result).toEqual(resultNullContent);
   });
 
 });

--- a/tests/__tests__/tsconfig-inline.spec.ts
+++ b/tests/__tests__/tsconfig-inline.spec.ts
@@ -11,7 +11,7 @@ describe('get inline ts config', () => {
   });
 
   it('should correctly read inline tsconfig options', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': {
         'module': 'commonjs',
@@ -26,7 +26,7 @@ describe('get inline ts config', () => {
   });
 
   it('should not read tsconfig.json', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': {
         'module': 'commonjs',
@@ -44,7 +44,7 @@ describe('get inline ts config', () => {
   });
 
   it('should not read my-tsconfig.json', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': {
         'module': 'commonjs',

--- a/tests/__tests__/tsconfig-string.spec.ts
+++ b/tests/__tests__/tsconfig-string.spec.ts
@@ -11,7 +11,7 @@ describe('get ts config from string', () => {
   });
 
   it('should correctly read my-tsconfig.json', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': 'my-tsconfig.json'
     });
@@ -26,7 +26,7 @@ describe('get ts config from string', () => {
   });
 
   it('should not read tsconfig.json', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': 'my-tsconfig.json'
     });
@@ -41,7 +41,7 @@ describe('get ts config from string', () => {
   });
 
   it('should not read inline tsconfig options', () => {
-    const {getTSConfig} = require('../../dist/utils');
+    const {getTSConfig} = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': 'my-tsconfig.json'
     });

--- a/tests/button/package.json
+++ b/tests/button/package.json
@@ -6,12 +6,6 @@
       "ts",
       "tsx",
       "js"
-    ],
-    "globals": {
-      "__TS_CONFIG__": {
-        "module": "commonjs",
-        "jsx": "react"
-      }
-    }
+    ]
   }
 }

--- a/tests/simple/package.json
+++ b/tests/simple/package.json
@@ -6,12 +6,6 @@
       "ts",
       "tsx",
       "js"
-    ],
-    "globals": {
-      "__TS_CONFIG__": {
-        "module": "commonjs",
-        "jsx": "react"
-      }
-    }
+    ]
   }
 }


### PR DESCRIPTION
#22 fix. And some small improvements in tests (they are working with part of sources in watch mode).
Fix and test for `null` and empty values in `globals` and `globals.__TS_CONFIG__`.