### PR TITLE
Fix for #691

### DIFF
--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -17,15 +17,6 @@ describe('get default ts config', () => {
     getTSConfig.cache.clear();
   });
 
-  it('should bail when no default tsconfig.json found', () => {
-    // there is no tsconfig file in that test module
-    ((path as any) as MockedPath).__setBaseDir('./tests/jestconfig-test');
-
-    expect(() => getTSConfig(mockJestConfig('jestconfig-test'))).toThrowError(
-      /unable to find ts configuration file/i,
-    );
-  });
-
   it('should correctly read tsconfig.json', () => {
     const result = getTSConfig(mockJestConfig(TEST_CASE));
 

--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -21,7 +21,7 @@ describe('get default ts config', () => {
     // there is no tsconfig file in that test module
     ((path as any) as MockedPath).__setBaseDir('./tests/jestconfig-test');
 
-    expect(() => getTSConfig(mockJestConfig('jestconfig-test'))).toBeDefined();
+    expect(getTSConfig(mockJestConfig('jestconfig-test'))).toBeDefined();
   });
 
   it('should correctly read tsconfig.json', () => {

--- a/tests/__tests__/tsconfig-default.spec.ts
+++ b/tests/__tests__/tsconfig-default.spec.ts
@@ -17,6 +17,13 @@ describe('get default ts config', () => {
     getTSConfig.cache.clear();
   });
 
+  it('should supply empty config if no default tsconfig.json found', () => {
+    // there is no tsconfig file in that test module
+    ((path as any) as MockedPath).__setBaseDir('./tests/jestconfig-test');
+
+    expect(() => getTSConfig(mockJestConfig('jestconfig-test'))).toBeDefined();
+  });
+
   it('should correctly read tsconfig.json', () => {
     const result = getTSConfig(mockJestConfig(TEST_CASE));
 


### PR DESCRIPTION
This is a proposed fix for issue #691.

As described in that issue, TypeScript doesn't require the user to create a `tsconfig.json` file anymore and in fact does not recommend it in their getting started section. I actually completely forgot about it because I was using Parcel, a zero-config bundler so it handled config options.

So I saw two options:

1. Force `ts-jest` to use an empty config object if no `tsconfig.json` is found.
2. Tell the user in the documentation that they must supply one to use `ts-jest`.

Since `ts-jest` actually works with an empty config object, I felt it was cleaner to simply take the first option rather than ask the user to put in a dummy file which is not needed by `typescript` or `ts-jest`.

This PR does that. It also removes a test which expects to throw an error if no config is found, as that behavior is what was intentionally removed.

It's a small change but hopefully saves you guys some typing. If you want to see changes let me know! Thanks for the useful tool!