### PR TITLE
Fix postprocess bug when babel config is supplied with no plugins

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ OJ Kwon <kwon.ohjoong@gmail.com>
 Oliver Joseph Ash <oliverjash@gmail.com>
 Orta Therox <orta.therox+gh@gmail.com>
 Patrick Housley <patrick.f.housley@gmail.com>
+Richard Silverton <richsilv@yahoo.co.uk>
 Rikki Tooley <rikki.tooley@travellocal.com>
 Tom Crockett <tomcrockett@tuplehealth.com>
 Trivikram Kamat <trivikr.dev@gmail.com>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "21.1.3",
+  "version": "21.1.4",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/src/postprocess.ts
+++ b/src/postprocess.ts
@@ -66,7 +66,7 @@ export const getPostProcessHook = (
   }
 
   const plugins = tsJestConfig.babelConfig
-    ? tsJestConfig.babelConfig.plugins
+    ? tsJestConfig.babelConfig.plugins || []
     : [];
   // If we're not skipping babel
   if (tsCompilerOptions.allowSyntheticDefaultImports) {


### PR DESCRIPTION
If the user specifies a babel config for *ts-jest* in `package.json`, but only includes a `presets` and not `plugins`, https://github.com/kulshekhar/ts-jest/blob/3039ef39075453b948c891f50e4a4d69b95f4cfc/src/postprocess.ts#L69 will assign `undefined` to `plugins`.  In the next line, the extra plugin (`transform-es2015-modules-commonjs`) is `push`ed into this variable, which will obviously fail if it's not an array.