### PR TITLE
Make babel-core a peerDependency. Support Babel 7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     ]
   },
   "dependencies": {
-    "babel-core": "^6.26.3",
     "babel-plugin-istanbul": "^4.1.6",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "babel-preset-jest": "^22.4.3",
@@ -74,17 +73,19 @@
     "yargs": "^11.0.0"
   },
   "peerDependencies": {
+    "babel-core": "^6.26.3 || ^7.0.0-0",
     "jest": "^22.4.0 || ^22.5.0-alpha.1 || ^23.0.0-alpha.1",
     "typescript": "2.x"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.108",
     "@types/babel-core": "latest",
     "@types/es6-shim": "0.31.36",
     "@types/fs-extra": "5.0.2",
     "@types/jest": "22.2.3",
+    "@types/lodash": "^4.14.108",
     "@types/node": "10.0.4",
     "@types/react": "16.3.13",
+    "babel-core": "^6.26.3",
     "babel-preset-env": "^1.6.0",
     "cross-spawn": "latest",
     "cross-spawn-with-kill": "latest",
@@ -96,7 +97,7 @@
     "react": "16.3.2",
     "react-test-renderer": "16.3.2",
     "reflect-metadata": "^0.1.12",
-    "rimraf": "latest",
+    "rimraf": "^2.6.2",
     "ts-jest": "22.4.4",
     "tslint": "^5.10.0",
     "typescript": "^2.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,7 +4092,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@latest:
+rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
Fixes #495.

As of now babel is included within this project, which makes it hard for users to define the babel version they want to use. This fix follows the same principle as [`babel-jest`](https://github.com/facebook/jest/blob/master/packages/babel-jest/package.json#L15..L20) and other babel "plugins" (e.g. [`gulp-babel`](https://github.com/babel/gulp-babel/blob/master/package.json#L46..L48)) by making it a peerDependency.

Doing so allows us to use the new Babel 7, for example, which is now used in Next.js 6. Too use with Babel 7, users simply have to install `babel-core: "7.0.0-bridge.0"` alongside `ts-jest`. E.g. https://github.com/zeit/next.js/pull/4278/files.

As a side note, I'm also not sure `jest` needs to be a peerDependency, but didn't want to touch it without confirming... Happy yo clarify anything.

Re: https://github.com/zeit/next.js/issues/4227