### PR TITLE
fix: flush logs even if `preprocess` throws

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "ts-nameof": "^1.0.0",
     "tslint": "^5.11.0",
     "ttypescript": "^1.4.6",
-    "typescript": "^2.9.2",
+    "typescript": "^3.0.3",
     "yargs": "^12.0.1"
   },
   "lint-staged": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { flushLogs } from './utils/logger';
 import getCacheKey from './utils/get-cache-key';
 import preprocess from './preprocess';
 
@@ -6,7 +7,13 @@ const createTransformer = (options?: any): jest.Transformer => {
   return {
     canInstrument: true,
     getCacheKey,
-    process: preprocess,
+    process: (...args) => {
+      try {
+        return preprocess(...args);
+      } finally {
+        flushLogs();
+      }
+    },
     createTransformer: undefined as any,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const createTransformer = (options?: any): jest.Transformer => {
         flushLogs();
       }
     },
-    createTransformer: undefined as any,
+    createTransformer: undefined,
   };
 };
 

--- a/src/preprocess.ts
+++ b/src/preprocess.ts
@@ -1,4 +1,4 @@
-import { flushLogs, logOnce } from './utils/logger';
+import { logOnce } from './utils/logger';
 import { postProcessCode } from './postprocess';
 import { transpileTypescript } from './transpiler';
 import runTsDiagnostics from './utils/run-ts-diagnostics';
@@ -72,8 +72,6 @@ export default function preprocess(
     transpileOutput,
     filePath,
   );
-
-  flushLogs();
 
   return { code: outputText.code, map: outputText.map };
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,8 +17,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": false,
     "skipLibCheck": true,
-    "lib": ["es2015"],
-    "types": ["jest"]
+    "lib": ["es2015"]
   },
   "exclude": ["**/node_modules/**/*"]
 }


### PR DESCRIPTION
Previously, logs were not flushed when an error was thrown in the `preprocess` function.