### PR TITLE
Prevent ENAMETOOLONG by hashing path names

### DIFF
--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -4,6 +4,7 @@ import {getTSConfig} from './utils';
 // TODO: rework next to ES6 style imports
 const glob = require('glob-all');
 const nodepath = require('path');
+const crypto = require('crypto');
 
 export function process(src, path, config) {
     const compilerOptions = getTSConfig(config.globals, config.collectCoverage);
@@ -30,7 +31,7 @@ export function process(src, path, config) {
 
         //store transpiled code contains source map into cache, except test cases
         if (!config.testRegex || !path.match(config.testRegex)) {
-            fs.outputFileSync(nodepath.join(config.cacheDirectory, '/ts-jest/', new Buffer(path).toString('base64')), transpiled.outputText);
+            fs.outputFileSync(nodepath.join(config.cacheDirectory, '/ts-jest/', crypto.createHash('md5').update(path).digest('hex')), transpiled.outputText);
         }
 
         const start = transpiled.outputText.length > 12 ? transpiled.outputText.substr(1, 10) : '';


### PR DESCRIPTION
We have an angular 2 project which includes a component lib in the node_modules folder, which must be complied by jest since it is shipped with `.ts` files. This results in very long file names like this one:

`/Users/wayne/web/myProject-newAmazingApp-ui/node_modules/myProject-components-ui/src/lib/components/container/my-dialog-edit-select-box/my-edit-select-box-item/my-edit-select-box-item.component.html`

When running jest I receive the following error:

```
ENAMETOOLONG: name too long, open '/var/folders/lr/dg7jdw9n2f7d8j1pns2drsfr0000gn/T/jest/ts-jest/L1VzZXJzL3BpdHRpL3dlYi91bHBpYW4tZmFsbGJlYXJiZWl0dW5nLXVpL25vZGVfbW9kdWxlcy91bHBpYW4tY29tcG9uZW50cy11aS9zcmMvbGliL2NvbXBvbmVudHMvY29udGFpbmVyL3VsLWRpYWxvZy1lZGl0LXNlbGVjdC1ib3gvdWwtZWRpdC1zZWxlY3QtYm94LWl0ZW0vdWwtZWRpdC1zZWxlY3QtYm94LWl0ZW0uY29tcG9uZW50LnRz'
      
      at Object.fs.openSync (fs.js:584:18)
      at Object.fs.writeFileSync (fs.js:1316:33)
      at process (node_modules/ts-jest/dist/preprocessor.js:25:16)
      at Object.module.exports.process (node_modules/jest-preset-angular/preprocessor.js:12:10)
```

The hash of the path name for the cache is too long. So I used the same approach as here (https://github.com/facebook/jest/pull/2559) to generate shorter path names.