### PR TITLE
Update types for FullJestConfig to be in sync with types in Jest

### DIFF
--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -41,7 +41,7 @@ export interface FullJestConfig {
   coveragePathIgnorePatterns: string[];
   cwd: Path;
   detectLeaks: boolean;
-  displayName: string;
+  displayName: string | null;
   forceCoverageMatch: Glob[];
   globals: ConfigGlobals;
   haste: HasteConfig;
@@ -60,7 +60,7 @@ export interface FullJestConfig {
   roots: Path[];
   runner: string;
   setupFiles: Path[];
-  setupTestFrameworkScriptFile: Path;
+  setupTestFrameworkScriptFile: Path | null;
   skipNodeResolution: boolean;
   snapshotSerializers: Path[];
   testEnvironment: string;

--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -39,6 +39,10 @@ export interface FullJestConfig {
   cacheDirectory: Path;
   clearMocks: boolean;
   coveragePathIgnorePatterns: string[];
+  cwd: Path;
+  detectLeaks: boolean;
+  displayName: string;
+  forceCoverageMatch: Glob[];
   globals: ConfigGlobals;
   haste: HasteConfig;
   moduleDirectories: string[];
@@ -51,12 +55,17 @@ export interface FullJestConfig {
   resetMocks: boolean;
   resetModules: boolean;
   resolver: Path | null;
+  restoreMocks: boolean;
   rootDir: Path;
   roots: Path[];
+  runner: string;
   setupFiles: Path[];
   setupTestFrameworkScriptFile: Path;
+  skipNodeResolution: boolean;
   snapshotSerializers: Path[];
   testEnvironment: string;
+  testEnvironmentOptions: object;
+  testLocationInResults: boolean;
   testMatch: Glob[];
   testPathIgnorePatterns: string[];
   testRegex: string;
@@ -65,6 +74,7 @@ export interface FullJestConfig {
   timers: 'real' | 'fake';
   transform: Array<[string, Path]>;
   transformIgnorePatterns: Glob[];
+  watchPathIgnorePatterns: string[];
   unmockedModulePathPatterns: string[] | null;
 }
 


### PR DESCRIPTION
I recognize we have some missing types in FullJestConfig. This PR is to keep it in sync with types definition in Jest at https://github.com/facebook/jest/blob/master/types/Config.js