### PR TITLE
Add realpath to language host

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "22.4.5",
+  "version": "22.4.6",
   "main": "index.js",
   "types": "./dist/index.d.ts",
   "description": "A preprocessor with sourcemap support to help use Typescript with Jest",

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -64,6 +64,7 @@ function transpileViaLanguageServer(
     fileExists: ts.sys.fileExists,
     readFile: ts.sys.readFile,
     readDirectory: ts.sys.readDirectory,
+    realpath: ts.sys.realpath,
     getDirectories: ts.sys.getDirectories,
     directoryExists: ts.sys.directoryExists,
   };


### PR DESCRIPTION
It is necessary to supply realpath to language host so that typescript could follow symlinks as it supposed to be.