### PR TITLE
fix for decorator coverage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Eric Anderson <e@ericlanderson.com>
 Felipe Matos <felipems@yahoo.com.br>
 Forbes Lindesay <forbes@lindesay.co.uk>
 Gino Zhang <whitetrefoil@gmail.com>
+Gregor Stamac <1668205+gstamac@users.noreply.github.com>
 Gustav Wengel <gustavwengel@gmail.com>
 Henry Zektser <japhar81@gmail.com>
 Ihor Chulinda <ichulinda@gmail.com>

--- a/README.md
+++ b/README.md
@@ -233,6 +233,21 @@ If you want to enable Syntactic & Semantic TypeScript error reporting you can en
 }
 ```
 
+### Ignore coverage on decorators
+If you want to ignore coverage on decorators you can enable this through `ignoreCoverageForAllDecorators` flag;
+
+```json
+{
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "ignoreCoverageForAllDecorators": true
+      }
+    }
+  }
+}
+```
+
 ## Use cases
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -234,13 +234,14 @@ If you want to enable Syntactic & Semantic TypeScript error reporting you can en
 ```
 
 ### Ignore coverage on decorators
-If you want to ignore coverage on decorators you can enable this through `ignoreCoverageForAllDecorators` flag;
+If you want to ignore coverage on decorators you can enable this through `ignoreCoverageForDecorators` and `ignoreCoverageForAllDecorators` flags. If you enable the first option you have to add the `/* istanbul ignore decorator */` comment after the decorator. If you choose the second option all decorators will be ignored.
 
 ```json
 {
   "jest": {
     "globals": {
       "ts-jest": {
+        "ignoreCoverageForDecorators": true,
         "ignoreCoverageForAllDecorators": true
       }
     }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ ts-jest is a TypeScript preprocessor with source map support for Jest that lets 
   - [Using `.babelrc`](#using-babelrc)
   - [Using a custom Babel config](#using-a-custom-babel-config)
   - [TS compiler & error reporting](#ts-compiler--error-reporting)
+  - [Ignore coverage on decorators](#ignore-coverage-on-decorators)
 - [Use cases](#use-cases)
   - [React Native](#react-native)
 - [Angular 2](#angular-2)
@@ -234,6 +235,9 @@ If you want to enable Syntactic & Semantic TypeScript error reporting you can en
 ```
 
 ### Ignore coverage on decorators
+
+**Note:** This is an experimental feature, comes with no guarantees and could be removed if it causes more problems than it solves
+
 If you want to ignore coverage on decorators you can enable this through `ignoreCoverageForDecorators` and `ignoreCoverageForAllDecorators` flags. If you enable the first option you have to add the `/* istanbul ignore decorator */` comment after the decorator. If you choose the second option all decorators will be ignored.
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "22.4.3",
+  "version": "22.4.4",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "22.4.2",
+  "version": "22.4.3",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -86,4 +86,5 @@ export interface TsJestConfig {
   enableInternalCache?: boolean;
   enableTsDiagnostics?: boolean;
   disableSourceMapSupport?: boolean;
+  ignoreCoverageForAllDecorators?: boolean;
 }

--- a/src/jest-types.ts
+++ b/src/jest-types.ts
@@ -86,5 +86,6 @@ export interface TsJestConfig {
   enableInternalCache?: boolean;
   enableTsDiagnostics?: boolean;
   disableSourceMapSupport?: boolean;
+  ignoreCoverageForDecorators?: boolean;
   ignoreCoverageForAllDecorators?: boolean;
 }

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -55,10 +55,18 @@ export function process(
     fileName: filePath,
   });
 
-  var tsTranspiledText = tsTranspiled.outputText.replace(
-    /(__decorate\(\[\r?\n[^\n\r]*)\/\*\s*istanbul\s*ignore\s*decorate(.*)\*\//g,
-    '/* istanbul ignore next$2*/$1',
-  );
+  let tsTranspiledText = tsTranspiled.outputText;
+  if (tsJestConfig.ignoreCoverageForAllDecorators === true) {
+    tsTranspiledText = tsTranspiledText.replace(
+      /__decorate/g,
+      '/* istanbul ignore next */__decorate',
+    );
+  } else {
+    tsTranspiledText = tsTranspiledText.replace(
+      /(__decorate\(\[\r?\n[^\n\r]*)\/\*\s*istanbul\s*ignore\s*decorate(.*)\*\//g,
+      '/* istanbul ignore next$2*/$1',
+    );
+  }
 
   const postHook = getPostProcessHook(
     compilerOptions,

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -55,6 +55,11 @@ export function process(
     fileName: filePath,
   });
 
+  var tsTranspiledText = tsTranspiled.outputText.replace(
+    /(__decorate\(\[\r?\n[^\n\r]*)\/\*\s*istanbul\s*ignore\s*decorate(.*)\*\//g,
+    '/* istanbul ignore next$2*/$1',
+  );
+
   const postHook = getPostProcessHook(
     compilerOptions,
     jestConfig,
@@ -62,7 +67,7 @@ export function process(
   );
 
   const outputText = postHook(
-    tsTranspiled.outputText,
+    tsTranspiledText,
     filePath,
     jestConfig,
     transformOptions,
@@ -71,7 +76,7 @@ export function process(
   const modified =
     tsJestConfig.disableSourceMapSupport === true
       ? outputText
-      : injectSourcemapHook(filePath, tsTranspiled.outputText, outputText);
+      : injectSourcemapHook(filePath, tsTranspiledText, outputText);
 
   flushLogs();
 

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -61,9 +61,10 @@ export function process(
       /__decorate/g,
       '/* istanbul ignore next */__decorate',
     );
-  } else {
+  }
+  if (tsJestConfig.ignoreCoverageForDecorators === true) {
     tsTranspiledText = tsTranspiledText.replace(
-      /(__decorate\(\[\r?\n[^\n\r]*)\/\*\s*istanbul\s*ignore\s*decorate(.*)\*\//g,
+      /(__decorate\(\[\r?\n[^\n\r]*)\/\*\s*istanbul\s*ignore\s*decorator(.*)\*\//g,
       '/* istanbul ignore next$2*/$1',
     );
   }


### PR DESCRIPTION
As discussed in #454 there is a problem with coverage on decorators when emitDecoratorMetadata is enabled. This is kind of a hack to fix this until something better is implemented in tsc/jest/istanbul. There are two options. First you can set a configuration option ignoreCoverageForAllDecorators to true and it will ignore all decorators (and possible something else). The second option is to add /* istanbul ignore decorate */ right after the decorator like this
`@Decorator /* istanbul ignore decorate */`