### PR TITLE
make babel-jest normal dependency

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Bartosz Gościński <bargosc@gmail.com>
 Blake Embrey <hello@blakeembrey.com>
 Chong Guo <cguo@azendless.com>
 Daniel Perez Alvarez <unindented@gmail.com>
+David Sheldrick <djsheldrick@gmail.com>
 Emil Persson <emil.n.persson@gmail.com>
 Eric Anderson <e@ericlanderson.com>
 Felipe Matos <felipems@yahoo.com.br>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "19.0.12",
+  "version": "19.0.13",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     ]
   },
   "dependencies": {
+    "babel-jest": "^19.0.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "fs-extra": "^2.1.2",
     "glob-all": "^3.1.0",
@@ -71,7 +72,6 @@
     "yargs": "^7.0.2"
   },
   "peerDependencies": {
-    "babel-jest": "^19.0.0",
     "jest": "^19.0.0",
     "typescript": "^2.1.0"
   },


### PR DESCRIPTION
As @blakeembrey pointed out here: https://github.com/kulshekhar/ts-jest/pull/180#issuecomment-297470047 babel-jest should not be a peer dependency because that would mean consumers of ts-jest would have to explicitly add it as dependency in their package.json, which would be a breaking change.