### PR TITLE
Update test coverage for unexpected coverage values

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,10 @@
   "scripts": {
     "build": "tsc -p .",
     "build:watch": "tsc -p . -w",
-
     "clean": "rimraf dist/**/* && rimraf tests/simple/coverage/**/*",
     "clean-build": "npm run clean && npm run build",
-
     "pretest": "npm run clean-build",
     "test": "node scripts/tests.js",
-
     "doc": "doctoc .",
     "prepublish": "npm run clean-build"
   },
@@ -56,15 +53,16 @@
     ]
   },
   "dependencies": {
-    "source-map-support": "^0.4.4",
     "glob-all": "^3.1.0",
+    "istanbul-lib-instrument": "^1.2.0",
+    "jest-config": "^16.0.2",
+    "jest-util": "^16.0.2",
     "lodash.assign": "^4.2.0",
+    "lodash.includes": "^4.3.0",
     "lodash.partition": "^4.6.0",
     "remap-istanbul": "^0.7.0",
-    "istanbul-lib-instrument": "^1.2.0",
-    "yargs": "^6.1.1",
-    "jest-util": "^16.0.2",
-    "jest-config": "^16.0.2"
+    "source-map-support": "^0.4.4",
+    "yargs": "^6.1.1"
   },
   "peerDependencies": {
     "typescript": "~2.0.6",
@@ -78,12 +76,10 @@
     "@types/node": "latest",
     "typescript": "next",
     "tslint": "next",
-
     "react": "latest",
     "react-test-renderer": "latest",
     "jest": "latest",
     "ts-jest": "latest",
-
     "cross-spawn": "latest",
     "rimraf": "latest",
     "doctoc": "latest"

--- a/src/coverageprocessor.ts
+++ b/src/coverageprocessor.ts
@@ -19,12 +19,15 @@ function processResult(result: any): void {
   const uncoveredFiles = partition(coverageCollectFiles, x => coveredFiles.includes(x))[1];
   const coverageOutputPath = path.join(coverageConfig.coverageDirectory || 'coverage', 'remapped');
 
-  //generate 'empty' coverage against uncovered files
+  //generate 'empty' coverage against uncovered files.
+  //If source is non-ts passed by allowJS, return empty since not able to lookup from cache
   const emptyCoverage = uncoveredFiles.map(x => {
-    const instrumenter = istanbulInstrument.createInstrumenter();
-    instrumenter.instrumentSync(sourceCache[x], x);
-    const ret = {};
-    ret[x] = instrumenter.fileCoverage;
+    var ret = {};
+    if (sourceCache[x]) {
+        var instrumenter = istanbulInstrument.createInstrumenter();
+        instrumenter.instrumentSync(sourceCache[x], x);
+        ret[x] = instrumenter.fileCoverage;
+    }
     return ret;
   });
 

--- a/src/coverageprocessor.ts
+++ b/src/coverageprocessor.ts
@@ -2,6 +2,7 @@ declare const global: any;
 
 import * as path from 'path';
 
+const includes = require('lodash.includes');
 const partition = require('lodash.partition');
 const loadCoverage = require('remap-istanbul/lib/loadCoverage');
 const remap = require('remap-istanbul/lib/remap');
@@ -16,7 +17,7 @@ function processResult(result: any): void {
 
   const coverage = result.testResults.map(value => value.coverage);
   const coveredFiles = coverage.reduce((acc, x) => x ? acc.concat(Object.keys(x)) : acc, []);
-  const uncoveredFiles = partition(coverageCollectFiles, x => coveredFiles.includes(x))[1];
+  const uncoveredFiles = partition(coverageCollectFiles, x => includes(coveredFiles, x))[1];
   const coverageOutputPath = path.join(coverageConfig.coverageDirectory || 'coverage', 'remapped');
 
   //generate 'empty' coverage against uncovered files.

--- a/tests/simple/NullCoverage.js
+++ b/tests/simple/NullCoverage.js
@@ -1,0 +1,6 @@
+function nullCoverageFunction(value) {
+  if (value) {
+    return value;
+  }
+  return null;
+}

--- a/tests/simple/package.json
+++ b/tests/simple/package.json
@@ -4,6 +4,10 @@
     "testResultsProcessor": "../../coverageprocessor.js",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "coverageReporters": ["json"],
+    "collectCoverageFrom": [
+      "Hello.ts",
+      "NullCoverage.js"
+    ],
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/tests/simple/tsconfig.json
+++ b/tests/simple/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": false,
-    "jsx": "react"
+    "jsx": "react",
+    "allowJs": true
   }
 }


### PR DESCRIPTION
This PR adds missing test coverage from PR https://github.com/kulshekhar/ts-jest/pull/44, checks coverage processor behavior if unexpected value delivered, especially with `allowJS` options in TSC who uses those configuration options. 