### PR TITLE
Update Travis CI environment, add fs-extra v4 to yarn.lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
+dist: trusty
+sudo: required
 language: node_js
 node_js:
   - "8"
   - "6"
   - "4"
 before_install:
-  - npm i -g npm@latest tslint
   - sudo sysctl fs.inotify.max_user_watches=524288
-
-sudo: required

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,14 @@ fs-extra@^3.0.0:
     jsonfile "^3.0.0"
     universalify "^0.1.0"
 
+fs-extra@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.0.tgz#414fb4ca2d2170ba0014159d3a8aec3303418d9e"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"


### PR DESCRIPTION
* Updates `yarn.lock` to account for `fs-extra@4` added in #267 
* Use ubuntu trusty instead of the default precise so the change doesn't catch us by surprise when travis changes the default ([travis trusty docs](https://docs.travis-ci.com/user/trusty-ci-environment/))
* Do not install `tslint` globally on travis, it's unnecessary as it's installed as a dependency