### PR TITLE
Use shallow renderer in tsx test to avoid skipping it with node8/react16

### DIFF
--- a/tests/__tests__/tsx-errors.spec.ts
+++ b/tests/__tests__/tsx-errors.spec.ts
@@ -1,13 +1,7 @@
 import runJest from '../__helpers__/runJest';
 import * as React from 'react';
 
-const nodeVersion = parseInt(process.version.substr(1, 2));
-const reactVersion = parseInt(React.version.substr(0, 2));
-
-const tmpDescribe =
-  nodeVersion >= 8 && reactVersion >= 16 ? xdescribe : describe;
-
-tmpDescribe('TSX Errors', () => {
+describe('TSX Errors', () => {
   it('should show the correct error locations in the typescript files', () => {
     const result = runJest('../button', ['--no-cache', '-u']);
 
@@ -15,6 +9,6 @@ tmpDescribe('TSX Errors', () => {
 
     expect(result.status).toBe(1);
     expect(stderr).toContain('Button.tsx:22:17');
-    expect(stderr).toContain('Button.test.tsx:15:12');
+    expect(stderr).toContain('Button.test.tsx:16:12');
   });
 });

--- a/tests/__tests__/tsx-errors.spec.ts
+++ b/tests/__tests__/tsx-errors.spec.ts
@@ -9,6 +9,6 @@ describe('TSX Errors', () => {
 
     expect(result.status).toBe(1);
     expect(stderr).toContain('Button.tsx:22:17');
-    expect(stderr).toContain('Button.test.tsx:16:12');
+    expect(stderr).toContain('Button.test.tsx:19:12');
   });
 });

--- a/tests/button/__tests__/Button.test.tsx
+++ b/tests/button/__tests__/Button.test.tsx
@@ -12,6 +12,9 @@ it('Button renders correctly', () => {
 });
 
 it('BadButton should throw an error on line 22', () => {
+  // We're using shallow renderer here because the behaviour of 
+  // the test-renderer is causing a bug when used with React 16 & node 8
+  // https://github.com/kulshekhar/ts-jest/issues/334
   const renderer = new ShallowRenderer();
   renderer.render(<BadButton>hi!</BadButton>);
 });

--- a/tests/button/__tests__/Button.test.tsx
+++ b/tests/button/__tests__/Button.test.tsx
@@ -1,17 +1,17 @@
 declare var jest, describe, it, expect, require;
 
 import * as React from 'react';
-const renderer = require('react-test-renderer');
+import * as testRenderer from 'react-test-renderer';
+import * as ShallowRenderer from 'react-test-renderer/shallow';
 
 import { Button, BadButton } from '../Button';
 
 it('Button renders correctly', () => {
-  const tree = renderer.create(<Button>hi!</Button>).toJSON();
+  const tree = testRenderer.create(<Button>hi!</Button>).toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 it('BadButton should throw an error on line 22', () => {
-
-  renderer.create(<BadButton>hi!</BadButton>).toJSON();
-
+  const renderer = new ShallowRenderer();
+  renderer.render(<BadButton>hi!</BadButton>);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3750,7 +3750,7 @@ yargs-parser@^8.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@10.0.3:
+yargs@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.0.3.tgz#6542debd9080ad517ec5048fb454efe9e4d4aaae"
   dependencies:


### PR DESCRIPTION
This replaces the use of test-renderer with shallow renderer in a test that caused a test to fail with React 16 and Node 8 (#334)

While this helps us avoid skipping tests, it isn't a real fix for that issue. However, it probably indicates that the issue lies somewhere in the test-renderer.