### PR TITLE
Add `allowJs` explanation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,14 @@ The default setup shown here picks up only `.ts` and `.tsx` files. However, if t
     }
 ```
 
+If you want to use ts-jest to process `.js` files, you will also need TypeScript itself to not ignore them. `allowJs` is `false` by default, so you will need to add the following to you `tsconfig.json`:
+
+````
+    "compilerOptions": {
+      "allowJs": true
+    }
+````
+
 ## Tips
 ### Importing packages written in TypeScript
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ The default setup shown here picks up only `.ts` and `.tsx` files. However, if t
     }
 ```
 
-If you want to use ts-jest to process `.js` files, you will also need TypeScript itself to not ignore them. `allowJs` is `false` by default, so you will need to add the following to you `tsconfig.json`:
+If you want to use ts-jest to process `.js` files, you will also need TypeScript itself not to ignore them. `allowJs` is `false` by default, so you will need to add the following to your `tsconfig.json`:
 
 ````
     "compilerOptions": {


### PR DESCRIPTION
After a few hours debugging why I was getting jest failures for a module in my node_modules which was using es6 module syntax, I found that even after I explicitly specified that I wanted ts-jest to transform javascript files, I was still getting test failures. After some digging, I found that even though jest picked up the `.js` file for the transform step, ts-jest was not actually transforming it until I added `"allowJs": true` to my tsconfig.

Hopefully this can save someone else a few hours of debugging. 😄 