### PR TITLE
Update docs to include json in `moduleFileExtensions`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Mohammad Rajabifard <mo.rajbi@gmail.com>
 OJ Kwon <kwon.ohjoong@gmail.com>
 Tom Crockett <tomcrockett@tuplehealth.com>
 Umidbek Karimov <uma.karimov@gmail.com>
+Oliver Joseph Ash <oliverjash@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,6 @@ Marshall Bowers <elliott.codes@gmail.com>
 Maxim Samoilov <samoilowmaxim@gmail.com>
 Mohammad Rajabifard <mo.rajbi@gmail.com>
 OJ Kwon <kwon.ohjoong@gmail.com>
+Oliver Joseph Ash <oliverjash@gmail.com>
 Tom Crockett <tomcrockett@tuplehealth.com>
 Umidbek Karimov <uma.karimov@gmail.com>
-Oliver Joseph Ash <oliverjash@gmail.com>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Modify your project's `package.json` so that the `jest` section looks something 
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "json"
     ]
   }
 }


### PR DESCRIPTION
Without `json` in `moduleFileExtensions`, I was getting error `Cannot find module './package' from 'index.js`

https://github.com/facebook/jest/issues/1371