### PR TITLE
[FIX] cache key resolver for getTSConfig

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Gino Zhang <whitetrefoil@gmail.com>
 Gregor Stamac <1668205+gstamac@users.noreply.github.com>
 Gustav Wengel <gustavwengel@gmail.com>
 Henry Zektser <japhar81@gmail.com>
+Huafu Gandon <huafu.gandon@gmail.com>
 Ihor Chulinda <ichulinda@gmail.com>
 J Cheyo Jimenez <cheyo@masters3d.com>
 Jim Cummins <jimthedev@gmail.com>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,7 +116,7 @@ export const getTSConfig = _.memoize(getTSConfig_local, (globals, rootDir) => {
   // check cache before resolving configuration
   // NB: We use JSON.stringify() to create a consistent, unique signature. Although it lacks a uniform
   //     shape, this is simpler and faster than using the crypto package to generate a hash signature.
-  return JSON.stringify(globals, rootDir);
+  return `${rootDir}:${JSON.stringify(globals)}`;
 });
 
 // Non-memoized version of TSConfig

--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -3,13 +3,14 @@ jest.mock('path');
 
 import * as ts from 'typescript';
 import { getTSConfig } from '../../src/utils';
-import runJest from '../__helpers__/runJest';
 import * as path from 'path';
 
 describe('get default ts config', () => {
   beforeEach(() => {
     // Set up some mocked out file info before each test
     ((path as any) as MockedPath).__setBaseDir('./tests/tsconfig-test');
+    // empties the lodash memoized cache for this function
+    getTSConfig.cache.clear();
   });
 
   it('should correctly read tsconfig.json', () => {
@@ -47,7 +48,7 @@ describe('get default ts config', () => {
     });
   });
 
-  describe('new behaviour (tsConfigFile & tsConfig)', () => {
+  describe('new behavior (tsConfigFile & tsConfig)', () => {
     it('should be same results for null/undefined/etc.', () => {
       const result = getTSConfig(null);
       const resultUndefinedParam = getTSConfig(undefined);
@@ -65,6 +66,12 @@ describe('get default ts config', () => {
       expect(result).toEqual(resultEmptyParam);
       expect(result).toEqual(resultUndefinedContentFile);
       expect(result).toEqual(resultNullContentFile);
+    });
+
+    it('should be different results for different rootDir with same jest config.', () => {
+      const rootConfig = getTSConfig({});
+      const subConfig = getTSConfig({}, 'tsconfig-module');
+      expect(rootConfig).not.toEqual(subConfig);
     });
 
     it('should not change the module if it is loaded from a non-default config file', () => {


### PR DESCRIPTION
In the weird case you'd have such a directory structure:
```
src/
  ...
other-src/
  tsconfig.json
tsconfig.json
```
and `jest.globals` would be the same for both directories, the second call to `getTSConfig` will return the same as the other one, because `rootDir` is ignored in the cache key resolver for `getTSConfig`.

I've also added the reset of `memoized` cache for that function before each test, as it could land to weird results in some cases (passing but shouldn't or even the opposite because of cached data between tests)