### PR TITLE
explicitly invalidate cache key when transform options change

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Henry Zektser <japhar81@gmail.com>
 Ihor Chulinda <ichulinda@gmail.com>
 J Cheyo Jimenez <cheyo@masters3d.com>
 Joscha Feth <joscha@feth.com>
+Justin Bay <jwbay@users.noreply.github.com>
 Kulshekhar Kabra <kulshekhar@users.noreply.github.com>
 Kyle Roach <kroach.work@gmail.com>
 Marshall Bowers <elliott.codes@gmail.com>

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -89,6 +89,7 @@ export function getCacheKey(
 
     return crypto.createHash('md5')
         .update(JSON.stringify(tsConfig), 'utf8')
+        .update(JSON.stringify(options), 'utf8')
         .update(fileData + filePath + configStr, 'utf8')
         .digest('hex');
 }

--- a/tests/__tests__/get-cache-key.spec.ts
+++ b/tests/__tests__/get-cache-key.spec.ts
@@ -1,4 +1,5 @@
 import { getCacheKey } from '../../src/preprocessor';
+import { TransformOptions } from '../../src/jest-types'
 
 describe('getCacheKey', () => {
   const src = 'console.log(123);';
@@ -17,7 +18,8 @@ describe('getCacheKey', () => {
     },
     "testRegex": "(/__tests__/.*|\\\\.(test|spec))\\\\.(ts|tsx|js)$"
   }`;
-  const originalHash = getCacheKey(src, filepath, configStr);
+  const options: TransformOptions = { instrument: false };
+  const originalHash = getCacheKey(src, filepath, configStr, options);
 
   it('should change hash when src changes', () => {
     const newSrc = 'console.log(1234);';
@@ -37,4 +39,9 @@ describe('getCacheKey', () => {
     expect(newHash).not.toBe(originalHash);
   });
 
+  it('should change hash when transform options change', () => {
+    const newOptions: TransformOptions = { instrument: true };
+    const newHash = getCacheKey(src, filepath, configStr, newOptions);
+    expect(newHash).not.toBe(originalHash);
+  });
 });


### PR DESCRIPTION
Transform cache invalidation for coverage seems to implicitly rely on instrumentation changing some value in tsconfig. Besides making the invalidation more explicit, since the last value passed to getCacheKey is an options bag, ts-jest can insulate itself from new transform options being added in the future that should also bust the cache by just stringifying the object. I'm trying to get a change into jest that adds mapCoverage to the options here, for example.