### PR TITLE
[beta] updates peers & merge master

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "yargs-parser": "^10.1.0"
   },
   "peerDependencies": {
-    "jest": ">=22 <24",
-    "typescript": ">=2.7.0 <4.0.0"
+    "jest": ">=22 <24"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "yargs-parser": "^10.1.0"
   },
   "peerDependencies": {
-    "babel-jest": ">=22 <24",
     "jest": ">=22 <24",
     "typescript": ">=2.7.0 <4.0.0"
   },


### PR DESCRIPTION
- `jest` brings `babel-jest`, so we don't want `babel-jest` in the peers
- users may want to use `ttypescript` instead of `typescript`, or even another typescript compiler, so `typescript` shouldn't be in peer deps.

Now yarn or npm will warn only if `jest` is not installed or if version isn't in our compatible range.

TSJest will warn anyway if an installed package's version does not verify our compatible range for those packages (unless it is not `require()`d):

https://github.com/kulshekhar/ts-jest/blob/e70d11c0f66c4853153f5ccfcb2ec879be2b58de/src/util/version-checkers.ts#L9-L15