### PR TITLE
Change the package entry point to preprocessor.js itself

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ Justin Bay <jwbay@users.noreply.github.com>
 Kulshekhar Kabra <kulshekhar@users.noreply.github.com>
 Kyle Roach <kroach.work@gmail.com>
 Marshall Bowers <elliott.codes@gmail.com>
+Martijn The <post@martijnthe.nl>
 Matheus Gambati <matheusgambati@gmail.com>
 Maxim Samoilov <samoilowmaxim@gmail.com>
 Mohammad Rajabifard <mo.rajbi@gmail.com>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Modify your project's `package.json` so that the `jest` section looks something 
 {
   "jest": {
     "transform": {
-      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
@@ -226,7 +226,7 @@ In `package.json`, inside `jest` section, the `transform` should be like this:
 ```json
 "transform": {
   "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest",
-  "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+  "^.+\\.tsx?$": "ts-jest"
 }
 ```
 
@@ -237,7 +237,7 @@ Fully completed jest section should look like this:
     "preset": "react-native",
     "transform": {
       "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest",
-      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
@@ -269,7 +269,7 @@ You'll also need to extend your `transform` regex with `html` extension:
 {
   "jest": {
     "transform": {
-      "^.+\\.(tsx?|html)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.(tsx?|html)$": "ts-jest"
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/index');

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "yargs": "^10.0.3"
   },
   "peerDependencies": {
-    "jest": "^21.1.0 || ^21.1.0-alpha.1 || ^22.0.0-alpha.1",
+    "jest": "^21.1.0 || ^21.3.0-alpha.1 || ^22.0.0-alpha.1",
     "typescript": "2.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ts-jest",
-  "version": "21.1.4",
-  "main": "index.js",
-  "types": "./dist/index.d.ts",
+  "version": "21.2.0",
+  "main": "preprocessor.js",
+  "types": "./dist/preprocessor.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",
   "scripts": {
     "build": "tsc -p .",

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,7 +1,6 @@
 import * as sourceMapSupport from 'source-map-support';
 import { defaultRetrieveFileHandler } from './default-retrieve-file-handler';
 
-export { transpileIfTypescript } from './transpile-if-ts';
 export function install() {
   const options: sourceMapSupport.Options = {};
 

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -6,6 +6,8 @@ import { JestConfig, Path, TransformOptions } from './jest-types';
 import { getPostProcessHook } from './postprocess';
 import { getTSConfig, getTSJestConfig } from './utils';
 
+export { install } from './install';
+
 export function process(
   src: string,
   path: Path,

--- a/tests/__tests__/transpile-if-ts.spec.ts
+++ b/tests/__tests__/transpile-if-ts.spec.ts
@@ -1,4 +1,4 @@
-import { transpileIfTypescript } from '../../src';
+import { transpileIfTypescript } from '../../src/transpile-if-ts';
 
 describe('transpileIfTypescript', () => {
   it('should ignore anything non-TS', () => {

--- a/tests/jestconfig-test/jest.json
+++ b/tests/jestconfig-test/jest.json
@@ -1,7 +1,7 @@
 {
   "rootDir": "./",
   "transform": {
-    "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    "^.+\\.tsx?$": "ts-jest"
   },
   "mapCoverage": true,
   "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",


### PR DESCRIPTION
This way, the `"ts-jest"` package name can be used as Jest transform, instead of specifying the path to preprocessor.js.
The latter did not work when the ts-jest package had been hoisted to a parent folder (for example by lerna).

Fixes https://github.com/kulshekhar/ts-jest/issues/361