### PR TITLE
Disable internal caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "22.0.0",
+  "version": "22.0.1",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -73,4 +73,5 @@ export interface TsJestConfig {
   useBabelrc?: boolean;
   babelConfig?: BabelTransformOpts;
   tsConfigFile?: string;
+  enableInternalCache?: boolean;
 }

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -43,10 +43,12 @@ export function process(
     fileName: filePath,
   });
 
+  const tsJestConfig = getTSJestConfig(jestConfig.globals);
+
   const postHook = getPostProcessHook(
     compilerOptions,
     jestConfig,
-    getTSJestConfig(jestConfig.globals),
+    tsJestConfig,
   );
 
   const outputText = postHook(
@@ -58,7 +60,15 @@ export function process(
 
   const modified = injectSourcemapHook(outputText);
 
-  cacheFile(jestConfig, filePath, modified);
+  if (tsJestConfig.enableInternalCache === true) {
+    // This config is undocumented.
+    // This has been made configurable for now to ensure that
+    // if this breaks something for existing users, there's a quick fix
+    // in place.
+    // If this doesn't cause a problem, this if block will be removed
+    // in a future version
+    cacheFile(jestConfig, filePath, modified);
+  }
 
   return modified;
 }


### PR DESCRIPTION
Following the discussion in #406 
https://github.com/kulshekhar/ts-jest/issues/406#issuecomment-354708580

This PR removes some caching that ts-jest does. Given that we have the `getCacheKey` function that jest can use to determine whether to cache something or not, there seems no reason to continue caching internally.
  