### PR TITLE
Relax peer dependency version range on Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "typescript": "^2.0.6 || ^2.1.0-dev || ^2.2.0-dev",
-    "jest": "~18.0.0"
+    "jest": "^18.0.0"
   },
   "devDependencies": {
     "@types/es6-shim": "latest",


### PR DESCRIPTION
Jest's current version is 18.1, and by specifying a version range of `~18.0.0` we preclude using that even though it's fine:

```
└── UNMET PEER DEPENDENCY jest@18.1.0

npm ERR! peer dep missing: jest@~18.0.0, required by ts-jest@18.0.0
npm ERR! code 1
```