### PR TITLE
Fix/babel transpile only module statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "dependencies": {
-    "babel-preset-es2015": "^6.24.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "fs-extra": "^2.1.2",
     "glob-all": "^3.1.0",
     "istanbul-lib-instrument": "^1.2.0",
@@ -71,6 +71,7 @@
     "yargs": "^7.0.2"
   },
   "peerDependencies": {
+    "babel-jest": "^19.0.0",
     "jest": "^19.0.0",
     "typescript": "^2.1.0"
   },

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -4,7 +4,11 @@ import { getTSConfig } from './utils';
 // TODO: rework next to ES6 style imports
 const glob = require('glob-all');
 const nodepath = require('path');
-const babelJest = require('babel-jest').createTransformer({presets: ['es2015']});
+const babelJest = require('babel-jest')
+  .createTransformer({
+      presets: [],
+      plugins: ['transform-es2015-modules-commonjs']
+  });
 
 export function process(src, path, config, transformOptions) {
     const root = require('jest-util').getPackageRoot();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,7 +110,6 @@ export function getTSConfig(globals, collectCoverage: boolean = false) {
   if (config.allowSyntheticDefaultImports) {
     // compile ts to es2015 and transform with babel afterwards
     config.module = 'es2015';
-    config.target = 'es2015';
   }
   return tsc.convertCompilerOptionsFromJson(config, undefined).options;
 }

--- a/tests/synthetic-default/__tests__/module.test.ts
+++ b/tests/synthetic-default/__tests__/module.test.ts
@@ -7,3 +7,16 @@ describe('the module which has no default export', () => {
     expect(mod.someExport).toBe('someExport');
   });
 });
+
+async function noop() {
+  return Promise.resolve('noop');
+}
+
+describe('async-await stuff', () => {
+  it('should be compiled by TS not Babel', async (done) => {
+    const g = await noop();
+
+    expect(g).toBe('noop');
+    done();
+  });
+});


### PR DESCRIPTION
This replaces #179, and apparently solves the issue it identifies, and adds `babel-jest` as a peer dependency to close #177