### PR TITLE
Add 'source-map-support' to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "jest-config": "^22.4.3",
     "lodash": "^4.17.10",
     "pkg-dir": "^2.0.0",
+    "source-map-support": "^0.5.5",
     "yargs": "^11.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -974,6 +974,10 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-from@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -4274,6 +4278,13 @@ source-map-support@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
   dependencies:
+    source-map "^0.6.0"
+
+source-map-support@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.5.tgz#0d4af9e00493e855402e8ec36ebed2d266fceb90"
+  dependencies:
+    buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map-url@^0.4.0:


### PR DESCRIPTION
As mentioned in #506, 'source-map-support' is required in [install.ts](https://github.com/kulshekhar/ts-jest/blob/970d4a83926ba96eae7b9a5ac67b5f0d636066c3/src/install.ts#L1), but does not explicitly appear in package.json.