### PR TITLE
Update @maxdeviant's email address

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,7 +16,7 @@ Henry Zektser <japhar81@gmail.com>
 Ihor Chulinda <ichulinda@gmail.com>
 Joscha Feth <joscha@feth.com>
 Kulshekhar Kabra <kulshekhar@users.noreply.github.com>
-Marshall Bowers <mbowers@gravic.com>
+Marshall Bowers <elliott.codes@gmail.com>
 Maxim Samoilov <samoilowmaxim@gmail.com>
 OJ Kwon <kwon.ohjoong@gmail.com>
 Tom Crockett <tomcrockett@tuplehealth.com>


### PR DESCRIPTION
I committed at work, so it used my work email, but I prefer to use my personal email for OSS activity :smile: