### PR TITLE
Revert yargs to 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest-util": "^21.0.0",
     "pkg-dir": "^2.0.0",
     "source-map-support": "^0.4.4",
-    "yargs": "^9.0.1"
+    "yargs": "^8.0.1"
   },
   "peerDependencies": {
     "jest": "^21.0.0 || ^21.1.0-alpha.1 || ^22.0.0-alpha.1",


### PR DESCRIPTION
Greenkeeper had updated this (#326) but `yarn.lock` didn't get updated properly. Reverting this to

- hopefully have greenkeeper send in a PR along with the yarn.lock updates
- test the new setup (#329) for this
