### PR TITLE
Move @types/babel to dev dependencies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Maxim Samoilov <samoilowmaxim@gmail.com>
 Mohammad Rajabifard <mo.rajbi@gmail.com>
 OJ Kwon <kwon.ohjoong@gmail.com>
 Oliver Joseph Ash <oliverjash@gmail.com>
+Orta Therox <orta.therox+gh@gmail.com>
 Tom Crockett <tomcrockett@tuplehealth.com>
 Umidbek Karimov <uma.karimov@gmail.com>
-Orta Therox <orta.therox+gh@gmail.com>
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ OJ Kwon <kwon.ohjoong@gmail.com>
 Oliver Joseph Ash <oliverjash@gmail.com>
 Tom Crockett <tomcrockett@tuplehealth.com>
 Umidbek Karimov <uma.karimov@gmail.com>
+Orta Therox <orta.therox+gh@gmail.com>

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     ]
   },
   "dependencies": {
-    "@types/babel-core": "^6.7.14",
     "babel-core": "^6.24.1",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
@@ -76,6 +75,7 @@
     "typescript": "2.x"
   },
   "devDependencies": {
+    "@types/babel-core": "^6.7.14",
     "@types/es6-shim": "latest",
     "@types/fs-extra": "^4.0.0",
     "@types/jest": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,9 +37,9 @@
   version "0.31.33"
   resolved "https://registry.yarnpkg.com/@types/es6-shim/-/es6-shim-0.31.33.tgz#4792bdecc8c7f09a7e086968cfbb8058e459379d"
 
-"@types/fs-extra@^3.0.0":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-3.0.2.tgz#00cbf48563f377f9ce5cf24237b21b3d9779e055"
+"@types/fs-extra@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
Looks like this was added in https://github.com/kulshekhar/ts-jest/commit/7e927e3d529a00c29dc87769b9da3ad8d7c7146e#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R59 - I think it's reasonable to assume that this is a bug (I've done this by accident many times and [automated a check](https://github.com/orta/danger-plugin-yarn/blob/master/src/index.ts#L179))

I was getting build failures in another project due to this: https://travis-ci.org/danger/danger-js/jobs/261328625#L938 - maybe because of different TS versions

<img width="629" alt="screen shot 2017-08-05 at 13 13 07" src="https://user-images.githubusercontent.com/49038/28997329-da46d08a-79df-11e7-86b5-b5751e62f377.png">