### PR TITLE
Remove jest-util as dependency

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Orta Therox <orta.therox+gh@gmail.com>
 Patrick Housley <patrick.f.housley@gmail.com>
 Richard Silverton <richsilv@yahoo.co.uk>
 Rikki Tooley <rikki.tooley@travellocal.com>
+Simen Bekkhus <sbekkhus91@gmail.com>
 Thomas Fontaine <thomas.fontaine@me.com>
 Tom Crockett <tomcrockett@tuplehealth.com>
 Trivikram Kamat <trivikr.dev@gmail.com>

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "cpx": "^1.5.0",
     "fs-extra": "^4.0.2",
     "jest-config": "^21.2.1",
-    "jest-util": "^21.2.1",
     "pkg-dir": "^2.0.0",
     "source-map-support": "^0.5.0",
     "yargs": "^10.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "21.2.3",
+  "version": "21.2.4",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",


### PR DESCRIPTION
It's not used

![image](https://user-images.githubusercontent.com/1404810/33451207-9ae0256e-d60e-11e7-8aae-8dff0b0c0d57.png)

Not sure why it was added in #109