### PR TITLE
pass configFile path to ts.parseJsonConfigFileContent()

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,8 @@ function readCompilerOptions(
     config,
     tsc.sys,
     path.resolve(rootDir),
+    undefined,
+    configPath,
   );
 
   if (errors.length > 0) {

--- a/tests/__tests__/relative-extended-config.spec.ts
+++ b/tests/__tests__/relative-extended-config.spec.ts
@@ -1,0 +1,23 @@
+import { MockedPath } from '../__mocks__/path';
+jest.mock('path');
+import * as path from 'path';
+import { getTSConfig } from '../../src/utils';
+
+describe('loads extended config file relative to the original config file, not the root dir', () => {
+  it('should pass', () => {
+    ((path as any) as MockedPath).__setBaseDir(
+      './tests/relative-extended-config',
+    );
+
+    // this should fail when `ts.parseJsonConfigFileContent()` is called without the configFile path
+    const config = getTSConfig({
+      'ts-jest': {
+        tsConfigFile: './config/tsconfig.tests.json',
+      },
+    });
+
+    // tsconfig.tests.json does not contain a "pretty" field,
+    // while tsconfig.base.json does. Default value would be "false".
+    expect(config.pretty).toBeTruthy();
+  });
+});

--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -17,6 +17,7 @@ describe('get default ts config', () => {
     const result = getTSConfig(null);
 
     expect(result).toEqual({
+      configFilePath: expect.stringContaining('tsconfig-test/tsconfig.json'),
       declaration: false,
       declarationMap: false,
       emitDeclarationOnly: false,

--- a/tests/__tests__/tsconfig-string.spec.ts
+++ b/tests/__tests__/tsconfig-string.spec.ts
@@ -19,6 +19,9 @@ describe('get ts config from string', () => {
       });
 
       expect(result).toMatchObject({
+        configFilePath: expect.stringContaining(
+          'tsconfig-test/my-tsconfig.json',
+        ),
         inlineSourceMap: true,
         inlineSources: true,
         target: ts.ScriptTarget.ES2015,
@@ -66,6 +69,9 @@ describe('get ts config from string', () => {
       });
 
       expect(result).toEqual({
+        configFilePath: expect.stringContaining(
+          'tsconfig-test/extends-tsconfig.json',
+        ),
         declaration: false,
         declarationMap: false,
         emitDeclarationOnly: false,
@@ -87,6 +93,9 @@ describe('get ts config from string', () => {
       });
 
       expect(result).toEqual({
+        configFilePath: expect.stringContaining(
+          'tsconfig-test/extends-with-overrides-tsconfig.json',
+        ),
         declaration: false,
         declarationMap: false,
         emitDeclarationOnly: false,

--- a/tests/relative-extended-config/config/tsconfig.base.json
+++ b/tests/relative-extended-config/config/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": false,
+    "jsx": "react",
+    "allowJs": true,
+    "pretty": true
+  },
+}

--- a/tests/relative-extended-config/config/tsconfig.tests.json
+++ b/tests/relative-extended-config/config/tsconfig.tests.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "../**/*.ts"
+  ]
+}

--- a/tests/relative-extended-config/sum.ts
+++ b/tests/relative-extended-config/sum.ts
@@ -1,0 +1,3 @@
+export function sum(...numbers: number[]) {
+  return numbers.reduce((total, next) => total + next, 0);
+}


### PR DESCRIPTION
When `ts-jest` is passed a `tsconfig` file via `jest.globals.ts-jest.tsConfigFile` that does not live in the root directory, when the `tsconfig` file contains an `extends` property and the extended `tsconfig` file is relative to the original `tsconfig` file and not the root directory, then this error is emitted:

```
Some errors occurred while attempting to read from <path>/ts-jest/tests/relative-extended-config/config/tsconfig.tests.json: error TS5058: The specified path does not exist: '<path>/ts-jest/tests/relative-extended-config/tsconfig.base.json'.
```

See the test for more details.