### PR TITLE
Fix problem with tsconfig from node_modules (Issue #536)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ function readCompilerOptions(configPath: string, rootDir: string) {
   }
 
   // Second step: Parse the config, resolving all potential references.
-  const basePath = path.dirname(configPath); // equal to "getDirectoryPath" from ts, at least in our case.
+  const basePath = path.resolve(rootDir);
   const parsedConfig = tsc.parseJsonConfigFileContent(
     loaded.config,
     tsc.sys,

--- a/tests/__tests__/use-config-from-node-modules.spec.ts
+++ b/tests/__tests__/use-config-from-node-modules.spec.ts
@@ -9,7 +9,7 @@ describe('Use config from node_modules', () => {
     const targetDir = path.resolve(testDir, 'node_modules', 'common-tsconfig');
     const targetConfigPath = path.resolve(targetDir, 'tsconfig.json');
     fs.ensureDirSync(targetDir);
-    fs.copyFileSync(configPath, targetConfigPath);
+    fs.copySync(configPath, targetConfigPath);
 
     const result = runJest('../use-config-from-node-modules', ['--no-cache']);
     const stderr = result.stderr;

--- a/tests/__tests__/use-config-from-node-modules.spec.ts
+++ b/tests/__tests__/use-config-from-node-modules.spec.ts
@@ -1,0 +1,22 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import runJest from '../__helpers__/runJest';
+
+describe('Use config from node_modules', () => {
+  it('Should run all tests', () => {
+    const testDir = path.resolve(__dirname, '../use-config-from-node-modules');
+    const configPath = path.resolve(testDir, 'tsconfig.json');
+    const targetDir = path.resolve(testDir, 'node_modules', 'common-tsconfig');
+    const targetConfigPath = path.resolve(targetDir, 'tsconfig.json');
+    fs.ensureDirSync(targetDir);
+    fs.copyFileSync(configPath, targetConfigPath);
+
+    const result = runJest('../use-config-from-node-modules', ['--no-cache']);
+    const stderr = result.stderr;
+
+    expect(result.status).toBe(1);
+    expect(stderr).toContain('1 failed, 1 total');
+    expect(stderr).toContain('Hello Class');
+    expect(stderr).toContain('should throw an error on line 18');
+  });
+});

--- a/tests/use-config-from-node-modules/Hello.ts
+++ b/tests/use-config-from-node-modules/Hello.ts
@@ -1,0 +1,28 @@
+interface FooInterface {
+  foo: string;
+  bar: number; //This interface should be stripped and the line numbers should still fit.
+}
+
+export class Hello {
+  constructor() {
+    const greeting = `
+      this
+      is
+      a
+      multiline
+      greeting
+    `;
+
+    this.unexcuted(() => {});
+
+    throw new Error('Hello error!');
+  }
+
+  public unexcuted(action: () => void = () => {}): void {
+    if (action) {
+      action();
+    } else {
+      console.log('unexcuted');
+    }
+  }
+}

--- a/tests/use-config-from-node-modules/__tests__/Hello.test.ts
+++ b/tests/use-config-from-node-modules/__tests__/Hello.test.ts
@@ -1,0 +1,9 @@
+declare var jest, describe, it, expect;
+
+import { Hello } from '../Hello';
+
+describe('Hello Class', () => {
+  it('should throw an error on line 18', () => {
+    const hello = new Hello();
+  });
+});

--- a/tests/use-config-from-node-modules/package.json
+++ b/tests/use-config-from-node-modules/package.json
@@ -1,0 +1,20 @@
+{
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "tsConfigFile": "./node_modules/common-tsconfig/tsconfig.json"
+      }
+    },
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json"
+    ]
+  }
+}

--- a/tests/use-config-from-node-modules/tsconfig.json
+++ b/tests/use-config-from-node-modules/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": false,
+    "jsx": "react",
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
  * Use Jest rootDir in parseJsonConfigFileContent as basePath
  * Add test for config from node_modules

Fix issue https://github.com/kulshekhar/ts-jest/issues/536
