### PR TITLE
Rewrite 'useBabelrc' documentation 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Emil Persson <emil.n.persson@gmail.com>
 Eric Anderson <e@ericlanderson.com>
 Felipe Matos <felipems@yahoo.com.br>
 Forbes Lindesay <forbes@lindesay.co.uk>
+Gino Zhang <whitetrefoil@gmail.com>
 Gustav Wengel <gustavwengel@gmail.com>
 Henry Zektser <japhar81@gmail.com>
 Ihor Chulinda <ichulinda@gmail.com>

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Simply add skipBabel to your global variables under the `ts-jest` key:
 
 ### Using `.babelrc`
 
-When using Babel, ts-jest, by default, doesn't use the `.babelrc` file. If you want ts-jest to use `.babelrc`, you should set the `globals > ts-jest > useBabelrc` flag to `true`.
+When using Babel, ts-jest, by default, doesn't use the `.babelrc` file. If you want ts-jest to use `.babelrc`, you should set the `globals > ts-jest > useBabelrc` flag to `true` in the `jest` section in `package.json`.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ Simply add skipBabel to your global variables under the `ts-jest` key:
 }
 ```
 
+### Using `.babelrc`
+
+When using Babel, ts-jest, by default, doesn't use the `.babelrc` file. If you want ts-jest to use `.babelrc`, you should set the `globals > ts-jest > useBabelrc` flag to `true`.
+
+```json
+{
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "useBabelrc": true
+      }
+    }
+  }
+}
+```
+
 ## Use cases
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Simply add skipBabel to your global variables under the `ts-jest` key:
 
 ### Using `.babelrc`
 
-When using Babel, ts-jest, by default, doesn't use the `.babelrc` file. If you want ts-jest to use `.babelrc`, you should set the `globals > ts-jest > useBabelrc` flag to `true` in the `jest` section in `package.json`.
+When using Babel, ts-jest, by default, doesn't use the `.babelrc` file. If you want ts-jest to use `.babelrc`, you should set the `globals > ts-jest > useBabelrc` flag to `true` in your `jest` configuration.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -152,23 +152,6 @@ Simply add skipBabel to your global variables under the `ts-jest` key:
 }
 ```
 
-### Use customized .babalrc
-By default, `ts-jest` use only the embedded .babelrc file.
-It should work in most cases, and keep configuration simple.
-In case your tests need special .babelrc settings to work,
-set `"useBabelrc": true` to tell `ts-jest` read your .babelrc.
-```json
-{
-  "jest": {
-    "globals": {
-      "ts-jest": {
-        "useBabelrc": true
-      }
-    }
-  }
-}
-```
-
 ## Use cases
 
 ### React Native
@@ -261,33 +244,6 @@ your Jest configuration:
 
 By default Jest ignores everything in `node_modules`. This setting prevents Jest from ignoring the package you're interested in, in this case `@foo`, while continuing to ignore everything else in `node_modules`.
 
-### Test code w/ ES (Webpack 2+) dynamic import
-Newest Webpack introduced ES dynamic import which cannot be handled by babel without plugins even with env preset.
-In development usually use `babel-plugin-syntax-dynamic-import` to prevent errors.
-But in tests it have to be converted to commonjs' require:
-```
-npm install -D babel-plugin-syntax-dynamic-import babel-plugin-dynamic-import-node
-```
-```
-// .babalrc
-{
-  // ...
-  "plugins"      : [
-    "syntax-dynamic-import"
-  ],
-  "env"          : {
-    "test": {
-      "plugins": [
-       "dynamic-import-node"
-      ]
-    }
-  }
-}
-```
-
-Notice, by default `ts-jest` will not use project .babelrc,
-so `"useBabelrc": true` must be set.
-(See [Use customized .babalrc](#user-content-use-customized-babalrc) above)
 
 ## Known Limitations
 ### Known limitations for TS compiler options


### PR DESCRIPTION
Reverts kulshekhar/ts-jest#270

- The `Test code w/ ES (Webpack 2+) dynamic import` section seems unnecessary. It has nothing to do with ts-jest. 

- babelrc is spelled incorrectly

- The `Use customized .babalrc` section makes it seem that ts-jest uses babelrc by default. I don't think that's the case. @GeeWee can you confirm one way or another?

The author list should also be updated to include @whitetrefoil

closes #265 