### PR TITLE
support for jest multi-projects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Jim Cummins <jimthedev@gmail.com>
 Joscha Feth <joscha@feth.com>
 Junle Li <lijunle@gmail.com>
 Justin Bay <jwbay@users.noreply.github.com>
+Kamijin Fanta <kamijin@live.jp>
 Kulshekhar Kabra <kulshekhar@users.noreply.github.com>
 Kyle Roach <kroach.work@gmail.com>
 Marshall Bowers <elliott.codes@gmail.com>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "22.0.3",
+  "version": "22.0.4",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -21,6 +21,7 @@ export function process(
   // https://github.com/kulshekhar/ts-jest/issues/201#issuecomment-300572902
   const compilerOptions = getTSConfig(
     jestConfig.globals,
+    jestConfig.rootDir,
     transformOptions.instrument,
   );
 
@@ -84,7 +85,11 @@ export function getCacheKey(
 ): string {
   const jestConfig: JestConfig = JSON.parse(jestConfigStr);
 
-  const tsConfig = getTSConfig(jestConfig.globals, transformOptions.instrument);
+  const tsConfig = getTSConfig(
+    jestConfig.globals,
+    jestConfig.rootDir,
+    transformOptions.instrument,
+  );
 
   return crypto
     .createHash('md5')

--- a/src/transpile-if-ts.ts
+++ b/src/transpile-if-ts.ts
@@ -1,11 +1,17 @@
 import * as tsc from 'typescript';
 import { getTSConfig, mockGlobalTSConfigSchema } from './utils';
 
-export function transpileIfTypescript(path, contents, config?) {
+export function transpileIfTypescript(
+  path,
+  contents,
+  config?,
+  rootDir: string = '',
+) {
   if (path && (path.endsWith('.tsx') || path.endsWith('.ts'))) {
     let transpiled = tsc.transpileModule(contents, {
       compilerOptions: getTSConfig(
         config || mockGlobalTSConfigSchema(global),
+        rootDir,
         true,
       ),
       fileName: path,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,8 +14,8 @@ function formatTscParserErrors(errors: tsc.Diagnostic[]) {
   return errors.map(s => JSON.stringify(s, null, 4)).join('\n');
 }
 
-function readCompilerOptions(configPath: string) {
-  configPath = path.resolve(configPath);
+function readCompilerOptions(configPath: string, rootDir: string) {
+  configPath = path.resolve(rootDir, configPath);
 
   // First step: Let tsc pick up the config.
   const loaded = tsc.readConfigFile(configPath, file => {
@@ -118,7 +118,11 @@ export function mockGlobalTSConfigSchema(globals: any) {
 const tsConfigCache: { [key: string]: any } = {};
 // TODO: Perhaps rename collectCoverage to here, as it seems to be the official jest name now:
 // https://github.com/facebook/jest/issues/3524
-export function getTSConfig(globals, collectCoverage: boolean = false) {
+export function getTSConfig(
+  globals,
+  rootDir: string = '',
+  collectCoverage: boolean = false,
+) {
   let configPath = getTSConfigPathFromConfig(globals);
   logOnce(`Reading tsconfig file from path ${configPath}`);
   const skipBabel = getTSJestConfig(globals).skipBabel;
@@ -135,7 +139,7 @@ export function getTSConfig(globals, collectCoverage: boolean = false) {
     return tsConfigCache[tsConfigCacheKey];
   }
 
-  const config = readCompilerOptions(configPath);
+  const config = readCompilerOptions(configPath, rootDir);
   logOnce('Original typescript config before modifications: ', config);
 
   // ts-jest will map lines numbers properly if inlineSourceMap and

--- a/tests/__tests__/jest-projects.spec.ts
+++ b/tests/__tests__/jest-projects.spec.ts
@@ -1,0 +1,10 @@
+import runJest from '../__helpers__/runJest';
+
+describe('Jest Projects', () => {
+  it('should compile typescript succesfully', () => {
+    const result = runJest('../jest-projects', ['--no-cache']);
+    const stderr = result.stderr;
+    expect(result.status).toEqual(0);
+    expect(stderr).toContain('1 passed, 1 total');
+  });
+});

--- a/tests/jest-projects/package.json
+++ b/tests/jest-projects/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "projects": ["<rootDir>", "<rootDir>/packages/*"]
+  }
+}

--- a/tests/jest-projects/packages/child/Hello.ts
+++ b/tests/jest-projects/packages/child/Hello.ts
@@ -1,0 +1,3 @@
+export const Hello = {
+  filed: 'Hello',
+};

--- a/tests/jest-projects/packages/child/__test__/index.test.ts
+++ b/tests/jest-projects/packages/child/__test__/index.test.ts
@@ -1,0 +1,5 @@
+import { Hello } from '../Hello';
+
+it('jest packages', () => {
+  expect(Hello.filed).toEqual('Hello');
+});

--- a/tests/jest-projects/packages/child/custom-tsconfig.json
+++ b/tests/jest-projects/packages/child/custom-tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": false
+  }
+}

--- a/tests/jest-projects/packages/child/package.json
+++ b/tests/jest-projects/packages/child/package.json
@@ -1,0 +1,22 @@
+{
+  "jest": {
+    "transform": {
+      ".(ts|tsx)": "ts-jest"
+    },
+    "moduleDirectories": [
+      "node_modules"
+    ],
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json"
+    ],
+    "globals": {
+      "ts-jest": {
+        "tsConfigFile": "custom-tsconfig.json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
fix #422

in order to support jest multi-project, need to reference `jestConfig.rootDir`.
Find tsconfig based on rootDir.

---

- multi-project detail
  - news: https://facebook.github.io/jest/blog/2017/05/06/jest-20-delightful-testing-multi-project-runner.html
  - options: https://facebook.github.io/jest/docs/en/configuration.html#projects-array-string-projectconfig
