### PR TITLE
test: when diagnostics are enabled, importing .graphql files throws error

### DIFF
--- a/tests/__tests__/ts-diagnostics.spec.ts
+++ b/tests/__tests__/ts-diagnostics.spec.ts
@@ -4,10 +4,13 @@ describe('TypeScript Diagnostics errors', () => {
   it('should show the correct error locations in the typescript files', () => {
     const result = runJest('../ts-diagnostics', ['--no-cache']);
     expect(result.stderr).toContain(
-      `Hello.ts(2,10): error TS2339: Property 'push' does not exist on type`,
+      `Hello.ts(1,38): error TS2307: Cannot find module './deleteDog.graphql'.`,
     );
     expect(result.stderr).toContain(
-      `Hello.ts(13,10): error TS2339: Property 'unexcuted' does not exist on type 'Hello`,
+      `Hello.ts(5,10): error TS2339: Property 'push' does not exist on type`,
+    );
+    expect(result.stderr).toContain(
+      `Hello.ts(16,10): error TS2339: Property 'unexcuted' does not exist on type 'Hello`,
     );
   });
 

--- a/tests/ts-diagnostics/Hello.ts
+++ b/tests/ts-diagnostics/Hello.ts
@@ -1,3 +1,6 @@
+import * as DELETE_DOG_MUTATION from './deleteDog.graphql';
+import styles from './styles.css';
+
 export class Hello {
   x = ''.push();
 

--- a/tests/ts-diagnostics/deleteDog.graphql
+++ b/tests/ts-diagnostics/deleteDog.graphql
@@ -1,0 +1,7 @@
+  mutation deleteDog($name: String!) {
+    deleteDog(name: $name) {
+      id
+      name
+      breed
+    }
+  }

--- a/tests/ts-diagnostics/styles.css
+++ b/tests/ts-diagnostics/styles.css
@@ -1,0 +1,3 @@
+body {
+  font-size: 16px;
+}


### PR DESCRIPTION
tsc does not complain for the` .css` file & only for the `.graphql` file. This is probably an issue with typescript compiler.
i added a testcase which demonstrates #477.
