### PR TITLE
Allow a babelConfig option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Bartosz Gościński <bargosc@gmail.com>
 Blake Embrey <hello@blakeembrey.com>
 Brian Ruddy <briancruddy@gmail.com>
 Chong Guo <cguo@azendless.com>
+Chris Sauve <chrismsauve@gmail.com>
 Christian Linne <ShadowVampire@web.de>
 Christian Rackerseder <git@echooff.de>
 Daniel Perez Alvarez <unindented@gmail.com>

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ In some cases, projects may not want to have a `.babelrc` file, but still need t
 }
 ```
 
+Note that if you also set the `useBabelrc` option to `true`, any configuration passed using this method will be overwritten by corresponding keys in `.babelrc` files.
+
 ## Use cases
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 - [Configuration](#configuration)
   - [tsconfig](#tsconfig)
   - [Skipping Babel](#skipping-babel)
+  - [Using `.babelrc`](#using-babelrc)
+  - [Using a custom Babel config](#using-a-custom-babel-config)
 - [Use cases](#use-cases)
   - [React Native](#react-native)
 - [Angular 2](#angular-2)
@@ -163,6 +165,24 @@ When using Babel, ts-jest, by default, doesn't use the `.babelrc` file. If you w
     "globals": {
       "ts-jest": {
         "useBabelrc": true
+      }
+    }
+  }
+}
+```
+
+### Using a custom Babel config
+
+In some cases, projects may not want to have a `.babelrc` file, but still need to provide custom Babel configuration. In these cases, you can provide a Babel config directly to `ts-jest` using the `globals > ts-jest > babelConfig` option in your `jest` configuration.
+
+```json
+{
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "babelConfig": {
+          "presets": ["env"]
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/source-map-support": "latest",
+    "babel-preset-env": "^1.6.0",
     "cross-spawn": "latest",
     "cross-spawn-with-kill": "latest",
     "doctoc": "latest",

--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -71,5 +71,6 @@ export interface FullJestConfig {
 export interface TsJestConfig {
   skipBabel?: boolean;
   useBabelrc?: boolean;
+  babelConfig?: BabelTransformOpts;
   tsConfigFile?: String;
 }

--- a/src/postprocess.ts
+++ b/src/postprocess.ts
@@ -18,8 +18,8 @@ import {
 function createBabelTransformer(options: BabelTransformOptions) {
   options = {
     ...options,
-    plugins: (options && options.plugins) || [],
-    presets: ((options && options.presets) || []).concat([jestPreset]),
+    plugins: options.plugins || [],
+    presets: (options.presets || []).concat([jestPreset]),
     // If retainLines isn't set to true, the line numbers
     // are off by 1
     retainLines: true,
@@ -65,15 +65,16 @@ export const getPostProcessHook = (
     return src => src; // Identity function
   }
 
-  const plugins = [];
+  const plugins = tsJestConfig.babelConfig ? tsJestConfig.babelConfig.plugins : [];
   // If we're not skipping babel
   if (tsCompilerOptions.allowSyntheticDefaultImports) {
     plugins.push('transform-es2015-modules-commonjs');
   }
 
   return createBabelTransformer({
+        ...tsJestConfig.babelConfig,
     babelrc: tsJestConfig.useBabelrc || false,
     plugins,
-    presets: [],
+    presets: tsJestConfig.babelConfig ? tsJestConfig.babelConfig.presets : [],
   });
 };

--- a/src/postprocess.ts
+++ b/src/postprocess.ts
@@ -65,14 +65,16 @@ export const getPostProcessHook = (
     return src => src; // Identity function
   }
 
-  const plugins = tsJestConfig.babelConfig ? tsJestConfig.babelConfig.plugins : [];
+  const plugins = tsJestConfig.babelConfig
+    ? tsJestConfig.babelConfig.plugins
+    : [];
   // If we're not skipping babel
   if (tsCompilerOptions.allowSyntheticDefaultImports) {
     plugins.push('transform-es2015-modules-commonjs');
   }
 
   return createBabelTransformer({
-        ...tsJestConfig.babelConfig,
+    ...tsJestConfig.babelConfig,
     babelrc: tsJestConfig.useBabelrc || false,
     plugins,
     presets: tsJestConfig.babelConfig ? tsJestConfig.babelConfig.presets : [],

--- a/tests/__tests__/babel-config.spec.ts
+++ b/tests/__tests__/babel-config.spec.ts
@@ -1,17 +1,36 @@
 import runJest from '../__helpers__/runJest';
 
 describe('babelConfig flag', () => {
-    
-    it('should use a custom Babel config', () => {
-        const result = runJest('../babel-config', ['--no-cache', '-u']);
-        expect(result.status).toBe(0);
-    });
+  it('should use a custom Babel config', () => {
+    const result = runJest('../babel-config', ['--no-cache', '-u']);
+    expect(result.status).toBe(0);
+  });
 
-    it('should fail for invalid babel configs', () => {
-        const result = runJest('../babel-config-invalid', ['--no-cache', '-u']);
-        const stderr = result.stderr.toString();
-        expect(result.status).toBe(1);
-        expect(stderr).toContain('ReferenceError: [BABEL]');
-        expect(stderr).toContain('Check out http://babeljs.io/docs/usage/options/ for more information about options.');
-    });
+  it('should fail for invalid babel configs', () => {
+    const result = runJest('../babel-config-invalid', ['--no-cache', '-u']);
+    const stderr = result.stderr.toString();
+    expect(result.status).toBe(1);
+    expect(stderr).toContain('ReferenceError: [BABEL]');
+    expect(stderr).toContain(
+      'Check out http://babeljs.io/docs/usage/options/ for more information about options.',
+    );
+  });
+
+  it('should not merge in .babelrc options when ommiting the useBabelrc option', () => {
+    const result = runJest('../babel-config-merge-ignore-babelrc', [
+      '--no-cache',
+      '-u',
+    ]);
+    expect(result.status).toBe(0);
+  });
+
+  it('should merge in .babelrc options when using the useBabelrc option', () => {
+    const result = runJest('../babel-config-merge-with-babelrc', [
+      '--no-cache',
+      '-u',
+    ]);
+    const stderr = result.stderr.toString();
+    expect(result.status).toBe(1);
+    expect(stderr).toContain(`Couldn't find preset "nonexistent"`);
+  });
 });

--- a/tests/__tests__/babel-config.spec.ts
+++ b/tests/__tests__/babel-config.spec.ts
@@ -1,0 +1,17 @@
+import runJest from '../__helpers__/runJest';
+
+describe('babelConfig flag', () => {
+    
+    it('should use a custom Babel config', () => {
+        const result = runJest('../babel-config', ['--no-cache', '-u']);
+        expect(result.status).toBe(0);
+    });
+
+    it('should fail for invalid babel configs', () => {
+        const result = runJest('../babel-config-invalid', ['--no-cache', '-u']);
+        const stderr = result.stderr.toString();
+        expect(result.status).toBe(1);
+        expect(stderr).toContain('ReferenceError: [BABEL]');
+        expect(stderr).toContain('Check out http://babeljs.io/docs/usage/options/ for more information about options.');
+    });
+});

--- a/tests/babel-config-invalid/.gitignore
+++ b/tests/babel-config-invalid/.gitignore
@@ -1,0 +1,1 @@
+coverage-custom

--- a/tests/babel-config-invalid/Hello.ts
+++ b/tests/babel-config-invalid/Hello.ts
@@ -1,0 +1,1 @@
+export class Hello {}

--- a/tests/babel-config-invalid/NullCoverage.js
+++ b/tests/babel-config-invalid/NullCoverage.js
@@ -1,0 +1,6 @@
+function nullCoverageFunction(value) {
+  if (value) {
+    return value;
+  }
+  return null;
+}

--- a/tests/babel-config-invalid/__tests__/index.test.ts
+++ b/tests/babel-config-invalid/__tests__/index.test.ts
@@ -1,0 +1,11 @@
+import {Hello} from '../Hello';
+
+describe('Hello Class', () => {
+
+  it('should throw an error when compiling through Babel', () => {
+
+    expect(typeof Hello).toBe('function');
+
+  });
+
+});

--- a/tests/babel-config-invalid/package.json
+++ b/tests/babel-config-invalid/package.json
@@ -1,0 +1,24 @@
+{
+	"jest": {
+		"transform": {
+			".(ts|tsx)": "../../preprocessor.js"
+		},
+		"moduleDirectories": [
+			"node_modules",
+			"src"
+		],
+		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js"
+		],
+		"globals": {
+			"ts-jest": {
+				"babelConfig": {
+					"foo": "bar"
+				}
+			}
+		}
+	}
+}

--- a/tests/babel-config-invalid/tsconfig.json
+++ b/tests/babel-config-invalid/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": false,
+    "jsx": "react",
+    "allowJs": true
+  }
+}

--- a/tests/babel-config-merge-ignore-babelrc/.babelrc
+++ b/tests/babel-config-merge-ignore-babelrc/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "nonexistent"
+  ]
+}

--- a/tests/babel-config-merge-ignore-babelrc/.gitignore
+++ b/tests/babel-config-merge-ignore-babelrc/.gitignore
@@ -1,0 +1,1 @@
+coverage-custom

--- a/tests/babel-config-merge-ignore-babelrc/Hello.ts
+++ b/tests/babel-config-merge-ignore-babelrc/Hello.ts
@@ -1,0 +1,1 @@
+export class Hello {}

--- a/tests/babel-config-merge-ignore-babelrc/NullCoverage.js
+++ b/tests/babel-config-merge-ignore-babelrc/NullCoverage.js
@@ -1,0 +1,6 @@
+function nullCoverageFunction(value) {
+  if (value) {
+    return value;
+  }
+  return null;
+}

--- a/tests/babel-config-merge-ignore-babelrc/__tests__/index.test.ts
+++ b/tests/babel-config-merge-ignore-babelrc/__tests__/index.test.ts
@@ -1,0 +1,7 @@
+import { Hello } from '../Hello';
+
+describe('Hello Class', () => {
+  it('should throw an error when compiling through Babel', () => {
+    expect(typeof Hello).toBe('function');
+  });
+});

--- a/tests/babel-config-merge-ignore-babelrc/package.json
+++ b/tests/babel-config-merge-ignore-babelrc/package.json
@@ -1,0 +1,26 @@
+{
+	"jest": {
+		"transform": {
+			".(ts|tsx)": "../../preprocessor.js"
+		},
+		"moduleDirectories": [
+			"node_modules",
+			"src"
+		],
+		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js"
+		],
+		"globals": {
+			"ts-jest": {
+				"babelConfig": {
+					"presets": [
+						"env"
+					]
+				}
+			}
+		}
+	}
+}

--- a/tests/babel-config-merge-ignore-babelrc/tsconfig.json
+++ b/tests/babel-config-merge-ignore-babelrc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": false,
+    "jsx": "react",
+    "allowJs": true
+  }
+}

--- a/tests/babel-config-merge-with-babelrc/.babelrc
+++ b/tests/babel-config-merge-with-babelrc/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "nonexistent"
+  ]
+}

--- a/tests/babel-config-merge-with-babelrc/.gitignore
+++ b/tests/babel-config-merge-with-babelrc/.gitignore
@@ -1,0 +1,1 @@
+coverage-custom

--- a/tests/babel-config-merge-with-babelrc/Hello.ts
+++ b/tests/babel-config-merge-with-babelrc/Hello.ts
@@ -1,0 +1,1 @@
+export class Hello {}

--- a/tests/babel-config-merge-with-babelrc/NullCoverage.js
+++ b/tests/babel-config-merge-with-babelrc/NullCoverage.js
@@ -1,0 +1,6 @@
+function nullCoverageFunction(value) {
+  if (value) {
+    return value;
+  }
+  return null;
+}

--- a/tests/babel-config-merge-with-babelrc/__tests__/index.test.ts
+++ b/tests/babel-config-merge-with-babelrc/__tests__/index.test.ts
@@ -1,0 +1,7 @@
+import { Hello } from '../Hello';
+
+describe('Hello Class', () => {
+  it('should throw an error when compiling through Babel', () => {
+    expect(typeof Hello).toBe('function');
+  });
+});

--- a/tests/babel-config-merge-with-babelrc/package.json
+++ b/tests/babel-config-merge-with-babelrc/package.json
@@ -1,0 +1,27 @@
+{
+	"jest": {
+		"transform": {
+			".(ts|tsx)": "../../preprocessor.js"
+		},
+		"moduleDirectories": [
+			"node_modules",
+			"src"
+		],
+		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js"
+		],
+		"globals": {
+			"ts-jest": {
+				"babelConfig": {
+					"presets": [
+						"env"
+					]
+				},
+				"useBabelrc": true
+			}
+		}
+	}
+}

--- a/tests/babel-config-merge-with-babelrc/tsconfig.json
+++ b/tests/babel-config-merge-with-babelrc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": false,
+    "jsx": "react",
+    "allowJs": true
+  }
+}

--- a/tests/babel-config/.gitignore
+++ b/tests/babel-config/.gitignore
@@ -1,0 +1,1 @@
+coverage-custom

--- a/tests/babel-config/Hello.ts
+++ b/tests/babel-config/Hello.ts
@@ -1,0 +1,1 @@
+export class Hello {}

--- a/tests/babel-config/NullCoverage.js
+++ b/tests/babel-config/NullCoverage.js
@@ -1,0 +1,6 @@
+function nullCoverageFunction(value) {
+  if (value) {
+    return value;
+  }
+  return null;
+}

--- a/tests/babel-config/__tests__/index.test.ts
+++ b/tests/babel-config/__tests__/index.test.ts
@@ -1,0 +1,11 @@
+import {Hello} from '../Hello';
+
+describe('Hello Class', () => {
+
+  it('should allow custom Babel config', () => {
+
+    expect(typeof Hello).toBe('function');
+
+  });
+
+});

--- a/tests/babel-config/package.json
+++ b/tests/babel-config/package.json
@@ -1,0 +1,24 @@
+{
+	"jest": {
+		"transform": {
+			".(ts|tsx)": "../../preprocessor.js"
+		},
+		"moduleDirectories": [
+			"node_modules",
+			"src"
+		],
+		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js"
+		],
+		"globals": {
+			"ts-jest": {
+				"babelConfig": {
+					"comments": false
+				}
+			}
+		}
+	}
+}

--- a/tests/babel-config/tsconfig.json
+++ b/tests/babel-config/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": false,
+    "jsx": "react",
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/kulshekhar/ts-jest/issues/284

This PR allows the user to pass a `jest.globals.babelConfig` option, which should be an object with a full babel config that gets merged into the "necessary" bits of the config that were already being added.

Change itself is pretty small, but I really wasn't sure what to do for the tests. In the end, I mostly copied the `babelrc` tests, but there are some cases (most notably, merging of the plugins/ presets arrays) that are not addressed by these tests. Would love suggestions!

@GeeWee @kulshekhar let me know if there is someone else I should ping for reviews.