### PR TITLE
Move to language service compiler api

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,0 +1,167 @@
+import * as ts from 'typescript';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as utils from './utils';
+
+function formatTscParserErrors(errors: ts.Diagnostic[]) {
+  return errors.map(s => JSON.stringify(s, null, 4)).join('\n');
+}
+
+interface File {
+  path: string;
+  version: number;
+  snapshot: ts.IScriptSnapshot;
+  src: string;
+}
+
+class Files {
+  private files: Map<string, File>;
+  constructor() {
+    this.files = new Map();
+  }
+  // set(path: string, file: File) {
+  //     this.files.set(path, file)
+  // }
+  update({ path, src }: { path: string; src: string }) {
+    const file = this.get(path);
+    if (file === undefined) {
+      const newFile: File = {
+        src,
+        path,
+        version: 0,
+        snapshot: ts.ScriptSnapshot.fromString(src),
+      };
+      this.files.set(path, newFile);
+      return;
+    }
+    if (file.src === src) {
+      return;
+    }
+    file.src = src;
+    file.version += 1;
+    file.snapshot = ts.ScriptSnapshot.fromString(src);
+  }
+  get(path: string) {
+    return this.files.get(path);
+  }
+  getFileNames() {
+    return Array.from(this.files.values()).map(f => f.path);
+  }
+  getScriptVersion(path: string) {
+    const f = this.get(path);
+    if (f === undefined) {
+      return '';
+    }
+    return f.version.toString();
+  }
+}
+
+export class Compiler {
+  private options?: ts.CompilerOptions;
+  private service: ts.LanguageService;
+  private files: Files;
+
+  constructor(options?: ts.CompilerOptions) {
+    this.files = new Files();
+    this.options = options;
+    this.service = this.createServiceHost();
+  }
+  setOptions(options: ts.CompilerOptions) {
+    this.options = options;
+  }
+  private createServiceHost() {
+    const { files, options } = this;
+
+    let service: ts.LanguageService;
+
+    class ServiceHost implements ts.LanguageServiceHost {
+      // getCustomTransformers() {
+      //     return {
+      //         before: [tsruntimeTransformer(service.getProgram())]
+      //     }
+      // }
+      getScriptFileNames() {
+        return files.getFileNames();
+      }
+      getScriptVersion(fileName: string) {
+        return files.getScriptVersion(fileName);
+      }
+      getScriptSnapshot(fileName: string) {
+        const file = files.get(fileName);
+        if (file !== undefined) {
+          return file.snapshot;
+        }
+        if (!fs.existsSync(fileName)) {
+          return undefined;
+        }
+        return ts.ScriptSnapshot.fromString(
+          fs.readFileSync(fileName).toString(),
+        ); //todo maybe put to files cache
+      }
+      getCurrentDirectory = () => process.cwd();
+      getCompilationSettings = () => options;
+      getDefaultLibFileName = (options: ts.CompilerOptions) =>
+        ts.getDefaultLibFilePath(options);
+      fileExists = ts.sys.fileExists;
+      readFile = ts.sys.readFile;
+      readDirectory = ts.sys.readDirectory;
+      // resolveTypeReferenceDirectives(typeDirectiveNames: string[], containingFile: string) {
+      //     const resolved = typeDirectiveNames.map(directive =>
+      //         ts.resolveTypeReferenceDirective(directive, containingFile, options, ts.sys)
+      //             .resolvedTypeReferenceDirective);
+
+      //     // resolved.forEach(res => {
+      //     if (res && res.resolvedFileName) {
+      //         fileDeps.add(containingFile, res.resolvedFileName);
+      //     }
+      // });
+
+      // return resolved;
+      // }
+    }
+
+    service = ts.createLanguageService(
+      new ServiceHost(),
+      ts.createDocumentRegistry(),
+    );
+
+    return service;
+  }
+
+  emitFile({ path, src }: { path: string; src: string }) {
+    this.files.update({ path, src });
+
+    let output = this.service.getEmitOutput(path);
+
+    if (output.emitSkipped) {
+      this.logErrors(path);
+    }
+    const res = utils.findResultFor(path, output);
+    return res;
+  }
+
+  private logErrors(fileName: string) {
+    let allDiagnostics = this.service
+      .getCompilerOptionsDiagnostics()
+      .concat(this.service.getSyntacticDiagnostics(fileName))
+      .concat(this.service.getSemanticDiagnostics(fileName));
+
+    allDiagnostics.forEach(diagnostic => {
+      let message = ts.flattenDiagnosticMessageText(
+        diagnostic.messageText,
+        '\n',
+      );
+      if (diagnostic.file) {
+        let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
+          diagnostic.start!,
+        );
+        console.log(
+          `  Error ${diagnostic.file.fileName} (${line + 1},${character +
+            1}): ${message}`,
+        );
+      } else {
+        console.log(`  Error: ${message}`);
+      }
+    });
+  }
+}

--- a/src/compiler/utils.ts
+++ b/src/compiler/utils.ts
@@ -1,0 +1,123 @@
+import * as path from 'path';
+import * as ts from 'typescript';
+import * as fs from 'fs';
+
+// from here: https://github.com/s-panferov/awesome-typescript-loader/blob/master/src/helpers.ts
+
+export interface OutputFile {
+  text: string;
+  sourceMap?: string;
+  declaration?: ts.OutputFile;
+}
+
+function statSyncNoException(path: string) {
+  try {
+    return fs.statSync(path);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function withoutExt(fileName: string): string {
+  return path.basename(fileName).split('.')[0];
+}
+
+let caseInsensitiveFs: boolean | undefined;
+
+export function isCaseInsensitive() {
+  if (typeof caseInsensitiveFs !== 'undefined') {
+    return caseInsensitiveFs;
+  }
+
+  const lowerCaseStat = statSyncNoException(process.execPath.toLowerCase());
+  const upperCaseStat = statSyncNoException(process.execPath.toUpperCase());
+
+  if (lowerCaseStat && upperCaseStat) {
+    caseInsensitiveFs =
+      lowerCaseStat.dev === upperCaseStat.dev &&
+      lowerCaseStat.ino === upperCaseStat.ino;
+  } else {
+    caseInsensitiveFs = false;
+  }
+
+  return caseInsensitiveFs;
+}
+
+function compareFileName(first: string, second: string) {
+  if (isCaseInsensitive()) {
+    return first.toLowerCase() === second.toLowerCase();
+  } else {
+    return first === second;
+  }
+}
+
+function isFileEmit(
+  fileName: string,
+  outputFileName: string,
+  sourceFileName: string,
+) {
+  return (
+    compareFileName(sourceFileName, fileName) &&
+    // typescript now emits .jsx files for .tsx files.
+    (outputFileName.substr(-3).toLowerCase() === '.js' ||
+      outputFileName.substr(-4).toLowerCase() === '.jsx')
+  );
+}
+
+function isSourceMapEmit(
+  fileName: string,
+  outputFileName: string,
+  sourceFileName: string,
+) {
+  return (
+    compareFileName(sourceFileName, fileName) &&
+    // typescript now emits .jsx files for .tsx files.
+    (outputFileName.substr(-7).toLowerCase() === '.js.map' ||
+      outputFileName.substr(-8).toLowerCase() === '.jsx.map')
+  );
+}
+
+function isDeclarationEmit(
+  fileName: string,
+  outputFileName: string,
+  sourceFileName: string,
+) {
+  return (
+    compareFileName(sourceFileName, fileName) &&
+    outputFileName.substr(-5).toLowerCase() === '.d.ts'
+  );
+}
+
+export function findResultFor(
+  fileName: string,
+  output: ts.EmitOutput,
+): OutputFile {
+  let text: string | undefined;
+  let sourceMap: string | undefined;
+  let declaration: ts.OutputFile | undefined;
+  fileName = withoutExt(fileName);
+
+  for (let i = 0; i < output.outputFiles.length; i++) {
+    let o = output.outputFiles[i];
+    let outputFileName = o.name;
+    let sourceFileName = withoutExt(o.name);
+    if (isFileEmit(fileName, outputFileName, sourceFileName)) {
+      text = o.text;
+    }
+    if (isSourceMapEmit(fileName, outputFileName, sourceFileName)) {
+      sourceMap = o.text;
+    }
+    if (isDeclarationEmit(fileName, outputFileName, sourceFileName)) {
+      declaration = o;
+    }
+  }
+  if (text === undefined) {
+    // console.log(text)
+    throw new Error('text is undefined');
+  }
+  return {
+    text,
+    sourceMap,
+    declaration,
+  };
+}

--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -73,4 +73,5 @@ export interface TsJestConfig {
   useBabelrc?: boolean;
   babelConfig?: BabelTransformOpts;
   tsConfigFile?: String;
+  customTransformersPath?: string;
 }

--- a/src/transpile-if-ts.ts
+++ b/src/transpile-if-ts.ts
@@ -1,17 +1,14 @@
-import * as tsc from 'typescript';
 import { getTSConfig, mockGlobalTSConfigSchema } from './utils';
+import { Compiler } from './compiler/compiler';
 
 export function transpileIfTypescript(path, contents, config?) {
   if (path && (path.endsWith('.tsx') || path.endsWith('.ts'))) {
-    let transpiled = tsc.transpileModule(contents, {
-      compilerOptions: getTSConfig(
-        config || mockGlobalTSConfigSchema(global),
-        true,
-      ),
-      fileName: path,
-    });
-
-    return transpiled.outputText;
+    const options = getTSConfig(
+      config || mockGlobalTSConfigSchema(global),
+      true,
+    );
+    const compiler = new Compiler(options);
+    return compiler.emitFile({ path, src: contents }).text;
   }
   return contents;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,11 @@
     "allowSyntheticDefaultImports": false,
     "outDir": "dist",
     "rootDir": "src",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["jest", "node"],
+    "lib": [
+      "es2015"
+    ]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
#281 
also makes easy to fix #303 

Notes:
- 3 tests are failing (1 one them was failing in master (about button))
- I guess when jest works on concurrency mode it creates `preprocessor.js` context for every process (or even reimport it on overy transpile). If yes, this means that we have multiple `compiler` instances, so it will recompile same files for every jest worker. It could be optimized by using shared `DocumentRegistry` (https://github.com/Microsoft/TypeScript/blob/master/lib/typescript.d.ts#L4465)
- I'm not sure why source maps implemented this way, but it worth to mention, that with `sourceMap=true` in CompilerOptions, on calling `service.getEmitOutput` we can get sourcemaps. We can push it to some cache and on `install()` use 
```js
  options.retrieveSourceMap = function(path) { return sourceMapCache.get(path) };
```
I guess this way we can avoid second run of `transpileModule`.