### PR TITLE
Don't accumulate commonjs module transforms

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@
 
 Alex Jover Morales <alexjovermorales@gmail.com>
 Andreas Krummsdorf <andreas.krummsdorf@doksafe.de>
+Anonymous <goodforonefare@gmail.com>
 Bartosz Gościński <bargosc@gmail.com>
 Blake Embrey <hello@blakeembrey.com>
 Brian Ruddy <briancruddy@gmail.com>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "21.2.1",
+  "version": "21.2.2",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/src/postprocess.ts
+++ b/src/postprocess.ts
@@ -65,9 +65,7 @@ export const getPostProcessHook = (
     return src => src; // Identity function
   }
 
-  const plugins = tsJestConfig.babelConfig
-    ? tsJestConfig.babelConfig.plugins || []
-    : [];
+  const plugins = Array.from(tsJestConfig.babelConfig && tsJestConfig.babelConfig.plugins || []);
   // If we're not skipping babel
   if (tsCompilerOptions.allowSyntheticDefaultImports) {
     plugins.push('transform-es2015-modules-commonjs');

--- a/tests/__tests__/postprocess.spec.ts
+++ b/tests/__tests__/postprocess.spec.ts
@@ -1,0 +1,71 @@
+jest.mock('babel-core', () => {
+  return {
+    transform: jest.fn(() => {
+      return {code: 'stubbed_code'};
+    }),
+  };
+});
+
+import { getPostProcessHook } from '../../src/postprocess';
+
+describe('postprocess', () => {
+  function runHook(tsCompilerOptions = {}, jestConfig = {}, tsJestConfig = {}) {
+    return getPostProcessHook(tsCompilerOptions, jestConfig, tsJestConfig)(
+        'input_code',
+        'fake_file',
+        {},
+        {instrument: null},
+    );
+  }
+
+  it('skips postprocess when skipBabel=true', () => {
+    const transformMock = require.requireMock('babel-core').transform;
+
+    runHook({}, {}, {skipBabel: true});
+    expect(transformMock).not.toBeCalled();
+  });
+
+  it('skips commonjs module transform by default', () => {
+    const transformMock = require.requireMock('babel-core').transform;
+
+    runHook();
+    getPostProcessHook({}, {}, {})('input_code', 'fake_file', {}, {instrument: null});
+    expect(transformMock).lastCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        plugins: [],
+      }),
+    );
+  });
+
+  it('uses commonjs module transform when allowSyntheticDefaultImports=true', () => {
+    const transformMock = require.requireMock('babel-core').transform;
+
+    runHook({allowSyntheticDefaultImports: true});
+    expect(transformMock).lastCalledWith(
+      expect.any(String),
+      expect.objectContaining({plugins: ['transform-es2015-modules-commonjs']}),
+    );
+  });
+
+  it('doesn`t accumulate commonjs module transforms on consecutive calls', () => {
+    const transformMock = require.requireMock('babel-core').transform;
+    const tsCompilerOptions = {allowSyntheticDefaultImports: true};
+    const tsJestConfig = {
+      babelConfig: {
+        plugins: [],
+      },
+      skipBabel: false,
+    };
+
+    runHook(tsCompilerOptions, {}, tsJestConfig);
+    runHook(tsCompilerOptions, {}, tsJestConfig);
+
+    expect(transformMock).lastCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+          plugins: ['transform-es2015-modules-commonjs'],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Previously, each import in a test suite would add an extra `'transform-es2015-modules-commonjs'` transform to the babel config.

cc @lemonmade - this was adding ~27 seconds to our test startup.