### PR TITLE
fix: peer dependency against Typescript 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "jest": "^20.0.0",
-    "typescript": "^2.1.0"
+    "typescript": "2.x"
   },
   "devDependencies": {
     "@types/es6-shim": "latest",


### PR DESCRIPTION
Fixes:

```
yarn v0.23.2
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "ts-jest@20.0.0" has incorrect peer dependency "typescript@^2.1.0".
```