### PR TITLE
feat: add option to run TypeScript diagnostics

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,11 +3,13 @@
 #
 #   Name/Organization <email address>
 
+Alan Agius <alan.agius4@gmail.com>
 Alex Jover Morales <alexjovermorales@gmail.com>
 Andreas Krummsdorf <andreas.krummsdorf@doksafe.de>
 Anonymous <goodforonefare@gmail.com>
 Bartosz Gościński <bargosc@gmail.com>
 Blake Embrey <hello@blakeembrey.com>
+Bnaya Peretz <me@bnaya.net>
 Brian Ruddy <briancruddy@gmail.com>
 Chong Guo <cguo@azendless.com>
 Chris Sauve <chrismsauve@gmail.com>
@@ -46,5 +48,6 @@ Rikki Tooley <rikki.tooley@travellocal.com>
 Simen Bekkhus <sbekkhus91@gmail.com>
 Thomas Fontaine <thomas.fontaine@me.com>
 Tom Crockett <tomcrockett@tuplehealth.com>
+Tony Valderrama <tony.valderrama@outlook.com>
 Trivikram Kamat <trivikr.dev@gmail.com>
 Umidbek Karimov <uma.karimov@gmail.com>

--- a/README.md
+++ b/README.md
@@ -329,9 +329,19 @@ By default Jest ignores everything in `node_modules`. This setting prevents Jest
 }
 ```
 ### TS compiler && error reporting
-- ts-jest only returns syntax errors from [tsc](https://github.com/Microsoft/TypeScript/issues/4864#issuecomment-141567247)
-- Non syntactic errors do not show up in [jest](https://github.com/facebook/jest/issues/2168)
-- If you only want to run jest if tsc does not output any errors, a workaround is `tsc --noEmit -p . && jest`
+If you want to enable Syntactic & Semantic TypeScript error reporting you can enable this through `enableTsDiagnostics` flag;
+
+```json
+{
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "enableTsDiagnostics": true
+      }
+    }
+  }
+}
+```
 
 ### Known Limitations for hoisting
 If the `jest.mock()` calls is placed after actual code, (e.g. after functions or classes) and `skipBabel` is not set,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "22.0.2",
+  "version": "22.0.3",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",
@@ -31,6 +31,7 @@
   ],
   "author": "Kulshekhar Kabra <kulshekhar@users.noreply.github.com> (https://github.com/kulshekhar)",
   "contributors": [
+    "Alan Agius <alan.agius4@gmail.com> (https://github.com/alan-agius4)",
     "Bnaya Peretz <me@bnaya.net> (https://github.com/Bnaya)",
     "Brian Ruddy <briancruddy@gmail.com> (https://github.com/bcruddy)",
     "Emil Persson <emil.n.persson@gmail.com> (https://github.com/emilniklas)",

--- a/package.json
+++ b/package.json
@@ -30,16 +30,6 @@
     "testing"
   ],
   "author": "Kulshekhar Kabra <kulshekhar@users.noreply.github.com> (https://github.com/kulshekhar)",
-  "contributors": [
-    "Alan Agius <alan.agius4@gmail.com> (https://github.com/alan-agius4)",
-    "Bnaya Peretz <me@bnaya.net> (https://github.com/Bnaya)",
-    "Brian Ruddy <briancruddy@gmail.com> (https://github.com/bcruddy)",
-    "Emil Persson <emil.n.persson@gmail.com> (https://github.com/emilniklas)",
-    "Gustav Wengel <gustavwengel@gmail.com>(https://github.com/GeeWee)",
-    "Ihor Chulinda <ichulinda@gmail.com> (https://github.com/Igmat)",
-    "OJ Kwon <kwon.ohjoong@gmail.com> (https://github.com/kwonoj)",
-    "Tony Valderrama <tony.valderrama@outlook.com> (https://github.com/tvald)"
-  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/kulshekhar/ts-jest/issues"

--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -74,4 +74,5 @@ export interface TsJestConfig {
   babelConfig?: BabelTransformOpts;
   tsConfigFile?: string;
   enableInternalCache?: boolean;
+  enableTsDiagnostics?: boolean;
 }

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -7,6 +7,7 @@ import {
   cacheFile,
   getTSConfig,
   getTSJestConfig,
+  runTsDiagnostics,
   injectSourcemapHook,
 } from './utils';
 
@@ -41,13 +42,17 @@ export function process(
     return src;
   }
 
+  const tsJestConfig = getTSJestConfig(jestConfig.globals);
+  logOnce('tsJestConfig: ', tsJestConfig);
+
+  if (tsJestConfig.enableTsDiagnostics) {
+    runTsDiagnostics(filePath, compilerOptions);
+  }
+
   const tsTranspiled = tsc.transpileModule(src, {
     compilerOptions,
     fileName: filePath,
   });
-
-  const tsJestConfig = getTSJestConfig(jestConfig.globals);
-  logOnce('tsJestConfig: ', tsJestConfig);
 
   const postHook = getPostProcessHook(
     compilerOptions,

--- a/tests/__tests__/ts-diagnostics.spec.ts
+++ b/tests/__tests__/ts-diagnostics.spec.ts
@@ -1,0 +1,13 @@
+import runJest from '../__helpers__/runJest';
+
+describe('TypeScript Diagnostics errors', () => {
+  it('should show the correct error locations in the typescript files', () => {
+    const result = runJest('../ts-diagnostics', ['--no-cache']);
+    expect(result.stderr).toContain(
+      `Hello.ts (2,10): Property 'push' does not exist on type`,
+    );
+    expect(result.stderr).toContain(
+      `Hello.ts (13,10): Property 'unexcuted' does not exist on type`,
+    );
+  });
+});

--- a/tests/ts-diagnostics/Hello.ts
+++ b/tests/ts-diagnostics/Hello.ts
@@ -1,0 +1,17 @@
+export class Hello {
+  x = ''.push();
+
+  constructor() {
+    const greeting = `
+      this
+      is
+      a
+      multiline
+      greeting
+    `;
+
+    this.unexcuted(() => {});
+
+    throw new Error('Hello error!');
+  }
+}

--- a/tests/ts-diagnostics/__tests__/Hello.test.ts
+++ b/tests/ts-diagnostics/__tests__/Hello.test.ts
@@ -1,0 +1,7 @@
+import { Hello } from '../Hello';
+
+describe('Hello Class', () => {
+  it('should throw an error', () => {
+    const hello = new Hello();
+  });
+});

--- a/tests/ts-diagnostics/package.json
+++ b/tests/ts-diagnostics/package.json
@@ -1,0 +1,24 @@
+{
+	"jest": {
+		"transform": {
+			"^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+		},
+		"moduleDirectories": [
+			"node_modules",
+			"src"
+		],
+		"testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js",
+			"jsx",
+			"json"
+		],
+		"globals": {
+			"ts-jest": {
+				"enableTsDiagnostics": true
+			}
+		}
+	}
+}

--- a/tests/ts-diagnostics/tsconfig.json
+++ b/tests/ts-diagnostics/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": false
+  }
+}


### PR DESCRIPTION
By creating a `program` we are enabled to run diagnostics on typescipt files in order to emit semantic errors. For the time being I only used one of the many methods this one is `getPreEmitDiagnostics`

This enables syntactic & semantic TypeScript error reporting