### PR TITLE
Improve usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Modify your project's `package.json` so that the `jest` section looks something 
       "ts",
       "tsx",
       "js",
+      "jsx",
       "json"
     ]
   }


### PR DESCRIPTION
ts-jest README:
```json
{
  "jest": {
    "transform": {
      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
    },
    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
    "moduleFileExtensions": [
      "ts",
      "tsx",
      "js",
      "json"
    ]
  }
}
```

Jest documentation ([1](http://facebook.github.io/jest/docs/en/getting-started.html#using-typescript)) ([2](https://github.com/facebook/jest#using-typescript)):
```json
{
  "jest": {
    "transform": {
      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
    },
    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
    "moduleFileExtensions": [
      "ts",
      "tsx",
      "js",
      "json",
      "jsx"
    ]
  }
}
```

- moduleFileExtensions: jsx missing in ts-jest README
- transform are different
- testRegex are different

Which one is considered to be "canonical"/the official one?

I've also proposed to Jest to redirect to ts-jest documentation instead of duplicating it: https://github.com/facebook/jest/pull/4392