### PR TITLE
[beta] Use the proper way of mutating a node in a transformer

### DIFF
--- a/src/transformers/README.md
+++ b/src/transformers/README.md
@@ -5,13 +5,9 @@ See https://dev.doctorevidence.com/how-to-write-a-typescript-transform-plugin-fc
 ## Boilerplate
 
 ```ts
-import {
-  TransformationContext,
-  SourceFile,
-  Visitor,
-  Transformer,
-} from 'typescript';
-import { ConfigSet } from '../config-set'
+import { SourceFile, TransformationContext, Transformer, Visitor } from 'typescript'
+
+import { ConfigSet } from '../config/config-set'
 
 // this is a unique identifier for your transformer
 export const name = 'my-transformer'
@@ -26,7 +22,7 @@ export function factory(cs: ConfigSet) {
       // new nodes if we want to leave the node as is, and
       // continue searching through child nodes:
       return ts.visitEachChild(node, visitor, ctx)
-    };
+    }
     return visitor
   }
   // we return the factory expected in CustomTransformers

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,5 +1,5 @@
 import { AstTransformerDesc } from '../types'
 
-import * as hoisting from './hoisting'
+import * as hoisting from './hoist-jest'
 
 export const internals: AstTransformerDesc[] = [hoisting]


### PR DESCRIPTION
This doesn't change the generate code, but as @cspotcode pointed me out, this creates a mutable node before actually mutating it.

Ti doesn't change anything in the generated code (of what I've tested and what is in the e2e tests), but cloning readonly stuff before mutating is always advised right 🤣?

There is also a fix for the transformer boilerplate code anyway.