### PR TITLE
Use tsc to read config files, instead of separate tsconfig package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/kulshekhar/ts-jest#readme",
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "<rootDir>/dist/preprocessor.js"
     },
     "testRegex": "/__tests__/.*\\.(spec)\\.(ts|js)$",
     "coverageReporters": [
@@ -66,7 +66,6 @@
     "jest-util": "^20.0.0",
     "pkg-dir": "^2.0.0",
     "source-map-support": "^0.4.4",
-    "tsconfig": "^6.0.0",
     "yargs": "^8.0.1"
   },
   "peerDependencies": {

--- a/tests/__tests__/tsconfig-comments.spec.ts
+++ b/tests/__tests__/tsconfig-comments.spec.ts
@@ -1,7 +1,6 @@
 import { MockedPath } from '../__mocks__/path';
 jest.mock('path');
 import * as fs from 'fs';
-import * as tsconfig from 'tsconfig';
 import {getTSConfig} from '../../src/utils';
 import * as path from 'path';
 
@@ -35,10 +34,13 @@ describe('parse tsconfig with comments', () => {
   });
 
   it('one config file should extend the other', () => {
-    const content = fs.readFileSync(configFile1, 'utf8');
-    const config = tsconfig.parse(content, configFile1);
+    const config = getTSConfig({
+      __TS_CONFIG__: 'allows-comments.json'
+    });
 
-    expect(config.extends).toEqual('allows-comments2.json');
+    // allows-comments.json does not contain a "pretty" field,
+    // while allows-comments2.json does. Default value would be "false".
+    expect(config.pretty).toEqual(true);
   });
 
   it('should correctly read allow-comments.json', () => {

--- a/tests/tsconfig-test/allows-comments.json
+++ b/tests/tsconfig-test/allows-comments.json
@@ -1,5 +1,5 @@
 {
-  "extends": "allows-comments2.json",
+  "extends": "./allows-comments2.json",
   "compilerOptions": {
     // some comments
   }

--- a/tests/tsconfig-test/allows-comments2.json
+++ b/tests/tsconfig-test/allows-comments2.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
     //some comments
+    "pretty": true
   }
 }

--- a/tests/tsconfig-test/empty.ts
+++ b/tests/tsconfig-test/empty.ts
@@ -1,0 +1,1 @@
+// Dummy file to ensure the ts config loader does not complain about a missing input file.

--- a/tests/tsconfig-test/tsconfig-module/empty.ts
+++ b/tests/tsconfig-test/tsconfig-module/empty.ts
@@ -1,0 +1,1 @@
+// Dummy file to ensure the ts config loader does not complain about a missing input file.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,9 +2474,10 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.0.tgz#6bdedfe7f2aa49a6f3c432257687555957f342fd"
 
 ts-jest@latest:
-  version "20.0.5"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-20.0.5.tgz#6cb151e718e8739529d0a79459e09f7280fe044f"
+  version "20.0.6"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-20.0.6.tgz#39c2810c05d6f6908dac15929dae206b494b73f4"
   dependencies:
+    "@types/babel-core" "^6.7.14"
     babel-core "^6.24.1"
     babel-plugin-istanbul "^4.1.4"
     babel-plugin-transform-es2015-modules-commonjs "^6.24.1"


### PR DESCRIPTION
Aims at #245.

First of all - sorry for the confusion about what `tsc.readConfigFile` might simplify. Required some more things to apply to get this working. I've seen the usage of this function (also used it myself, of course) in several projects, and it worked without a hassle - otherwise, I wouldn't have suggested to head this ways. Seems my set of information got a bit ... malformed.

However, the results should not be that bad - the way config files are parsed and evaluated is quite close to how the typescript cli handles this, especially when following the `extends` key recursively. Note that the code is quite strict about errors: While the tsc API does not throw them, this code does, since they regularly would lead to curious behavior later on, e.g. when dealing with an obviously empty config which should not be empty.

I've gotten a bit puzzled about why the project references itself as a dev dependency. Didn't get the tests to work properly without changing the transformer to the local build.

The only downside I've recognized refers to reading the config in inline mode and adding custom options:
- If the options are read from the config file, they are already adopted to typescripts constants, like `tsc.ModuleKind.CommonJS` instead of `"commonjs"`. Using `tsc.convertCompilerOptionsFromJson` causes errors, since it expects the human-readable form. 
- In case of the inline version, it behaves vice-versa - converting is still required, so the options have to be set in the human-readable form.

As a result, it's required to differ between inline and file mode when adding additional properties.

