### PR TITLE
Use "canonical" Jest configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Modify your project's `package.json` so that the `jest` section looks something 
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
@@ -197,8 +197,8 @@ Ensure `.babelrc` contains:
 In `package.json`, inside `jest` section, the `transform` should be like this:
 ```json
 "transform": {
-  "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
-  ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+  "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest",
+  "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
 }
 ```
 
@@ -208,14 +208,16 @@ Fully completed jest section should look like this:
 "jest": {
     "preset": "react-native",
     "transform": {
-      "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest",
+      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 ```
@@ -239,7 +241,7 @@ You'll also need to extend your `transform` regex with `html` extension:
 {
   "jest": {
     "transform": {
-      "^.+\\.(ts|tsx|js|html)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.(tsx?|html)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc -p .",
     "build:watch": "tsc -p . -w",
-    "clean": "rimraf dist/**/* && rimraf tests/simple/coverage/**/* && rimraf tests/simple-async/coverage/**/*",
+    "clean": "rimraf dist/**/* && rimraf tests/simple/coverage && rimraf tests/simple-async/coverage",
     "clean-build": "npm run clean && npm run build",
     "pretest": "npm run tslint && npm run clean-build",
     "test": "node scripts/tests.js",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/kulshekhar/ts-jest#readme",
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/dist/preprocessor.js"
+      "^.+\\.tsx?$": "<rootDir>/dist/preprocessor.js"
     },
     "testRegex": "/__tests__/.*\\.(spec)\\.(ts|js)$",
     "coverageReporters": [
@@ -58,7 +58,9 @@
     ],
     "moduleFileExtensions": [
       "ts",
+      "tsx",
       "js",
+      "jsx",
       "json"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "transform": {
       "^.+\\.tsx?$": "<rootDir>/dist/preprocessor.js"
     },
-    "testRegex": "/__tests__/.*\\.(spec)\\.(ts|js)$",
+    "testRegex": "tests/__tests__/.*\\.spec\\.ts$",
     "coverageReporters": [
       "text"
     ],

--- a/tests/__tests__/get-cache-key.spec.ts
+++ b/tests/__tests__/get-cache-key.spec.ts
@@ -14,9 +14,9 @@ describe('getCacheKey', () => {
       }
     },
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\\\.(test|spec))\\\\.(ts|tsx|js)$"
+    "testRegex": "(/__tests__/.*|(\\\\.|/)(test|spec))\\\\.(jsx?|tsx?)$"
   }`;
   const options: TransformOptions = { instrument: false };
   const originalHash = getCacheKey(src, filepath, configStr, options);

--- a/tests/__tests__/ts-coverage-async.spec.ts
+++ b/tests/__tests__/ts-coverage-async.spec.ts
@@ -6,9 +6,9 @@ describe('Typescript async coverage', () => {
 
     const output = result.stdout.toString();
 
-    expect(output).toContain('Statements   : 66.67% ( 10/15 )');
+    expect(output).toContain('Statements   : 71.43% ( 10/14 )');
     expect(output).toContain('Branches     : 33.33% ( 2/6 )');
     expect(output).toContain('Functions    : 66.67% ( 4/6 )');
-    expect(output).toContain('Lines        : 61.54% ( 8/13 )');
+    expect(output).toContain('Lines        : 66.67% ( 8/12 )');
   });
 });

--- a/tests/__tests__/ts-coverage.spec.ts
+++ b/tests/__tests__/ts-coverage.spec.ts
@@ -6,9 +6,9 @@ describe('Typescript coverage', () => {
 
     const output = result.stdout.toString();
 
-    expect(output).toContain('Statements   : 66.67% ( 10/15 )');
+    expect(output).toContain('Statements   : 71.43% ( 10/14 )');
     expect(output).toContain('Branches     : 33.33% ( 2/6 )');
     expect(output).toContain('Functions    : 66.67% ( 4/6 )');
-    expect(output).toContain('Lines        : 61.54% ( 8/13 )');
+    expect(output).toContain('Lines        : 66.67% ( 8/12 )');
   });
 });

--- a/tests/button/package.json
+++ b/tests/button/package.json
@@ -1,13 +1,15 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/deprecated-tsconfig/package.json
+++ b/tests/deprecated-tsconfig/package.json
@@ -4,9 +4,9 @@
       "__TS_CONFIG__": "tsconfig.json"
     },
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "coverageReporters": [
       "json"
     ],
@@ -18,7 +18,9 @@
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   },
   "dependencies": {

--- a/tests/dynamic-imports/jest.allowdefaultimports.json
+++ b/tests/dynamic-imports/jest.allowdefaultimports.json
@@ -6,12 +6,14 @@
     }
   },
   "transform": {
-    ".(ts|tsx)": "../../preprocessor.js"
+    "^.+\\.tsx?$": "../../preprocessor.js"
   },
-  "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   "moduleFileExtensions": [
     "ts",
     "tsx",
-    "js"
+    "js",
+    "jsx",
+    "json"
   ]
 }

--- a/tests/dynamic-imports/package.json
+++ b/tests/dynamic-imports/package.json
@@ -1,13 +1,15 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/hoist-errors/package.json
+++ b/tests/hoist-errors/package.json
@@ -1,9 +1,9 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "coverageReporters": [
       "json"
     ],
@@ -15,7 +15,9 @@
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/hoist-test/package.json
+++ b/tests/hoist-test/package.json
@@ -1,14 +1,16 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
     "moduleDirectories": ["node_modules", "src"],
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/imports-test/package.json
+++ b/tests/imports-test/package.json
@@ -1,14 +1,16 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
     "moduleDirectories": ["node_modules", "src"],
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/jestconfig-test/jest.json
+++ b/tests/jestconfig-test/jest.json
@@ -1,10 +1,10 @@
 {
   "rootDir": "./",
   "transform": {
-    ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
   },
   "mapCoverage": true,
-  "testRegex": "/specs/.*\\.spec\\.(ts|tsx|js)$",
+  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   "testEnvironment": "jsdom",
   "coverageReporters": [
     "html",
@@ -16,6 +16,7 @@
     "ts",
     "tsx",
     "js",
+    "jsx",
     "json"
   ],
   "collectCoverageFrom": [

--- a/tests/no-synthetic-default/package.json
+++ b/tests/no-synthetic-default/package.json
@@ -1,14 +1,16 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
     "moduleDirectories": ["node_modules", "src"],
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/simple-async/package.json
+++ b/tests/simple-async/package.json
@@ -2,11 +2,11 @@
   "jest": {
     "rootDir": "./",
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx?|jsx?)$",
     "coverageReporters": [
-      "json"
+      "lcov"
     ],
     "collectCoverageFrom": [
       "Hello.ts",

--- a/tests/simple-async/package.json
+++ b/tests/simple-async/package.json
@@ -4,7 +4,7 @@
     "transform": {
       "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx?|jsx?)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "coverageReporters": [
       "lcov"
     ],
@@ -16,7 +16,9 @@
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/simple-long-path/package.json
+++ b/tests/simple-long-path/package.json
@@ -1,9 +1,9 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "coverageReporters": [
       "json"
     ],
@@ -14,7 +14,9 @@
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/simple/package.json
+++ b/tests/simple/package.json
@@ -3,7 +3,7 @@
     "transform": {
       "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx?|jsx?)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "coverageReporters": [
       "lcov"
     ],
@@ -15,7 +15,9 @@
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/simple/package.json
+++ b/tests/simple/package.json
@@ -1,11 +1,11 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx?|jsx?)$",
     "coverageReporters": [
-      "json"
+      "lcov"
     ],
     "collectCoverageFrom": [
       "Hello.ts",

--- a/tests/skip-babelrc/package.json
+++ b/tests/skip-babelrc/package.json
@@ -1,9 +1,9 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "coverageReporters": [
       "json"
     ],
@@ -15,7 +15,9 @@
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/synthetic-default/package.json
+++ b/tests/synthetic-default/package.json
@@ -1,17 +1,19 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
     "moduleDirectories": [
       "node_modules",
       "src"
     ],
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/use-babelrc/package.json
+++ b/tests/use-babelrc/package.json
@@ -1,17 +1,19 @@
 {
 	"jest": {
 		"transform": {
-			".(ts|tsx)": "../../preprocessor.js"
+			"^.+\\.tsx?$": "../../preprocessor.js"
 		},
 		"moduleDirectories": [
 			"node_modules",
 			"src"
 		],
-		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+		"testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
 		"moduleFileExtensions": [
 			"ts",
 			"tsx",
-			"js"
+			"js",
+			"jsx",
+			"json"
 		],
 		"globals": {
 			"ts-jest": {

--- a/tests/use-strict/package.json
+++ b/tests/use-strict/package.json
@@ -1,14 +1,16 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
     "mapCoverage": true,
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }

--- a/tests/watch-test/package.json
+++ b/tests/watch-test/package.json
@@ -1,17 +1,19 @@
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "../../preprocessor.js"
+      "^.+\\.tsx?$": "../../preprocessor.js"
     },
     "mapCoverage": true,
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "coverageReporters": [
       "json"
     ],
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "jsx",
+      "json"
     ]
   }
 }


### PR DESCRIPTION
Following #310

- `".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"`
should be `"^.+\\.tsx?$"` see [1](https://github.com/facebook/jest/blob/v20.0.4/packages/jest-config/src/constants.js#L14), [2](https://github.com/facebook/jest/tree/master/packages/babel-jest#setup), [3](https://github.com/facebook/jest/blob/de74b38aff9f0a91dcdaf5986d2a6f963b78cfdf/examples/typescript/package.json#L18)
- `"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$"`
should be `"(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$"` see [1](https://github.com/facebook/jest/blob/de74b38aff9f0a91dcdaf5986d2a6f963b78cfdf/packages/jest-config/src/valid_config.js#L84), [2](http://facebook.github.io/jest/docs/en/configuration.html#testregex-string)

<br>

Is `"^.+\\.tsx?$"` that different from `".(ts|tsx)"`? I can't explain it but it changes the coverage results for the `simple` and `simple-async` tests:

- With `".(ts|tsx)"`:

![screen shot 2017-08-31 at 15 51 11](https://user-images.githubusercontent.com/643434/29939726-20a4c584-8e8d-11e7-877b-03c5ba476a00.png)

- With `"^.+\\.tsx?$"`:

![screen shot 2017-08-31 at 15 51 54](https://user-images.githubusercontent.com/643434/29939733-26d5721e-8e8d-11e7-9d90-1ee5d0121db8.png)

And I believe the results with `"^.+\\.tsx?$"` are the correct ones.

As for root `package.json`, I've changed `"testRegex": "/__tests__/.*\\.(spec)\\.(ts|js)$"
` to `"tests/__tests__/.*\\.spec\\.ts$"`.
The path is now hardcoded to be sure to only match files `tests/__tests__/*.spec.ts` and not the others that end with `.test.ts` (differentiate test categories with `.spec.ts` vs `.test.ts` is dangerous IMHO).
