### PR TITLE
Add TypeScript ^3.0.0 as supported peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "peerDependencies": {
     "babel-core": "^6.26.3 || ^7.0.0-0",
     "jest": "^23.0.0 || ^24.0.0",
-    "typescript": "2.x"
+    "typescript": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@types/babel-core": "latest",


### PR DESCRIPTION
This ts-jest works fine with TypeScript 3 also, so I did change the version mask in peerDependencies to support all TypeScript 2 and 3 versions.