### PR TITLE
Support synthetic default imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     ]
   },
   "dependencies": {
+    "babel-preset-es2015": "^6.24.1",
     "fs-extra": "^2.1.2",
     "glob-all": "^3.1.0",
     "istanbul-lib-instrument": "^1.2.0",
@@ -70,8 +71,8 @@
     "yargs": "^7.0.2"
   },
   "peerDependencies": {
-    "typescript": "^2.1.0",
-    "jest": "^19.0.0"
+    "jest": "^19.0.0",
+    "typescript": "^2.1.0"
   },
   "devDependencies": {
     "@types/es6-shim": "latest",

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -4,7 +4,7 @@ import { getTSConfig } from './utils';
 // TODO: rework next to ES6 style imports
 const glob = require('glob-all');
 const nodepath = require('path');
-const babelJest = require('babel-jest');
+const babelJest = require('babel-jest').createTransformer({presets: ['es2015']});
 
 export function process(src, path, config, transformOptions) {
     const root = require('jest-util').getPackageRoot();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,13 +82,13 @@ export function getTSConfig(globals, collectCoverage: boolean = false) {
 
     if (configFileName === 'tsconfig.json') {
       // hardcode module to 'commonjs' in case the config is being loaded
-      // from the default tsconfig file. This is to ensure that coverage 
-      // works well. If there's a need to override, it can be done using 
+      // from the default tsconfig file. This is to ensure that coverage
+      // works well. If there's a need to override, it can be done using
       // the global __TS_CONFIG__ setting in Jest config
       config.module = 'commonjs';
     }
   }
-  
+
   config.module = config.module || 'commonjs';
 
   if (config.inlineSourceMap !== false) {
@@ -107,5 +107,10 @@ export function getTSConfig(globals, collectCoverage: boolean = false) {
     config.inlineSources = true;
   }
 
+  if (config.allowSyntheticDefaultImports) {
+    // compile ts to es2015 and transform with babel afterwards
+    config.module = 'es2015';
+    config.target = 'es2015';
+  }
   return tsc.convertCompilerOptionsFromJson(config, undefined).options;
 }

--- a/tests/__tests__/synthetic-default-imports.spec.ts
+++ b/tests/__tests__/synthetic-default-imports.spec.ts
@@ -1,0 +1,28 @@
+import { } from 'jest';
+import { } from 'node';
+import runJest from '../__helpers__/runJest';
+
+describe('synthetic default imports', () => {
+
+  it('should not work when the compiler option is false', () => {
+
+    const result = runJest('../no-synthetic-default', ['--no-cache']);
+
+    const stderr = result.stderr.toString();
+
+    expect(result.status).toBe(1);
+    expect(stderr).toContain(`TypeError: Cannot read property 'someExport' of undefined`);
+    expect(stderr).toContain('module.test.ts:6:15');
+
+  });
+
+  it('should work when the compiler option is true', () => {
+
+    const result = runJest('../synthetic-default', ['--no-cache']);
+
+    expect(result.status).toBe(0);
+
+  });
+
+
+});

--- a/tests/no-synthetic-default/__tests__/module.test.ts
+++ b/tests/no-synthetic-default/__tests__/module.test.ts
@@ -1,0 +1,8 @@
+import mod from '../module';
+import 'jest';
+
+describe('the module which has no default export', () => {
+  it('should return funky junk when trying to access its exports', () => {
+    expect(mod.someExport).toBe('someExport');
+  });
+});

--- a/tests/no-synthetic-default/module.js
+++ b/tests/no-synthetic-default/module.js
@@ -1,0 +1,3 @@
+module.exports = {
+  someExport: 'someExport'
+}

--- a/tests/no-synthetic-default/package.json
+++ b/tests/no-synthetic-default/package.json
@@ -1,0 +1,14 @@
+{
+  "jest": {
+    "transform": {
+      ".(ts|tsx)": "../../preprocessor.js"
+    },
+    "moduleDirectories": ["node_modules", "src"],
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ]
+  }
+}

--- a/tests/no-synthetic-default/tsconfig.json
+++ b/tests/no-synthetic-default/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": false
+  }
+}

--- a/tests/synthetic-default/__tests__/module.test.ts
+++ b/tests/synthetic-default/__tests__/module.test.ts
@@ -1,0 +1,9 @@
+import mod from '../module';
+import 'jest';
+
+
+describe('the module which has no default export', () => {
+  it('should return sensible values when trying to access its exports', () => {
+    expect(mod.someExport).toBe('someExport');
+  });
+});

--- a/tests/synthetic-default/module.js
+++ b/tests/synthetic-default/module.js
@@ -1,0 +1,3 @@
+module.exports = {
+  someExport: 'someExport'
+}

--- a/tests/synthetic-default/package.json
+++ b/tests/synthetic-default/package.json
@@ -1,0 +1,17 @@
+{
+  "jest": {
+    "transform": {
+      ".(ts|tsx)": "../../preprocessor.js"
+    },
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ]
+  }
+}

--- a/tests/synthetic-default/tsconfig.json
+++ b/tests/synthetic-default/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true
+  }
+}


### PR DESCRIPTION
Hey, thanks for this lib. It has been super helpful :+1:

As discussed in #146, TypeScript doesn't implement default synthetic imports, so if you want to use those while targeting CommonJS (which Jest requires) you have to add an extra compile step, e.g. with Babel.

Usage of babel-jest as a post-ts-transform step was briefly discussed in #63, and that's what I have done in this PR.

Perf obviously takes a hit, but thanks to Jest's caching you rarely notice.