### PR TITLE
Code cleanups

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "babel-jest": "^20.0.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "fs-extra": "^3.0.0",
-    "glob-all": "^3.1.0",
     "jest-config": "^20.0.0",
     "jest-util": "^20.0.0",
     "pkg-dir": "^2.0.0",

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs-extra';
 import * as tsc from 'typescript';
 import { getTSConfig, getTSJestConfig } from './utils';
-// TODO: rework next to ES6 style imports
 import * as nodepath from 'path';
 import * as babel from 'babel-jest';
 

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs-extra';
 import * as tsc from 'typescript';
 import { getTSConfig, getTSJestConfig } from './utils';
 // TODO: rework next to ES6 style imports
-const glob = require('glob-all');
 const nodepath = require('path');
 const babelJest = require('babel-jest')
     .createTransformer({

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -2,8 +2,10 @@ import * as fs from 'fs-extra';
 import * as tsc from 'typescript';
 import { getTSConfig, getTSJestConfig } from './utils';
 // TODO: rework next to ES6 style imports
-const nodepath = require('path');
-const babelJest = require('babel-jest')
+import * as nodepath from 'path';
+import * as babel from 'babel-jest';
+
+const babelJest = babel
     .createTransformer({
         presets: [],
         plugins: ['transform-es2015-modules-commonjs']

--- a/tests/__tests__/import.spec.ts
+++ b/tests/__tests__/import.spec.ts
@@ -1,6 +1,3 @@
-import { } from 'jest';
-import { } from 'node';
-import * as path from 'path';
 import runJest from '../__helpers__/runJest';
 
 describe('import with relative and absolute paths', () => {

--- a/tests/__tests__/synthetic-default-imports.spec.ts
+++ b/tests/__tests__/synthetic-default-imports.spec.ts
@@ -1,5 +1,3 @@
-import { } from 'jest';
-import { } from 'node';
 import runJest from '../__helpers__/runJest';
 
 describe('synthetic default imports', () => {

--- a/tests/__tests__/ts-compilation.spec.ts
+++ b/tests/__tests__/ts-compilation.spec.ts
@@ -1,5 +1,3 @@
-import { } from 'jest';
-import { } from 'node';
 import runJest from '../__helpers__/runJest';
 
 describe('hello_world', () => {

--- a/tests/__tests__/ts-coverage-async.spec.ts
+++ b/tests/__tests__/ts-coverage-async.spec.ts
@@ -1,19 +1,6 @@
 import runJest from '../__helpers__/runJest';
-import * as fs from 'fs';
-import * as path from 'path';
 
 describe('hello_world', () => {
-  const snapshot =
-    `------------------|----------|----------|----------|----------|----------------|
-File              |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-------------------|----------|----------|----------|----------|----------------|
- simple-async${path.sep}    |    66.67 |    33.33 |    66.67 |    61.54 |                |
-  Hello.ts        |    90.91 |       50 |       80 |    88.89 |             20 |
-  NullCoverage.js |        0 |        0 |        0 |        0 |        1,2,3,5 |
-------------------|----------|----------|----------|----------|----------------|
-All files         |    66.67 |    33.33 |    66.67 |    61.54 |                |
-------------------|----------|----------|----------|----------|----------------|
-`;
 
   it('should run successfully', () => {
     const result = runJest('../simple-async', ['--no-cache', '--coverage']);

--- a/tests/__tests__/ts-coverage.spec.ts
+++ b/tests/__tests__/ts-coverage.spec.ts
@@ -1,6 +1,4 @@
 import runJest from '../__helpers__/runJest';
-import * as fs from 'fs';
-import * as path from 'path';
 
 describe('hello_world', () => {
 

--- a/tests/__tests__/ts-errors.spec.ts
+++ b/tests/__tests__/ts-errors.spec.ts
@@ -1,5 +1,3 @@
-import { } from 'jest';
-import { } from 'node';
 import runJest from '../__helpers__/runJest';
 
 describe('hello_world', () => {

--- a/tests/__tests__/tsconfig-comments.spec.ts
+++ b/tests/__tests__/tsconfig-comments.spec.ts
@@ -1,10 +1,8 @@
-import { } from 'jest';
-import { } from 'node';
-import * as ts from 'typescript';
+jest.mock('path');
 import * as fs from 'fs';
 import * as tsconfig from 'tsconfig';
+import {getTSConfig} from '../../src/utils';
 
-jest.mock('path');
 
 describe('parse tsconfig with comments', () => {
   const configFile1 = './tests/tsconfig-test/allows-comments.json';
@@ -42,8 +40,6 @@ describe('parse tsconfig with comments', () => {
   });
 
   it('should correctly read allow-comments.json', () => {
-    const { getTSConfig } = require('../../src/utils');
-
     expect(() => {
       getTSConfig({
         '__TS_CONFIG__': 'allows-comments.json'

--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -1,19 +1,19 @@
-import { } from 'jest';
-import { } from 'node';
-import * as ts from 'typescript'
-
 jest.mock('path');
+
+import * as ts from 'typescript';
+import {getTSConfig} from '../../src/utils';
+import * as path from 'path';
+
 
 describe('get default ts config', () => {
 
   beforeEach(() => {
     // Set up some mocked out file info before each test
-    require('path').__setBaseDir('./tests/tsconfig-test');
+      (path as any).__setBaseDir('./tests/tsconfig-test');
   });
 
   it('should correctly read tsconfig.json', () => {
-    const { getTSConfig } = require('../../src/utils');
-    const result = getTSConfig();
+    const result = getTSConfig(null);
 
     expect(result).toEqual({
       'inlineSourceMap': true,
@@ -26,8 +26,7 @@ describe('get default ts config', () => {
   });
 
   it('should not read my-tsconfig.json', () => {
-    const { getTSConfig } = require('../../src/utils');
-    const result = getTSConfig();
+    const result = getTSConfig(null);
 
     expect(result).not.toEqual({
       'target': ts.ScriptTarget.ES2015,
@@ -39,8 +38,7 @@ describe('get default ts config', () => {
   });
 
   it('should not read inline tsconfig options', () => {
-    const { getTSConfig } = require('../../src/utils');
-    const result = getTSConfig();
+    const result = getTSConfig(null);
 
     expect(result).not.toEqual({
       'module': ts.ModuleKind.CommonJS,
@@ -49,8 +47,7 @@ describe('get default ts config', () => {
   });
 
   it('should be same results for null/undefined/etc.', () => {
-    const { getTSConfig } = require('../../src/utils');
-    const result = getTSConfig();
+    const result = getTSConfig(null);
     const resultUndefinedParam = getTSConfig(undefined);
     const resultNullParam = getTSConfig(null);
     const resultEmptyParam = getTSConfig({});
@@ -65,7 +62,6 @@ describe('get default ts config', () => {
   });
 
   it('should not change the module if it is loaded from the Jest config global', () => {
-    const { getTSConfig } = require('../../src/utils');
     const config = getTSConfig({
       '__TS_CONFIG__': {
         'module': 'es2015'
@@ -76,7 +72,6 @@ describe('get default ts config', () => {
   });
 
   it('should not change the module if it is loaded from a non-default config file', () => {
-    const { getTSConfig } = require('../../src/utils');
     const config = getTSConfig({
       '__TS_CONFIG__': 'tsconfig-module/custom-config.json'
     });
@@ -86,11 +81,9 @@ describe('get default ts config', () => {
 
   it('should set the module to CommonJS if it is not, when loading from the default tsconfig file', () => {
 
-    // set the base directory such that we can use 'tsconfig.json' as the 
+    // set the base directory such that we can use 'tsconfig.json' as the
     // config file name instead of 'dir/tsconfig.json'
     require('path').__setBaseDir('./tests/tsconfig-test/tsconfig-module');
-
-    const { getTSConfig } = require('../../src/utils');
 
     const config = getTSConfig({
       '__TS_CONFIG__': 'tsconfig.json'
@@ -120,9 +113,9 @@ describe('get default ts config', () => {
 
     expect(config2.skipBabel).toBe(false);
 
-    expect(getTSJestConfig({ 'ts-jest': {} })).toEqual({})
-    expect(getTSJestConfig({})).toEqual({})
-    expect(getTSJestConfig()).toEqual({})
+    expect(getTSJestConfig({ 'ts-jest': {} })).toEqual({});
+    expect(getTSJestConfig({})).toEqual({});
+    expect(getTSJestConfig()).toEqual({});
   });
 
 });

--- a/tests/__tests__/tsconfig-inline.spec.ts
+++ b/tests/__tests__/tsconfig-inline.spec.ts
@@ -1,8 +1,8 @@
-import { } from 'jest';
-import { } from 'node';
-import * as ts from 'typescript';
-
 jest.mock('path');
+
+import * as ts from 'typescript';
+import {getTSConfig} from '../../src/utils';
+
 
 describe('get inline ts config', () => {
 
@@ -12,7 +12,6 @@ describe('get inline ts config', () => {
   });
 
   it('should correctly read inline tsconfig options', () => {
-    const { getTSConfig } = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': {
         'module': 'commonjs',
@@ -28,7 +27,6 @@ describe('get inline ts config', () => {
   });
 
   it('should not read tsconfig.json', () => {
-    const { getTSConfig } = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': {
         'module': 'commonjs',
@@ -46,7 +44,6 @@ describe('get inline ts config', () => {
   });
 
   it('should not read my-tsconfig.json', () => {
-    const { getTSConfig } = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': {
         'module': 'commonjs',

--- a/tests/__tests__/tsconfig-string.spec.ts
+++ b/tests/__tests__/tsconfig-string.spec.ts
@@ -1,18 +1,18 @@
-import { } from 'jest';
-import { } from 'node';
-import * as ts from 'typescript';
-
 jest.mock('path');
+
+import {getTSConfig} from '../../dist/utils';
+import * as ts from 'typescript';
+import * as path from 'path';
+
 
 describe('get ts config from string', () => {
 
   beforeEach(() => {
     // Set up some mocked out file info before each test
-    require('path').__setBaseDir('./tests/tsconfig-test');
+      (path as any).__setBaseDir('./tests/tsconfig-test');
   });
 
   it('should correctly read my-tsconfig.json', () => {
-    const { getTSConfig } = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': 'my-tsconfig.json'
     });
@@ -28,7 +28,7 @@ describe('get ts config from string', () => {
   });
 
   it('should not read tsconfig.json', () => {
-    const { getTSConfig } = require('../../src/utils');
+
     const result = getTSConfig({
       '__TS_CONFIG__': 'my-tsconfig.json'
     });
@@ -43,7 +43,7 @@ describe('get ts config from string', () => {
   });
 
   it('should not read inline tsconfig options', () => {
-    const { getTSConfig } = require('../../src/utils');
+
     const result = getTSConfig({
       '__TS_CONFIG__': 'my-tsconfig.json'
     });
@@ -55,7 +55,7 @@ describe('get ts config from string', () => {
   });
 
   it('should correctly resolve the "extends" directive', () => {
-    const { getTSConfig } = require('../../src/utils');
+
     const result = getTSConfig({
       '__TS_CONFIG__': 'extends-tsconfig.json'
     });
@@ -71,7 +71,6 @@ describe('get ts config from string', () => {
   });
 
   it('should correctly override any config in the "extends" directive', () => {
-    const { getTSConfig } = require('../../src/utils');
     const result = getTSConfig({
       '__TS_CONFIG__': 'extends-with-overrides-tsconfig.json'
     });

--- a/tests/__tests__/tsx-compilation.spec.ts
+++ b/tests/__tests__/tsx-compilation.spec.ts
@@ -1,6 +1,3 @@
-import { } from 'jest';
-import { } from 'node';
-
 import runJest from '../__helpers__/runJest';
 
 describe('button', () => {

--- a/tests/__tests__/tsx-errors.spec.ts
+++ b/tests/__tests__/tsx-errors.spec.ts
@@ -1,6 +1,3 @@
-import { } from 'jest';
-import { } from 'node';
-
 import runJest from '../__helpers__/runJest';
 
 describe('button', () => {

--- a/tests/__tests__/use-strict.spec.ts
+++ b/tests/__tests__/use-strict.spec.ts
@@ -1,5 +1,3 @@
-import { } from 'jest';
-import { } from 'node';
 import runJest from '../__helpers__/runJest';
 
 describe('use strict', () => {

--- a/tests/__tests__/watch.spec.ts
+++ b/tests/__tests__/watch.spec.ts
@@ -1,5 +1,3 @@
-import { } from 'jest';
-import { } from 'node';
 import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';


### PR DESCRIPTION
I removed a bunch of dead imports from all the tests.
the `import { } from 'jest';` ones - I'm reasonably sure they didn't do anything.

I removed dynamic requires for getTSJestConfig and mocked path via jest instead.
(This also neccesitated that getTSJestConfig needed a parameter because it wasn't of type `any` now, so I just gave it `null`)

Removed glob-all as it wasn't being used.

Changed some requires to es6 modules.

All tests still pass.