### PR TITLE
WIP ignoreDecorators via ts transformer

### DIFF
--- a/src/ts-transformer-istanbul-ignore-decorators.ts
+++ b/src/ts-transformer-istanbul-ignore-decorators.ts
@@ -13,7 +13,7 @@
 
 import * as ts from 'typescript';
 
-function commentRangeText(sourceText: string, range: ts.CommentRange) {
+function commentRangeText(sourceText: string, range: ts.CommentRange): string {
   return sourceText.slice(range.pos, range.end);
 }
 
@@ -30,12 +30,12 @@ function findTrailingComment(
 
 const reIstanbulIgnoreDecorator = /^\/\*\s*istanbul\s*ignore\s*decorator.*\*\/$/;
 
-export function istanbulIgnoreTransformerFactory(context: ts.TransformationContext) {
+export function istanbulIgnoreTransformerFactory(context: ts.TransformationContext): ts.Transformer<ts.SourceFile> {
   const ignoreAllDecorators = false;
   const ignoreAnnotatedDecorators = true;
   return transformer;
 
-  function transformer(file: ts.SourceFile) {
+  function transformer(file: ts.SourceFile): ts.SourceFile {
     if (!ignoreAllDecorators && !ignoreAnnotatedDecorators) { return file; }
 
     const sourceText = file.text;
@@ -43,7 +43,7 @@ export function istanbulIgnoreTransformerFactory(context: ts.TransformationConte
     return ts.visitEachChild(file, (childNode) => visitNode(childNode, context), context);
 
     /** Visit each node to see if it's a decorator invocation */
-    function visitNode(node: ts.Node, ctx: ts.TransformationContext) {
+    function visitNode(node: ts.Node, ctx: ts.TransformationContext): ts.Node {
       if (node.kind === ts.SyntaxKind.Decorator) {
         if (
           ignoreAllDecorators ||

--- a/src/ts-transformer-istanbul-ignore-decorators.ts
+++ b/src/ts-transformer-istanbul-ignore-decorators.ts
@@ -1,0 +1,109 @@
+/**
+ *
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * Ported from https://github.com/facebook/jest/blob/
+ * 45db59de5f863a7d5007c7bca925a0fc0b497440/packages/babel-plugin-jest-hoist/src/index.js
+ */
+
+import * as ts from 'typescript';
+
+function commentRangeText(sourceText: string, range: ts.CommentRange) {
+  return sourceText.slice(range.pos, range.end);
+}
+
+function findTrailingComment(
+  sourceText: string,
+  node: ts.Node,
+  matcher: (text: string, kind: ts.CommentKind) => boolean,
+): string | undefined {
+  return ts.forEachTrailingCommentRange(sourceText, node.getEnd(), (pos, end, kind) => {
+    const text = sourceText.slice(pos, end);
+    return matcher(text, kind) ? text : undefined;
+  });
+}
+
+const reIstanbulIgnoreDecorator = /^\/\*\s*istanbul\s*ignore\s*decorator.*\*\/$/;
+
+export function istanbulIgnoreTransformerFactory(context: ts.TransformationContext) {
+  const ignoreAllDecorators = false;
+  const ignoreAnnotatedDecorators = true;
+  return transformer;
+
+  function transformer(file: ts.SourceFile) {
+    if (!ignoreAllDecorators && !ignoreAnnotatedDecorators) { return file; }
+
+    const sourceText = file.text;
+
+    return ts.visitEachChild(file, (childNode) => visitNode(childNode, context), context);
+
+    /** Visit each node to see if it's a decorator invocation */
+    function visitNode(node: ts.Node, ctx: ts.TransformationContext) {
+      if (node.kind === ts.SyntaxKind.Decorator) {
+        if (
+          ignoreAllDecorators ||
+          findTrailingComment(sourceText, node, (comment) => reIstanbulIgnoreDecorator.test(comment))
+        ) {
+          /*
+           * Generate this expression to replace the decorator's expression:
+           * (
+           *   function decoratorWrapperFactory(decorator) {
+           *     return function decoratorWrapper() {
+           *       /* istanbul ignore next * /
+           *       return decorator.apply(this, arguments);
+           *     }
+           *   }( < original decorator expression goes here > )
+           * )
+           */
+
+          // This decorator must be transformed
+          const originalDecorator = node as ts.Decorator;
+
+          // return decorator.apply(this, arguments)
+          const returnStatement = ts.createReturn(
+            ts.createCall(
+              ts.createPropertyAccess(ts.createIdentifier('decorator'), 'apply'),
+              undefined,
+              [ts.createThis(), ts.createIdentifier('arguments')],
+            ),
+          );
+          // TODO MOVE THIS TO FACTORY INVOCATION EXPRESSION??
+          ts.addSyntheticLeadingComment(
+            returnStatement,
+            ts.SyntaxKind.MultiLineCommentTrivia,
+            'istanbul ignore next',
+          );
+          const wrappedDecoratorExpression = ts.createCall(
+            ts.createFunctionExpression(
+              undefined, undefined, 'decoratorWrapperFactory', undefined,
+              [ts.createParameter(undefined, undefined, undefined, 'decorator')],
+              undefined,
+              ts.createBlock(
+                [
+                  ts.createReturn(
+                    ts.createFunctionExpression(
+                      undefined, undefined, 'decoratorWrapper', undefined, undefined, undefined,
+                      ts.createBlock([returnStatement]),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            undefined,
+            [originalDecorator.expression],
+          );
+
+          const replacementDecorator = ts.getMutableClone(originalDecorator);
+          replacementDecorator.expression = wrappedDecoratorExpression;
+          return ts.visitEachChild(replacementDecorator, (childNode) => visitNode(childNode, context), context);
+        }
+      }
+      return ts.visitEachChild(node, (childNode) => visitNode(childNode, context), context);
+    }
+  }
+}

--- a/src/ts-transformer-jest-hoist.ts
+++ b/src/ts-transformer-jest-hoist.ts
@@ -1,0 +1,218 @@
+/**
+ *
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * Ported from https://github.com/facebook/jest/blob/
+ * 45db59de5f863a7d5007c7bca925a0fc0b497440/packages/babel-plugin-jest-hoist/src/index.js
+ */
+
+import * as ts from 'typescript';
+
+function invariant(condition, message) {
+  if (!condition) {
+    throw new Error('ts-transformer-jest-hoist: ' + message);
+  }
+}
+
+// We allow `jest`, `expect`, `require`, all default Node.js globals and all
+// ES2015 built-ins to be used inside of a `jest.mock` factory.
+// We also allow variables prefixed with `mock` as an escape-hatch.
+const WHITELISTED_IDENTIFIERS = {
+  Array: true,
+  ArrayBuffer: true,
+  Boolean: true,
+  DataView: true,
+  Date: true,
+  Error: true,
+  EvalError: true,
+  Float32Array: true,
+  Float64Array: true,
+  Function: true,
+  Generator: true,
+  GeneratorFunction: true,
+  Infinity: true,
+  Int16Array: true,
+  Int32Array: true,
+  Int8Array: true,
+  InternalError: true,
+  Intl: true,
+  JSON: true,
+  Map: true,
+  Math: true,
+  NaN: true,
+  Number: true,
+  Object: true,
+  Promise: true,
+  Proxy: true,
+  RangeError: true,
+  ReferenceError: true,
+  Reflect: true,
+  RegExp: true,
+  Set: true,
+  String: true,
+  Symbol: true,
+  SyntaxError: true,
+  TypeError: true,
+  URIError: true,
+  Uint16Array: true,
+  Uint32Array: true,
+  Uint8Array: true,
+  Uint8ClampedArray: true,
+  WeakMap: true,
+  WeakSet: true,
+  arguments: true,
+  console: true,
+  expect: true,
+  isNaN: true,
+  jest: true,
+  parseFloat: true,
+  parseInt: true,
+  require: true,
+  undefined: true,
+};
+Object.keys(global).forEach(name => (WHITELISTED_IDENTIFIERS[name] = true));
+
+const JEST_GLOBAL = { name: 'jest' };
+const IDVisitor = {
+  ReferencedIdentifier(path) {
+    this.ids.add(path);
+  },
+  blacklist: ['TypeAnnotation'],
+};
+
+const disableEnableAutomock = (args: ts.NodeArray<ts.Expression>) =>
+  args.length === 0;
+
+const FUNCTIONS = Object.assign(Object.create(null), {
+  mock: (args: ts.NodeArray<ts.Expression>) => {
+    if (args.length === 1) {
+      return ts.isStringLiteral(args[0]) || ts.isLiteralExpression(args[0]);
+    } else if (args.length === 2 || args.length === 3) {
+      const moduleFactory = args[1];
+      invariant(
+        ts.isFunctionExpression(moduleFactory),
+        'The second argument of `jest.mock` must be an inline function.',
+      );
+
+      const ids = new Set<ts.Identifier>();
+      const parentScope = moduleFactory.parentPath.scope;
+      // Discover all identifiers within moduleFactory
+      function visitModuleFactoryIdentifiers(node: ts.Node) {
+        if (ts.isIdentifier(node)) {
+          ids.add(node);
+        }
+        ts.forEachChild(node, visitModuleFactoryIdentifiers);
+      }
+      visitModuleFactoryIdentifiers(moduleFactory);
+      for (const id of ids) {
+          const name = id.node.name;
+          let found = false;
+          let scope = id.scope;
+
+          while(scope !== parentScope) {
+              if(scope.bindings[name]) {
+                  found = true;
+                  break;
+              }
+
+              scope = scope.parent;
+          }
+
+          // If identifier is a reference to something declared *outside* the moduleFactory function...
+          if (!found) {
+              invariant(
+                  (scope.hasGlobal(name) && WHITELISTED_IDENTIFIERS[name]) ||
+                  /^mock/.test(name) ||
+                  // Allow istanbul's coverage variable to pass.
+                  /^(?:__)?cov/.test(name),
+                  'The module factory of `jest.mock()` is not allowed to ' +
+                  'reference any out-of-scope variables.\n' +
+                  'Invalid variable access: ' +
+                  name +
+                  '\n' +
+                  'Whitelisted objects: ' +
+                  Object.keys(WHITELISTED_IDENTIFIERS).join(', ') +
+                  '.\n' +
+                  'Note: This is a precaution to guard against uninitialized mock ' +
+                  'variables. If it is ensured that the mock is required lazily, ' +
+                  'variable names prefixed with `mock` are permitted.',
+              );
+          }
+      }
+
+      return true;
+    }
+    return false;
+  },
+
+  unmock: (args: ts.NodeArray<ts.Expression>) => args.length === 1 && ts.isStringLiteral(args[0]),
+  deepUnmock: (args: ts.NodeArray<ts.Expression>) => args.length === 1 && ts.isStringLiteral(args[0]),
+
+  disableAutomock: disableEnableAutomock,
+
+  enableAutomock: disableEnableAutomock,
+});
+
+function shouldHoistStatement(stmt: ts.Statement) {
+  if (!ts.isExpressionStatement(stmt)) {
+    return false;
+  }
+  const expr = stmt.expression;
+  if (!ts.isCallExpression(expr)) {
+    return false;
+  }
+  const propAccessExpression = expr.expression;
+  if (!ts.isPropertyAccessExpression(propAccessExpression)) {
+    return false;
+  }
+  const { expression, name } = propAccessExpression;
+  if (!ts.isIdentifier(expression) || !ts.isIdentifier(name)) {
+    return false;
+  }
+  if (expression.getText() !== JEST_GLOBAL.name) {
+    return false;
+  }
+  const validatorFunction = FUNCTIONS[name.getText()];
+  if (!validatorFunction) {
+    return false;
+  }
+  return validatorFunction(expr.arguments);
+}
+
+export function hoistTransformerFactory(context: ts.TransformationContext) {
+  return transformer;
+  function transformer(file: ts.SourceFile) {
+    const hoistedStatements: ts.Statement[] = [];
+    const nonHoistedStatements: ts.Statement[] = [];
+
+    ts.visitEachChild(file, (childNode) => visitSourceFileChild(childNode, context), context);
+
+    if (!hoistedStatements.length) {
+      return file;
+    }
+
+    // perform hoisting
+    const newFile = ts.getMutableClone(file);
+    newFile.statements = ts.setTextRange(
+      ts.createNodeArray([...hoistedStatements, ...nonHoistedStatements]),
+      newFile.statements,
+    );
+    return newFile;
+
+    /** Visit each direct child of SourceFile to see if it should be hoisted */
+    function visitSourceFileChild(childNode: ts.Node, ctx: ts.TransformationContext) {
+      const statement = childNode as ts.Statement;
+      if (shouldHoistStatement(statement)) {
+        hoistedStatements.push(statement);
+      } else {
+        nonHoistedStatements.push(statement);
+      }
+      return childNode;
+    }
+  }
+}


### PR DESCRIPTION
WIP & untested; the transformer isn't even wired up yet.  I'm posting in case anyone's curious.  This might be best spun into a third-party module and imported by ts-jest.

I wanted to see how easy it was to implement `ignoreCoverageForDecorators` via a TypeScript transformer instead of RegExp find-and-replace.  Turns out it's really straightforward; this only took me a couple hours.

The current regexp implementation can obviously break in certain situations, such as `/* my code talks about __decorate in a comment */`.

[Here's an example of the output](https://sokra.github.io/source-map-visualization/#base64,dmFyIF9fZGVjb3JhdGUgPSAodGhpcyAmJiB0aGlzLl9fZGVjb3JhdGUpIHx8IGZ1bmN0aW9uIChkZWNvcmF0b3JzLCB0YXJnZXQsIGtleSwgZGVzYykgew0KICAgIHZhciBjID0gYXJndW1lbnRzLmxlbmd0aCwgciA9IGMgPCAzID8gdGFyZ2V0IDogZGVzYyA9PT0gbnVsbCA/IGRlc2MgPSBPYmplY3QuZ2V0T3duUHJvcGVydHlEZXNjcmlwdG9yKHRhcmdldCwga2V5KSA6IGRlc2MsIGQ7DQogICAgaWYgKHR5cGVvZiBSZWZsZWN0ID09PSAib2JqZWN0IiAmJiB0eXBlb2YgUmVmbGVjdC5kZWNvcmF0ZSA9PT0gImZ1bmN0aW9uIikgciA9IFJlZmxlY3QuZGVjb3JhdGUoZGVjb3JhdG9ycywgdGFyZ2V0LCBrZXksIGRlc2MpOw0KICAgIGVsc2UgZm9yICh2YXIgaSA9IGRlY29yYXRvcnMubGVuZ3RoIC0gMTsgaSA+PSAwOyBpLS0pIGlmIChkID0gZGVjb3JhdG9yc1tpXSkgciA9IChjIDwgMyA/IGQocikgOiBjID4gMyA/IGQodGFyZ2V0LCBrZXksIHIpIDogZCh0YXJnZXQsIGtleSkpIHx8IHI7DQogICAgcmV0dXJuIGMgPiAzICYmIHIgJiYgT2JqZWN0LmRlZmluZVByb3BlcnR5KHRhcmdldCwga2V5LCByKSwgcjsNCn07DQp2YXIgRm9vID0gLyoqIEBjbGFzcyAqLyAoZnVuY3Rpb24gKCkgew0KICAgIGZ1bmN0aW9uIEZvbygpIHsNCiAgICB9DQogICAgRm9vID0gX19kZWNvcmF0ZShbDQogICAgICAgIGdldENvdmVyYWdlRm9yVGhpc0RlY29yYXRvciwNCiAgICAgICAgZnVuY3Rpb24gZGVjb3JhdG9yV3JhcHBlckZhY3RvcnkoZGVjb3JhdG9yKSB7IHJldHVybiBmdW5jdGlvbiBkZWNvcmF0b3JXcmFwcGVyKCkgeyAvKmlzdGFuYnVsIGlnbm9yZSBuZXh0Ki8gcmV0dXJuIGRlY29yYXRvci5hcHBseSh0aGlzLCBhcmd1bWVudHMpOyB9OyB9KGhlbGxvIC8qIGlzdGFuYnVsIGlnbm9yZSBkZWNvcmF0b3IgKi8pLA0KICAgICAgICBmdW5jdGlvbiBkZWNvcmF0b3JXcmFwcGVyRmFjdG9yeShkZWNvcmF0b3IpIHsgcmV0dXJuIGZ1bmN0aW9uIGRlY29yYXRvcldyYXBwZXIoKSB7IC8qaXN0YW5idWwgaWdub3JlIG5leHQqLyByZXR1cm4gZGVjb3JhdG9yLmFwcGx5KHRoaXMsIGFyZ3VtZW50cyk7IH07IH0oKHdvcmxkICsgb3RoZXJzdHVmZikgLyogaXN0YW5idWwgaWdub3JlIGRlY29yYXRvciAqLykNCiAgICBdLCBGb28pOw0KICAgIHJldHVybiBGb287DQp9KCkpOw0KLyogYmFzZTY0IHNvdXJjZSBtYXAgcmVtb3ZlZCAqLw==,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibW9kdWxlLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsibW9kdWxlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUtBO0lBQUE7SUFFQSxDQUFDO0lBRkssR0FBRztRQUhSLDJCQUEyQjtrS0FDM0IsS0FBSyxDQUFBLCtCQUErQjtrS0FDcEMsQ0FBQyxLQUFLLEdBQUcsVUFBVSxDQUFDLENBQUEsK0JBQStCO09BQzlDLEdBQUcsQ0FFUjtJQUFELFVBQUM7Q0FBQSxBQUZELElBRUMiLCJzb3)

EDIT: turns out the source-map-visualization link was truncated, so here's a link to a file that can be loaded into the visualizer: https://gist.github.com/cspotcode/c361666f919d059a51f2c078c4f1ddbc