### PR TITLE
Update Issue Template with new TS_JEST_LOG variable

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,14 +7,16 @@ https://github.com/kulshekhar/ts-jest/wiki/Troubleshooting -->
 ## Expected behavior <!-- describe the expected behavior below -->:
 
 
-## Output from debug log <!-- You can activate the debug logger by setting the environment variable TS_JEST_DEBUG="true" before running yarn test. The output of the logger will be in **<your_project_dir>/node_modules/ts-jest/debug.txt**, paste it below -->:
+## Output from debug log <!-- Run: TS_JEST_LOG=debug.txt yarn test  --- The output of the logger will be in **<your_project_dir>/debug.txt**, paste it below -->:
+<details>
+  <summary>debug.txt, Click to expand</summary>
 ```bash
-# content of debug.txt :
-
+# PASTE CONTENTS OF debug.txt HERE!
 ```
+</details>
 
-
-## Minimal repo <!-- If you haven't already, create the smallest possible repo that reproduces this issue by running `npm install` and `npm test`. This will speed up any fixes that this issue might need. Paste the minimal repo URL below -->:
+## Minimal repo
+<!-- If you haven't already, create the smallest possible repo that reproduces this issue by running `npm install` and `npm test`. This will speed up any fixes that this issue might need. Paste the minimal repo URL below -->:
 
 
 <!-- Optional (but highly recommended): Configure Travis (or your favorite system) with the minimal repo. This allows potential solutions to be tested against the minimal repo. This saves everyone time and avoids a lot of back and forth. -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,8 @@ https://github.com/kulshekhar/ts-jest/wiki/Troubleshooting -->
 ## Output from debug log <!-- Run: TS_JEST_LOG=debug.txt yarn test  --- The output of the logger will be in **<your_project_dir>/debug.txt**, paste it below -->:
 <details>
   <summary>debug.txt, Click to expand</summary>
-```bash
+
+  ```bash
 # PASTE CONTENTS OF debug.txt HERE!
 ```
 </details>


### PR DESCRIPTION
Original ISSUE_TEMPLATE was describing using a deprecated env-variable of TS_JEST_DEBUG, this PR switches that to using TS_JEST_LOG, as well as using a disclosable html tag, so the issue is easier to read in a browser.