### PR TITLE
Hardcode module commonjs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@
 #
 #   Name/Organization <email address>
 
+Alex Jover Morales <alexjovermorales@gmail.com>
 Bartosz Gościński <bargosc@gmail.com>
 Blake Embrey <hello@blakeembrey.com>
 Emil Persson <emil.n.persson@gmail.com>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Versioning
-From version `"jest": "17.0.0"` we are using same MAJOR.MINOR as [`Jest`](https://github.com/facebook/jest).  
+From version `"jest": "17.0.0"` we are using same MAJOR.MINOR as [`Jest`](https://github.com/facebook/jest).
 For `"jest": "< 17.0.0"` use `"ts-jest": "0.1.13"`. Docs for it see [here](https://github.com/kulshekhar/ts-jest/blob/e1f95e524ed62091736f70abf63530f1f107ec03/README.md).
 
 ## Usage
@@ -91,7 +91,10 @@ In `package.json`, inside `jest` section, the `transform` should be like this:
 ```
 
 ## Options
-By default this package will try to locate `tsconfig.json` and use its compiler options for your `.ts` and `.tsx` files.  
+By default this package will try to locate `tsconfig.json` and use its compiler options for your `.ts` and `.tsx` files.
+
+Additionaly, `module` property will be overwritten to `commonjs` since is what Jest expects.
+
 But you are able to override this behaviour and provide another path to your config for TypeScript by using `__TS_CONFIG__` option in `globals` for `jest`:
 ```json
 {
@@ -117,7 +120,7 @@ Or even declare options for `tsc` instead of using separate config, like this:
 ```
 For all available options see [TypeScript docs](https://www.typescriptlang.org/docs/handbook/compiler-options.html).
 
-### Known limitations for TS compiler options 
+### Known limitations for TS compiler options
 - You can't use `"target": "ES6"` while using `node v4` in your test environment;
 - You can't use `"react": "preserve"` for now (see [progress of this issue](https://github.com/kulshekhar/ts-jest/issues/63));
 - If you use `"baseUrl": "<path_to_your_sources>"`, you also have to change `jest config` a little bit:
@@ -125,7 +128,7 @@ For all available options see [TypeScript docs](https://www.typescriptlang.org/d
 "jest": {
   "moduleDirectories": ["node_modules", "<path_to_your_sources>"]
 }
-``` 
+```
 
 ## How to Contribute
 If you have any suggestions/pull requests to turn this into a useful package, just open an issue and I'll be happy to work with you to improve this.
@@ -141,5 +144,5 @@ npm test
 
 ## License
 
-Copyright (c) [Authors](AUTHORS).  
+Copyright (c) [Authors](AUTHORS).
 This source code is licensed under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ In `package.json`, inside `jest` section, the `transform` should be like this:
 ## Options
 By default this package will try to locate `tsconfig.json` and use its compiler options for your `.ts` and `.tsx` files.
 
-Additionaly, `module` property will be overwritten to `commonjs` since is what Jest expects.
+Additionaly, `module` property will be overwritten to `commonjs` since that is the format Jest expects
 
 But you are able to override this behaviour and provide another path to your config for TypeScript by using `__TS_CONFIG__` option in `globals` for `jest`:
 ```json

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,10 @@ export function getTSConfig(globals, collectCoverage: boolean = false) {
       config = Object.assign({}, require(parentConfigPath).compilerOptions, config);
     }
   }
-  config.module = config.module || tsc.ModuleKind.CommonJS;
+
+
+
+  config.module = 'commonjs';
   config.jsx = config.jsx || tsc.JsxEmit.React;
 
   //inline source with source map for remapping coverage

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,8 +79,6 @@ export function getTSConfig(globals, collectCoverage: boolean = false) {
     }
   }
 
-
-
   config.module = 'commonjs';
   config.jsx = config.jsx || tsc.JsxEmit.React;
 

--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -63,4 +63,16 @@ describe('get default ts config', () => {
     expect(result).toEqual(resultNullContent);
   });
 
+  it('should set the module to CommonJS if it is not', () => {
+    const {getTSConfig} = require('../../src/utils');
+    const config = getTSConfig({
+      '__TS_CONFIG__': {
+        'module': 'es2015'
+      }
+    });
+    console.log(config)
+
+    expect(config.module).toBe(ts.ModuleKind.CommonJS);
+  });
+
 });


### PR DESCRIPTION
Related to #122 

It additionally adds myself to authors and includes tests and the note in the option section of Readme.

Plus, there was a bug (solved by this PR). The `convertCompilerOptionsFromJson` expects `config.module` to be an string in order to be parsed (like if it comes from a tsconfig.json). So that was returning undefined and not working:

```javascript
// Wrong
config.module = tsc.ModuleKind.CommonJS
...
tsc.convertCompilerOptionsFromJson(config, undefined).options.module // is undefined
```

```javascript
// Right
config.module = 'commonjs'
...
tsc.convertCompilerOptionsFromJson(config, undefined).options.module // is 5 (the value of tsc.ModuleKind.CommonJS)
```