### PR TITLE
Adjust jest peer dependency to 23.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "yargs": "^11.0.0"
   },
   "peerDependencies": {
-    "jest": "^22.4.0 || ^22.5.0-alpha.1 || ^23.0.0-alpha.1",
+    "jest": "^22.4.0 || ^22.5.0-alpha.1 || ^23.0.0",
     "typescript": "2.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "yargs": "^11.0.0"
   },
   "peerDependencies": {
-    "jest": "^22.4.0 || ^22.5.0-alpha.1 || ^23.0.0",
+    "jest": "^22.4.0 || ^23.0.0",
     "typescript": "2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Since we are preparing to support jest 23, we should adjust peer dependency to Jest 23.0.0