### PR TITLE
Allow configuration of TypeScript location

### DIFF
--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs-extra';
-import * as tsc from 'typescript';
-import { getTSConfig } from './utils';
+import { getTsc, getTSConfig } from './utils';
 // TODO: rework next to ES6 style imports
 const glob = require('glob-all');
 const nodepath = require('path');
@@ -22,6 +21,7 @@ export function process(src, path, config) {
         : isTsFile;
 
     if (processFile) {
+        const tsc = getTsc(config.globals);
         const transpiled = tsc.transpileModule(
             src,
             {

--- a/src/transpile-if-ts.ts
+++ b/src/transpile-if-ts.ts
@@ -1,9 +1,9 @@
-import * as tsc from 'typescript';
-import { getTSConfig } from './utils';
+import { getTsc, getTSConfig } from './utils';
 
 export function transpileIfTypescript(path, contents, config?) {
   if (path && (path.endsWith('.tsx') || path.endsWith('.ts'))) {
 
+    const tsc = getTsc(config && config.globals);
     let transpiled = tsc.transpileModule(contents, {
       compilerOptions: getTSConfig(config || { __TS_CONFIG__: global['__TS_CONFIG__'] }, true),
       fileName: path

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import * as tsc from 'typescript';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as tsconfig from 'tsconfig';
@@ -64,6 +63,14 @@ export function getJestConfig(root) {
   return Object.freeze(setFromArgv(rawConfig, argv));
 }
 
+export function getTsc(globals) {
+  const tsPath = globals && globals.__TS_PATH__;
+  if (typeof tsPath === 'string') {
+    return require(tsPath);
+  }
+  return require('typescript');
+}
+
 export function getTSConfig(globals, collectCoverage: boolean = false) {
   let config = (globals && globals.__TS_CONFIG__) ? globals.__TS_CONFIG__ : 'tsconfig.json';
 
@@ -82,18 +89,20 @@ export function getTSConfig(globals, collectCoverage: boolean = false) {
 
     if (configFileName === 'tsconfig.json') {
       // hardcode module to 'commonjs' in case the config is being loaded
-      // from the default tsconfig file. This is to ensure that coverage 
-      // works well. If there's a need to override, it can be done using 
+      // from the default tsconfig file. This is to ensure that coverage
+      // works well. If there's a need to override, it can be done using
       // the global __TS_CONFIG__ setting in Jest config
       config.module = 'commonjs';
     }
   }
-  
+
   config.module = config.module || 'commonjs';
 
   if (config.inlineSourceMap !== false) {
     config.inlineSourceMap = true;
   }
+
+  const tsc = getTsc(globals);
 
   config.jsx = config.jsx || tsc.JsxEmit.React;
 


### PR DESCRIPTION
### Motivation

Right now `ts-jest` requires the `typescript` package be installed alongside it. In some cases it is desirable to use an instance of TypeScript installed elsewhere, such as in the case where there is a single package used to standardize on TypeScript version and configuration.

This PR adds the ability consume the `typescript` package from a configurable location.

### Usage

```json
{
  "jest": {
    "globals": {
      "__TS_PATH__": "./node_modules/@company/internal-typescript/node_modules/typescript/lib/"
    }
  }
}
```

### TODO

- [ ] Write some tests
- [ ] Document the option
- [ ] Figure out how to give `getTsc` a type other than `any`.