### PR TITLE
Include useBabelrc in react-native example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Chris Sauve <chrismsauve@gmail.com>
 Christian Linne <ShadowVampire@web.de>
 Christian Rackerseder <git@echooff.de>
 Daniel Perez Alvarez <unindented@gmail.com>
+Danilo Bürger <info@danilobuerger.de>
 David Schkalee <david.schkalee@magicline.de>
 David Sheldrick <djsheldrick@gmail.com>
 Emil Persson <emil.n.persson@gmail.com>

--- a/README.md
+++ b/README.md
@@ -265,7 +265,12 @@ Fully completed jest section should look like this:
       "jsx",
       "json",
       "node"
-    ]
+    ],
+    "globals": {
+      "ts-jest": {
+        "useBabelrc": true
+      }
+    }
   }
 ```
 If only testing typescript files then remove the `js` option in the testRegex.


### PR DESCRIPTION
As far as I know `useBabelrc` has to be set to true so that ts-jest uses the `.babelrc`. Since the react-native section declares a `.babelrc` it should also show that the option needs to be enabled.