### PR TITLE
Test performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@types/babel-core": "^6.7.14",
     "@types/es6-shim": "latest",
     "@types/fs-extra": "4.0.7",
-    "@types/jest": "latest",
+    "@types/jest": "^22.1.0",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/source-map-support": "latest",

--- a/tests/__helpers__/promisify-spawn.ts
+++ b/tests/__helpers__/promisify-spawn.ts
@@ -1,0 +1,36 @@
+import { spawn as crossSpawn } from 'cross-spawn';
+import * as eventToPromise from 'event-to-promise';
+import { JestResult } from './runJest';
+
+// Asynchronously spawn a process and return a promise
+export async function spawnProcess(
+  command: string,
+  args: string[],
+  options = {},
+): Promise<JestResult> {
+  return new Promise((resolve, reject) => {
+    // default to empty strings for stdio
+    let stdErr = '';
+    let stdOut = '';
+    let output = ''; // combined output;
+    const process = crossSpawn(command, args, options);
+    process.stdout.on('data', (data: Buffer) => {
+      stdOut += data.toString();
+      output += data.toString();
+    });
+
+    process.stderr.on('data', (data: Buffer) => {
+      stdErr += data.toString();
+      output += data.toString();
+    });
+
+    process.on('close', exitCode => {
+      resolve({
+        status: exitCode,
+        stderr: stdErr,
+        stdout: stdOut,
+        output,
+      });
+    });
+  }) as Promise<JestResult>;
+}

--- a/tests/__helpers__/promisify-spawn.ts
+++ b/tests/__helpers__/promisify-spawn.ts
@@ -1,5 +1,4 @@
 import { spawn as crossSpawn } from 'cross-spawn';
-import * as eventToPromise from 'event-to-promise';
 import { JestResult } from './runJest';
 
 // Asynchronously spawn a process and return a promise

--- a/tests/__helpers__/runJest.ts
+++ b/tests/__helpers__/runJest.ts
@@ -1,6 +1,6 @@
 // from: https://github.com/facebook/jest/blob/master/integration_tests/runJest.js
 
-import { sync as spawnSync } from 'cross-spawn';
+import { spawnProcess } from './promisify-spawn';
 import * as path from 'path';
 import { fileExists } from './utils';
 
@@ -9,9 +9,12 @@ import { fileExists } from './utils';
 const JEST_PATH = 'jest';
 
 // return the result of the spawned proccess:
-//  [ 'status', 'signal', 'output', 'pid', 'stdout', 'stderr',
+//  [ 'status', 'signal', 'output',  'pid', 'stdout', 'stderr',
 //    'envPairs', 'options', 'args', 'file' ]
-export default function runJest(dir: string, args: string[]) {
+export default async function runJest(
+  dir: string,
+  args: string[],
+): Promise<JestResult> {
   const isRelative = dir[0] !== '/';
 
   if (isRelative) {
@@ -28,12 +31,14 @@ export default function runJest(dir: string, args: string[]) {
     `);
   }
 
-  const result = spawnSync(JEST_PATH, args || [], {
+  return spawnProcess(JEST_PATH, args || [], {
     cwd: dir,
   });
+}
 
-  result.stdout = result.stdout && result.stdout.toString();
-  result.stderr = result.stderr && result.stderr.toString();
-
-  return result;
+export interface JestResult {
+  stderr: string;
+  stdout: string;
+  output: string;
+  status: number;
 }

--- a/tests/__helpers__/runJest.ts
+++ b/tests/__helpers__/runJest.ts
@@ -15,6 +15,7 @@ export default async function runJest(
   dir: string,
   args: string[],
 ): Promise<JestResult> {
+  jest.setTimeout(10000); // Set a ten second timeout, as sometimes the jest process takes a little while to return.
   const isRelative = dir[0] !== '/';
 
   if (isRelative) {

--- a/tests/__tests__/babel-config.spec.ts
+++ b/tests/__tests__/babel-config.spec.ts
@@ -1,13 +1,16 @@
 import runJest from '../__helpers__/runJest';
 
 describe('babelConfig flag', () => {
-  it('should use a custom Babel config', () => {
-    const result = runJest('../babel-config', ['--no-cache', '-u']);
+  it('should use a custom Babel config', async () => {
+    const result = await runJest('../babel-config', ['--no-cache', '-u']);
     expect(result.status).toBe(0);
   });
 
-  it('should fail for invalid babel configs', () => {
-    const result = runJest('../babel-config-invalid', ['--no-cache', '-u']);
+  it('should fail for invalid babel configs', async () => {
+    const result = await runJest('../babel-config-invalid', [
+      '--no-cache',
+      '-u',
+    ]);
     const stderr = result.stderr.toString();
     expect(result.status).toBe(1);
     expect(stderr).toContain('ReferenceError: [BABEL]');
@@ -16,16 +19,16 @@ describe('babelConfig flag', () => {
     );
   });
 
-  it('should not merge in .babelrc options when ommiting the useBabelrc option', () => {
-    const result = runJest('../babel-config-merge-ignore-babelrc', [
+  it('should not merge in .babelrc options when ommiting the useBabelrc option', async () => {
+    const result = await runJest('../babel-config-merge-ignore-babelrc', [
       '--no-cache',
       '-u',
     ]);
     expect(result.status).toBe(0);
   });
 
-  it('should merge in .babelrc options when using the useBabelrc option', () => {
-    const result = runJest('../babel-config-merge-with-babelrc', [
+  it('should merge in .babelrc options when using the useBabelrc option', async () => {
+    const result = await runJest('../babel-config-merge-with-babelrc', [
       '--no-cache',
       '-u',
     ]);

--- a/tests/__tests__/babelrc.spec.ts
+++ b/tests/__tests__/babelrc.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('babelrc flag', () => {
-  it('should crash on invalid babelrc', () => {
-    const result = runJest('../use-babelrc', ['--no-cache', '-u']);
+  it('should crash on invalid babelrc', async () => {
+    const result = await runJest('../use-babelrc', ['--no-cache', '-u']);
     const stderr = result.stderr.toString();
     expect(result.status).toBe(1);
     expect(stderr).toContain('ReferenceError: [BABEL]');
@@ -11,8 +11,8 @@ describe('babelrc flag', () => {
     );
   });
 
-  it('Should not crash on invalid babelrc if useBabelrc is not set', () => {
-    const result = runJest('../skip-babelrc', ['--no-cache', '-u']);
+  it('Should not crash on invalid babelrc if useBabelrc is not set', async () => {
+    const result = await runJest('../skip-babelrc', ['--no-cache', '-u']);
 
     expect(result.status).toBe(0);
   });

--- a/tests/__tests__/dynamic-imports.spec.ts
+++ b/tests/__tests__/dynamic-imports.spec.ts
@@ -1,14 +1,14 @@
 import runJest from '../__helpers__/runJest';
 
 describe('Dynamic imports', () => {
-  it('should work as expected', () => {
-    const result = runJest('../dynamic-imports', ['--no-cache']);
+  it('should work as expected', async () => {
+    const result = await runJest('../dynamic-imports', ['--no-cache']);
 
     expect(result.status).toBe(0);
   });
 
-  it('should work with synthetic default imports', () => {
-    const result = runJest('../dynamic-imports', [
+  it('should work with synthetic default imports', async () => {
+    const result = await runJest('../dynamic-imports', [
       '--no-cache',
       '--config',
       'jest.allowdefaultimports.json',

--- a/tests/__tests__/import.spec.ts
+++ b/tests/__tests__/import.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('import with relative and absolute paths', () => {
-  it('should run successfully', () => {
-    const result = runJest('../imports-test', ['--no-cache']);
+  it('should run successfully', async () => {
+    const result = await runJest('../imports-test', ['--no-cache']);
 
     const stderr = result.stderr.toString();
     const output = result.output.toString();

--- a/tests/__tests__/jest-hoist.spec.ts
+++ b/tests/__tests__/jest-hoist.spec.ts
@@ -1,16 +1,16 @@
 import runJest from '../__helpers__/runJest';
 
 describe('Jest.mock() calls', () => {
-  it('Should run all tests using jest.mock() underneath the imports succesfully.', () => {
-    const result = runJest('../hoist-test', ['--no-cache']);
+  it('Should run all tests using jest.mock() underneath the imports succesfully.', async () => {
+    const result = await runJest('../hoist-test', ['--no-cache']);
     const output = result.output.toString();
 
     expect(output).toContain('4 passed, 4 total');
     expect(result.status).toBe(0);
   });
 
-  it('Should retain proper line endings while hoisting', () => {
-    const result = runJest('../hoist-errors', ['--no-cache']);
+  it('Should retain proper line endings while hoisting', async () => {
+    const result = await runJest('../hoist-errors', ['--no-cache']);
 
     const stderr = result.stderr.toString();
 

--- a/tests/__tests__/long-path.spec.ts
+++ b/tests/__tests__/long-path.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('Long path', () => {
-  it('should work as expected', () => {
-    const result = runJest('../simple-long-path/', [
+  it('should work as expected', async () => {
+    const result = await runJest('../simple-long-path/', [
       '--no-cache',
       '--coverage',
     ]);

--- a/tests/__tests__/no-json-module-file-ext.spec.ts
+++ b/tests/__tests__/no-json-module-file-ext.spec.ts
@@ -3,8 +3,8 @@ import runJest from '../__helpers__/runJest';
 // Regression test for
 // https://github.com/kulshekhar/ts-jest/issues/367
 describe('no json in moduleFileExtensions', () => {
-  it('should run successfully', () => {
-    const result = runJest('../no-json-module-file-ext', ['--no-cache']);
+  it('should run successfully', async () => {
+    const result = await runJest('../no-json-module-file-ext', ['--no-cache']);
     expect(result.status).toBe(0);
   });
 });

--- a/tests/__tests__/synthetic-default-imports.spec.ts
+++ b/tests/__tests__/synthetic-default-imports.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('synthetic default imports', () => {
-  it('should not work when the compiler option is false', () => {
-    const result = runJest('../no-synthetic-default', ['--no-cache']);
+  it('should not work when the compiler option is false', async () => {
+    const result = await runJest('../no-synthetic-default', ['--no-cache']);
 
     const stderr = result.stderr.toString();
 
@@ -13,8 +13,8 @@ describe('synthetic default imports', () => {
     expect(stderr).toContain('module.test.ts:6');
   });
 
-  it('should work when the compiler option is true', () => {
-    const result = runJest('../synthetic-default', ['--no-cache']);
+  it('should work when the compiler option is true', async () => {
+    const result = await runJest('../synthetic-default', ['--no-cache']);
 
     expect(result.status).toBe(0);
   });

--- a/tests/__tests__/ts-compilation.spec.ts
+++ b/tests/__tests__/ts-compilation.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('TS Compilation', () => {
-  it('should compile typescript succesfully', () => {
-    const result = runJest('../simple', ['--no-cache']);
+  it('should compile typescript succesfully', async () => {
+    const result = await runJest('../simple', ['--no-cache']);
 
     const stderr = result.stderr.toString();
     const output = result.output.toString();

--- a/tests/__tests__/ts-coverage-async.spec.ts
+++ b/tests/__tests__/ts-coverage-async.spec.ts
@@ -1,8 +1,11 @@
 import runJest from '../__helpers__/runJest';
 
 describe('Typescript async coverage', () => {
-  it('Should generate the correct async coverage numbers', () => {
-    const result = runJest('../simple-async', ['--no-cache', '--coverage']);
+  it('Should generate the correct async coverage numbers', async () => {
+    const result = await runJest('../simple-async', [
+      '--no-cache',
+      '--coverage',
+    ]);
 
     const output = result.stdout.toString();
 

--- a/tests/__tests__/ts-coverage.spec.ts
+++ b/tests/__tests__/ts-coverage.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('Typescript coverage', () => {
-  it('Should generate the correct coverage numbers.', () => {
-    const result = runJest('../simple', ['--no-cache', '--coverage']);
+  it('Should generate the correct coverage numbers.', async () => {
+    const result = await runJest('../simple', ['--no-cache', '--coverage']);
 
     const output = result.stdout.toString();
 

--- a/tests/__tests__/ts-errors.spec.ts
+++ b/tests/__tests__/ts-errors.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('Typescript errors', () => {
-  it('should show the correct error locations in the typescript files', () => {
-    const result = runJest('../simple', ['--no-cache']);
+  it('should show the correct error locations in the typescript files', async () => {
+    const result = await runJest('../simple', ['--no-cache']);
 
     const stderr = result.stderr.toString();
 
@@ -12,7 +12,7 @@ describe('Typescript errors', () => {
   });
 
   it('Should show the correct error locations in async typescript files', async () => {
-    const result = runJest('../simple-async', ['--no-cache']);
+    const result = await runJest('../simple-async', ['--no-cache']);
 
     const stderr = result.stderr.toString();
 

--- a/tests/__tests__/ts-jest-module-interface.spec.ts
+++ b/tests/__tests__/ts-jest-module-interface.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('ts-jest module interface', () => {
-  it('should run successfully', () => {
-    const result = runJest('../ts-jest-module-interface', ['--no-cache']);
+  it('should run successfully', async () => {
+    const result = await runJest('../ts-jest-module-interface', ['--no-cache']);
     expect(result.status).toBe(0);
   });
 });

--- a/tests/__tests__/tsconfig-string.spec.ts
+++ b/tests/__tests__/tsconfig-string.spec.ts
@@ -1,8 +1,8 @@
 jest.mock('path');
 
-import { getTSConfig } from '../../dist/utils';
-import * as ts from 'typescript';
 import * as path from 'path';
+import * as ts from 'typescript';
+import { getTSConfig } from '../../dist/utils';
 
 describe('get ts config from string', () => {
   beforeEach(() => {

--- a/tests/__tests__/tsx-compilation.spec.ts
+++ b/tests/__tests__/tsx-compilation.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('TSX Compilation', () => {
-  it('Should compile a button succesfully', () => {
-    const result = runJest('../button', ['--no-cache', '-u']);
+  it('Should compile a button succesfully', async () => {
+    const result = await runJest('../button', ['--no-cache', '-u']);
 
     const stderr = result.stderr.toString();
     const output = result.output.toString();

--- a/tests/__tests__/tsx-errors.spec.ts
+++ b/tests/__tests__/tsx-errors.spec.ts
@@ -2,8 +2,8 @@ import runJest from '../__helpers__/runJest';
 import * as React from 'react';
 
 describe('TSX Errors', () => {
-  it('should show the correct error locations in the typescript files', () => {
-    const result = runJest('../button', ['--no-cache', '-u']);
+  it('should show the correct error locations in the typescript files', async () => {
+    const result = await runJest('../button', ['--no-cache', '-u']);
 
     const stderr = result.stderr.toString();
 

--- a/tests/__tests__/use-strict.spec.ts
+++ b/tests/__tests__/use-strict.spec.ts
@@ -1,8 +1,8 @@
 import runJest from '../__helpers__/runJest';
 
 describe('use strict', () => {
-  it('should show the error locations for "use strict" violations', () => {
-    const result = runJest('../use-strict', [
+  it('should show the error locations for "use strict" violations', async () => {
+    const result = await runJest('../use-strict', [
       '--no-cache',
       '-t',
       'Invalid Strict',
@@ -15,8 +15,12 @@ describe('use strict', () => {
     expect(stderr).toContain('Strict.test.ts:7:5');
   });
 
-  it('should work with "use strict"', () => {
-    const result = runJest('../use-strict', ['--no-cache', '-t', 'Strict1']);
+  it('should work with "use strict"', async () => {
+    const result = await runJest('../use-strict', [
+      '--no-cache',
+      '-t',
+      'Strict1',
+    ]);
 
     expect(result.status).toBe(0);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,9 +59,9 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jest@latest":
-  version "21.1.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-21.1.1.tgz#70008ecce439774a45c7d0b543d879ec58a1b332"
+"@types/jest@^22.1.0":
+  version "22.1.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.1.0.tgz#c1de03bbac66fac4cc741f7a69cb73bc01a1707c"
 
 "@types/node@*", "@types/node@latest":
   version "8.0.31"


### PR DESCRIPTION
I've noticed our tests run slow, and we're spawning the jest synchronously. If we do it async we can save a lot of time. This is a promised based implementation of cross-spawn that allows us to spawn the jest processes async.

Surprisingly enough, while this *should* be faster, it's approximately the same speed on my machine. I'm not sure whether we'll get any performance improvements when we keep spawning processes or not. I'm not sure whether this PR should be accepted, but I figured I'd give it a shot. The code is a little more complex for no perceivable (current) gain