### PR TITLE
Let sourcemaps be cached

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,6 @@ export { transpileIfTypescript } from './transpile-if-ts';
 export function install() {
   const options: sourceMapSupport.Options = {};
   options.retrieveFile = defaultRetrieveFileHandler;
-  options.emptyCacheBetweenOperations = true; // left here only for
-  // sourceMapCache TODO: check this for correctness and performance with
-  // false value
 
   /* tslint:disable */
   // disabling tslint because the types for the source-map-support version


### PR DESCRIPTION
This change allows source-map-support to use the default value for `emptyCacheBetweenOperations` (`false`) to improve the performance of ts-jest.

Thanks to @hermanbanken for [pointing out this issue](https://github.com/kulshekhar/ts-jest/issues/259#issuecomment-320227209) in #259
