### PR TITLE
Do not store test case source maps into cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ By default `jest` does not provide code coverage remapping for transpiled codes,
 {
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/ts-jest/preprocessor.js",
-    "testResultsProcessor": "<rootDir>/node_modules/ts-jest/coverageprocessor.js",
-    ...
+    "testResultsProcessor": "<rootDir>/node_modules/ts-jest/coverageprocessor.js"
   }
 }
 ```
+
+> **Note:** If you're experiencing remapping failure with source lookup, it may due to pre-created cache from `jest`. It can be manually deleted, or execute with [`--no-cache`](https://facebook.github.io/jest/docs/troubleshooting.html#caching-issues) to not use those.
 
 ## Options
 By default this package will try to locate `tsconfig.json` and use its compiler options for your `.ts` and `.tsx` files.

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -7,7 +7,8 @@ const getPackageRoot = require('jest-util').getPackageRoot;
 const glob = require('glob-all');
 
 const root = getPackageRoot();
-const { collectCoverage,
+const { testRegex,
+        collectCoverage,
         coverageDirectory,
         coverageReporters,
         collectCoverageFrom,
@@ -37,9 +38,11 @@ module.exports = {
           fileName: path
         });
 
-      //store transpiled code contains source map into cache
+      //store transpiled code contains source map into cache, except test cases
       if (global.__ts_coverage__cache__) {
-        global.__ts_coverage__cache__.sourceCache[path] = transpiled.outputText;
+        if (!testRegex || !path.match(testRegex)) {
+            global.__ts_coverage__cache__.sourceCache[path] = transpiled.outputText;
+        }
       }
 
       const modified = `require('ts-jest').install({environment: 'node', emptyCacheBetweenOperations: true});${transpiled.outputText}`;


### PR DESCRIPTION
While I need to follow up https://github.com/kulshekhar/ts-jest/issues/26, I've added small enhancement to not to store transpiled source into cache, if give file matches with `testRegex` which does not being included in code coverage.

Also added small documentation note can cause failure if cache does not cleared up for existing sources.