### PR TITLE
Always set inlineSources and inlineSourceMap to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "20.0.12",
+  "version": "20.0.13",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",
@@ -105,7 +105,7 @@
       "prettier --write --single-quote --trailing-comma es5",
       "git add"
     ],
-    "*.ts" : [
+    "*.ts": [
       "prettier --write --single-quote --trailing-comma all",
       "git add"
     ]

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -1,7 +1,6 @@
 import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
 import * as nodepath from 'path';
-import * as pkgDir from 'pkg-dir';
 import * as tsc from 'typescript';
 import { JestConfig, Path, TransformOptions } from './jest-types';
 import { getPostProcessHook } from './postprocess';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -177,17 +177,14 @@ export function getTSConfig(globals, collectCoverage: boolean = false) {
     }
   }
 
-  if (config.inlineSourceMap !== false) {
-    config.inlineSourceMap = true;
-  }
+  // ts-jest will map lines numbers properly if inlineSourceMap and
+  // inlineSources are set to true. For testing, we don't need the
+  // sourceMap configuration
+  delete config.sourceMap;
+  config.inlineSourceMap = true;
+  config.inlineSources = true;
 
-  // inline source with source map for remapping coverage
   if (collectCoverage) {
-    delete config.sourceMap;
-
-    config.inlineSourceMap = true;
-    config.inlineSources = true;
-
     // the coverage report is broken if `.outDir` is set
     // see https://github.com/kulshekhar/ts-jest/issues/201
     delete config.outDir;

--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -15,7 +15,7 @@ describe('get default ts config', () => {
   it('should correctly read tsconfig.json', () => {
     const result = getTSConfig(null);
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       inlineSourceMap: true,
       target: ts.ScriptTarget.ES2015,
       module: ts.ModuleKind.CommonJS,

--- a/tests/__tests__/tsconfig-inline.spec.ts
+++ b/tests/__tests__/tsconfig-inline.spec.ts
@@ -20,7 +20,7 @@ describe('get inline ts config', () => {
         },
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         inlineSourceMap: true,
         module: ts.ModuleKind.CommonJS,
         jsx: ts.JsxEmit.React,

--- a/tests/__tests__/tsconfig-string.spec.ts
+++ b/tests/__tests__/tsconfig-string.spec.ts
@@ -16,7 +16,7 @@ describe('get ts config from string', () => {
         __TS_CONFIG__: 'my-tsconfig.json',
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         inlineSourceMap: true,
         target: ts.ScriptTarget.ES2015,
         module: ts.ModuleKind.CommonJS,
@@ -56,7 +56,7 @@ describe('get ts config from string', () => {
         __TS_CONFIG__: 'extends-tsconfig.json',
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         inlineSourceMap: true,
         target: ts.ScriptTarget.ES2015,
         module: ts.ModuleKind.CommonJS,
@@ -71,7 +71,7 @@ describe('get ts config from string', () => {
         __TS_CONFIG__: 'extends-with-overrides-tsconfig.json',
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         inlineSourceMap: true,
         target: ts.ScriptTarget.ES5,
         module: ts.ModuleKind.CommonJS,
@@ -91,7 +91,7 @@ describe('get ts config from string', () => {
         },
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         inlineSourceMap: true,
         target: ts.ScriptTarget.ES2015,
         module: ts.ModuleKind.CommonJS,
@@ -137,7 +137,7 @@ describe('get ts config from string', () => {
         },
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         inlineSourceMap: true,
         target: ts.ScriptTarget.ES2015,
         module: ts.ModuleKind.CommonJS,
@@ -154,7 +154,7 @@ describe('get ts config from string', () => {
         },
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         inlineSourceMap: true,
         target: ts.ScriptTarget.ES5,
         module: ts.ModuleKind.CommonJS,


### PR DESCRIPTION
Fixes #299 

This PR also changes some related tests. The tests for the configuration object were doing an exact match to check that the actual object is exactly equal to the expected object.

These tests have been updated to assert that the expected object is a subset of the actual object. This is because the actual object will now always have `inlineSources` and `inlineSourceMap` set to true.