### PR TITLE
Support code coverage remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ts-jest 
+# ts-jest
 
 [![Build Status](https://semaphoreci.com/api/v1/k/ts-jest/branches/master/badge.svg)](https://semaphoreci.com/k/ts-jest)
 
@@ -41,8 +41,19 @@ Modify your project's `package.json` so that the `jest` section looks something 
 ```
 This setup should allow you to write Jest tests in Typescript and be able to locate errors without any additional gymnastics.
 
+By default `jest` does not provide code coverage remapping for transpiled codes, so if you'd like to have code coverage it needs additional coverage remapping. This can be done via writing custom processing script, or configure `testResultsProcessor` to use built-in coverage remapping in `ts-jest`.
+```json
+{
+  "jest": {
+    "scriptPreprocessor": "<rootDir>/node_modules/ts-jest/preprocessor.js",
+    "testResultsProcessor": "<rootDir>/node_modules/ts-jest/coverageprocessor.js",
+    ...
+  }
+}
+```
+
 ## Options
-By default this package will try to locate `tsconfig.json` and use its compiler options for your `.ts` and `.tsx` files.  
+By default this package will try to locate `tsconfig.json` and use its compiler options for your `.ts` and `.tsx` files.
 But you are able to override this behaviour and provide another path to your config for TypeScript by using `__TS_CONFIG__` option in `globals` for `jest`:
 ```json
 {
@@ -82,5 +93,5 @@ npm test
 
 ## License
 
-Copyright (c) Kulshekhar Kabra.  
-This source code is licensed under the [MIT license](LICENSE). 
+Copyright (c) Kulshekhar Kabra.
+This source code is licensed under the [MIT license](LICENSE).

--- a/coverageprocessor.js
+++ b/coverageprocessor.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/coverageprocessor');

--- a/package.json
+++ b/package.json
@@ -44,17 +44,22 @@
     ]
   },
   "dependencies": {
+    "glob-all": "^3.1.0",
+    "lodash.assign": "^4.2.0",
+    "lodash.partition": "^4.6.0",
     "source-map": "^0.5.6",
-    "typescript": "^2.0.3"
+    "typescript": "^2.0.3",
+    "yargs": "^6.1.1"
   },
   "devDependencies": {
+    "@types/es6-shim": "latest",
     "@types/jest": "latest",
     "@types/react": "latest",
     "@types/source-map": "latest",
     "@types/node": "latest",
     "typescript": "latest",
     "tslint": "latest",
-    
+
     "react": "latest",
     "react-test-renderer": "latest",
     "jest": "latest",

--- a/src/coverageprocessor.ts
+++ b/src/coverageprocessor.ts
@@ -1,0 +1,46 @@
+declare const global: any;
+
+import * as path from 'path';
+
+const partition = require('lodash.partition');
+const loadCoverage = require('remap-istanbul/lib/loadCoverage');
+const remap = require('remap-istanbul/lib/remap');
+const writeReport = require('remap-istanbul/lib/writeReport');
+const istanbulInstrument = require('istanbul-lib-instrument');
+
+function processResult(result: any): void {
+  const { coverageConfig, sourceCache, coverageCollectFiles } = global.__ts_coverage__cache__;
+  if (!coverageConfig.collectCoverage) {
+    return;
+  }
+
+  const coverage = result.testResults.map(value => value.coverage);
+  const coveredFiles = coverage.reduce((acc, x) =>  acc.concat(Object.keys(x)), []);
+  const uncoveredFiles = partition(coverageCollectFiles, x => coveredFiles.includes(x))[1];
+  const coverageOutputPath = path.join(coverageConfig.coverageDirectory, 'remapped');
+
+  //generate 'empty' coverage against uncovered files
+  const emptyCoverage = uncoveredFiles.map(x => {
+    const instrumenter = istanbulInstrument.createInstrumenter();
+    instrumenter.instrumentSync(sourceCache[x], x);
+    const ret = {};
+    ret[x] = instrumenter.fileCoverage;
+    return ret;
+  });
+
+  const mergedCoverage = loadCoverage(coverage.concat(emptyCoverage), { readJSON: (t) => t });
+  const coverageCollector = remap(mergedCoverage, {
+    readFile: (x) => {
+      const key = path.normalize(x);
+      const source = sourceCache[key];
+      delete global.__ts_coverage__cache__.sourceCache[key];
+      return source;
+    }
+  });
+
+  writeReport(coverageCollector, 'html', {}, path.join(coverageOutputPath, 'html'));
+  writeReport(coverageCollector, 'lcovonly', {}, path.join(coverageOutputPath, 'lcov.info'));
+  writeReport(coverageCollector, 'json', {}, path.join(coverageOutputPath, 'coverage.json'));
+}
+
+module.exports = processResult;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-// Except a small part of the code, all of the code here is taken from 
+// Except a small part of the code, all of the code here is taken from
 // https://github.com/evanw/node-source-map-support
 
 import { SourceMapConsumer } from 'source-map';
@@ -507,8 +507,6 @@ exports.install = function (options) {
 
 function addSourceMapToTSConfig() {
   // if a global __TS_CONFIG__ is set, update the compiler setting to include inline SourceMap
-  var config = getTSConfig({ __TS_CONFIG__: global['__TS_CONFIG__'] });
-  config.inlineSourceMap = true;
-
+  var config = getTSConfig({ __TS_CONFIG__: global['__TS_CONFIG__'] }, true);
   return config;
 }

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -1,5 +1,31 @@
+declare const global: any;
+
+import * as nodepath from 'path';
 const tsc = require('typescript');
-const {getTSConfig} = require('./utils');
+const {getTSConfig, getJestConfig} = require('./utils');
+const getPackageRoot = require('jest-util').getPackageRoot;
+const glob = require('glob-all');
+
+const root = getPackageRoot();
+const { collectCoverage,
+        coverageDirectory,
+        coverageReporters,
+        collectCoverageFrom,
+        testResultsProcessor
+      } = getJestConfig(root);
+
+//setting up cache to global object to resultprocessor consume
+if (testResultsProcessor) {
+  global.__ts_coverage__cache__ = {};
+  global.__ts_coverage__cache__.sourceCache = {};
+  global.__ts_coverage__cache__.coverageConfig = {collectCoverage, coverageDirectory, coverageReporters};
+  global.__ts_coverage__cache__.coverageCollectFiles =
+    collectCoverage &&
+    testResultsProcessor &&
+    collectCoverageFrom &&
+    collectCoverageFrom.length ?
+    glob.sync(collectCoverageFrom).map(x => nodepath.resolve(root, x)) : [];
+}
 
 module.exports = {
   process(src, path, config) {
@@ -7,9 +33,14 @@ module.exports = {
       const transpiled = tsc.transpileModule(
         src,
         {
-          compilerOptions: getTSConfig(config.globals),
+          compilerOptions: getTSConfig(config.globals, collectCoverage),
           fileName: path
         });
+
+      //store transpiled code contains source map into cache
+      if (global.__ts_coverage__cache__) {
+        global.__ts_coverage__cache__.sourceCache[path] = transpiled.outputText;
+      }
 
       const modified = `require('ts-jest').install({environment: 'node', emptyCacheBetweenOperations: true});${transpiled.outputText}`;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,72 @@
 import * as tsc from 'typescript';
 import * as path from 'path';
+import * as fs from 'fs';
 
-export function getTSConfig(globals) {
+const assign = require('lodash.assign');
+const normalize = require('jest-config').normalize;
+const setFromArgv = require('jest-config/build/setFromArgv');
+
+function parseConfig(argv) {
+  if (argv.config && typeof argv.config === 'string') {
+    // If the passed in value looks like JSON, treat it as an object.
+    if (argv.config[0] === '{' && argv.config[argv.config.length - 1] === '}') {
+      return JSON.parse(argv.config);
+    }
+  }
+  return argv.config;
+}
+
+function loadJestConfigFromFile(filePath, argv) {
+  const config = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  config.rootDir = config.rootDir ?
+    path.resolve(path.dirname(filePath), config.rootDir) :
+    process.cwd();
+    return normalize(config, argv);
+}
+
+function loadJestConfigFromPackage(filePath, argv) {
+  try {
+    fs.accessSync(filePath, fs.constants.R_OK);
+  } catch (e) {
+    return null;
+  }
+
+  const packageData = require(filePath);
+  const config = packageData.jest || {};
+  const root = path.dirname(filePath);
+  config.rootDir = config.rootDir ? path.resolve(root, config.rootDir) : root;
+  return normalize(config, argv);
+}
+
+function readRawConfig(argv, root) {
+  const rawConfig = parseConfig(argv);
+
+  if (typeof rawConfig === 'string') {
+    return loadJestConfigFromFile(path.resolve(process.cwd(), rawConfig), argv);
+  }
+
+  if (typeof rawConfig === 'object') {
+    const config = assign({}, rawConfig);
+    config.rootDir = config.rootDir || root;
+    return normalize(config, argv);
+  }
+
+  const packageConfig = loadJestConfigFromPackage(path.join(root, 'package.json'), argv);
+  return packageConfig || normalize({ rootDir: root }, argv);
+}
+
+export function getJestConfig(root) {
+  try {
+    const yargs = require('yargs');
+    const argv = yargs(process.argv.slice(2)).argv;
+    const rawConfig = readRawConfig(argv, root);
+    return Object.freeze(setFromArgv(rawConfig, argv));
+  } catch (e) {
+    return {};
+  }
+}
+
+export function getTSConfig(globals, collectCoverage: boolean = false) {
   let config = (globals && globals.__TS_CONFIG__) ? globals.__TS_CONFIG__ : undefined;
   if (config === undefined) {
     config = 'tsconfig.json';
@@ -11,5 +76,16 @@ export function getTSConfig(globals) {
   }
   config.module = config.module || tsc.ModuleKind.CommonJS;
   config.jsx = config.jsx || tsc.JsxEmit.React;
+
+  //inline source with source map for remapping coverage
+  if (collectCoverage) {
+    if (config.sourceMap) {
+      delete config.sourceMap;
+    }
+
+    config.inlineSourceMap = true;
+    config.inlineSources = true;
+  }
+
   return tsc.convertCompilerOptionsFromJson(config, undefined).options;
 }


### PR DESCRIPTION
This PR adds code coverage remapping after tests completes, using [testresultsprocessor](https://facebook.github.io/jest/docs/configuration.html#testresultsprocessor-string) .

### How does it work?
`jest` does not exposes hook to process code coverage after test completes, but provides hook for processing test results `testresultsprocessor`. This PR utilizes those to post process code coverage remapping. Unfortunately this hook is bit limited to post process coverage since this hook is being invoked after coverage processing is done, reason implementation has some workarounds.

### How to use
as same as configuring preprosessor, setting result processor will enable coverage remapping. processor will honor most of coverage configuration.
```js
{
  "scriptPreprocessor": "<rootDir>/node_modules/ts-jest/preprocessor.js",
  "testResultsProcessor": "<rootDir>/node_modules/ts-jest/coverageprocessor.js",
...
```

closes https://github.com/kulshekhar/ts-jest/issues/19.