### PR TITLE
Set the start dir of looking for tsconfig to process.cwd()

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "author": "Kulshekhar Kabra <kulshekhar@users.noreply.github.com> (https://github.com/kulshekhar)",
   "contributors": [
+    "Bnaya Peretz <me@bnaya.net> (https://github.com/Bnaya)",
     "Brian Ruddy <briancruddy@gmail.com> (https://github.com/bcruddy)",
     "Emil Persson <emil.n.persson@gmail.com> (https://github.com/emilniklas)",
     "Gustav Wengel <gustavwengel@gmail.com>(https://github.com/GeeWee)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "21.1.2",
+  "version": "21.1.3",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,8 +123,9 @@ function getStartDir(): string {
 
   const grandparent = path.resolve(__dirname, '..', '..');
   if (grandparent.endsWith('/node_modules')) {
-    return path.resolve(grandparent, '..');
+    return process.cwd();
   }
+
   return '.';
 }
 

--- a/tests/__tests__/synthetic-default-imports.spec.ts
+++ b/tests/__tests__/synthetic-default-imports.spec.ts
@@ -10,7 +10,7 @@ describe('synthetic default imports', () => {
     expect(stderr).toContain(
       `TypeError: Cannot read property 'someExport' of undefined`,
     );
-    expect(stderr).toContain('module.test.ts:6:15');
+    expect(stderr).toContain('module.test.ts:6');
   });
 
   it('should work when the compiler option is true', () => {


### PR DESCRIPTION
Mimic jest behaviour to find `package.json` (and his config inside it)

See
https://github.com/facebook/jest/blob/d62a7e0edfec556758e1c0e23158e4ce4ac84e91/packages/jest-runtime/src/cli/index.js#L60-L68
https://github.com/facebook/jest/blob/e04e45102b3ebe486462d45db656f9b47f0e70e1/packages/jest-config/src/index.js#L18-L26  

resolved #347 