### PR TITLE
Add node 7.x to travis config (failure allowed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "7"
   - "6"
   - "4"
 before_install:
@@ -9,4 +10,5 @@ sudo: false
 
 matrix:
   allow_failures:
+    - node_js: "7"
     - node_js: "4"


### PR DESCRIPTION
This should help keep us aware of any breakages that we might encounter in the future