### PR TITLE
Support dev versions of typescript.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "yargs": "^6.1.1"
   },
   "peerDependencies": {
-    "typescript": "^2.0.6",
+    "typescript": "^2.0.6 || ^2.1.0-dev || ^2.2.0-dev",
     "jest": "~17.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Another, possible better option, would be to remove the typescript dependency all together.