### PR TITLE
[beta] warns the user if jest config transform matches js files without allowJs in tsconfig

### DIFF
--- a/src/ts-jest-transformer.spec.ts
+++ b/src/ts-jest-transformer.spec.ts
@@ -117,7 +117,7 @@ Array [
 
   it('should return stringified version of file', () => {
     config.shouldStringifyContent.mockImplementation(() => true)
-    expect(process()).toMatchInlineSnapshot(`"ts:module.exports=\\"export default \\\\\\"foo\\\\\\"\\""`)
+    expect(process()).toMatchInlineSnapshot(`"module.exports=\\"export default \\\\\\"foo\\\\\\"\\""`)
   })
 
   it('should warn when trying to process js but allowJs is false', () => {
@@ -131,6 +131,28 @@ Array [
   "[level:40] Got a \`.js\` file to compile while \`allowJs\` option is not set to \`true\` (file: /foo/bar.js). To fix this:
   - if you want TypeScript to process JS files, set \`allowJs\` to \`true\` in your TypeScript config (usually tsconfig.json)
   - if you do not want TypeScript to process your \`.js\` files, in your Jest config change the \`transform\` key which value is \`ts-jest\` so that it does not match \`.js\` files anymore
+",
+]
+`)
+  })
+
+  it('should warn when trying to process unknown file types', () => {
+    args[1] = '/foo/bar.jest'
+    const logs = logTargetMock()
+    logs.clear()
+    expect(process()).toBe(INPUT)
+    expect(logs.lines.warn).toMatchInlineSnapshot(`
+Array [
+  "[level:40] Got a unknown file type to compile (file: /foo/bar.jest). To fix this, in your Jest config change the \`transform\` key which value is \`ts-jest\` so that it does not match this kind of files anymore.
+",
+]
+`)
+    logs.clear()
+    babel = { process: jest.fn(s => `babel:${s}`) }
+    expect(process()).toBe(`babel:${INPUT}`)
+    expect(logs.lines.warn).toMatchInlineSnapshot(`
+Array [
+  "[level:40] Got a unknown file type to compile (file: /foo/bar.jest). To fix this, in your Jest config change the \`transform\` key which value is \`ts-jest\` so that it does not match this kind of files anymore. If you still want Babel to process it, add another entry to the \`transform\` option with value \`babel-jest\` which key matches this type of files.
 ",
 ]
 `)

--- a/src/ts-jest-transformer.spec.ts
+++ b/src/ts-jest-transformer.spec.ts
@@ -1,5 +1,7 @@
 import stringify from 'fast-json-stable-stringify'
+import { ParsedCommandLine } from 'typescript'
 
+import { logTargetMock } from './__helpers__/mocks'
 import { TsJestTransformer } from './ts-jest-transformer'
 
 describe('configFor', () => {
@@ -31,8 +33,12 @@ describe('lastTransformerId', () => {
 describe('process', () => {
   let tr: TsJestTransformer
   let babel: any
+  let typescript: ParsedCommandLine
   let args: [string, string, any, any]
   const config = {
+    get typescript() {
+      return typescript
+    },
     shouldStringifyContent: jest.fn(),
     get babelJestTransformer() {
       return babel
@@ -53,12 +59,12 @@ describe('process', () => {
       .mockImplementation(() => config)
       .mockClear()
     config.shouldStringifyContent.mockImplementation(() => false).mockClear()
-    babel = { process: jest.fn(s => `babel:${s}`) }
+    babel = null
     config.tsCompiler.compile.mockImplementation(s => `ts:${s}`).mockClear()
+    typescript = { options: {} } as any
   })
 
   it('should process input without babel', () => {
-    babel = null
     expect(process()).toBe(`ts:${INPUT}`)
     expect(config.shouldStringifyContent.mock.calls).toMatchInlineSnapshot(`
 Array [
@@ -78,6 +84,7 @@ Array [
   })
 
   it('should process input with babel', () => {
+    babel = { process: jest.fn(s => `babel:${s}`) }
     expect(process()).toBe(`babel:ts:${INPUT}`)
     expect(config.shouldStringifyContent.mock.calls).toMatchInlineSnapshot(`
 Array [
@@ -113,7 +120,24 @@ Array [
     expect(process()).toMatchInlineSnapshot(`"ts:module.exports=\\"export default \\\\\\"foo\\\\\\"\\""`)
   })
 
+  it('should warn when trying to process js but allowJs is false', () => {
+    args[1] = '/foo/bar.js'
+    typescript.options.allowJs = false
+    const logs = logTargetMock()
+    logs.clear()
+    expect(process()).toBe(INPUT)
+    expect(logs.lines.warn).toMatchInlineSnapshot(`
+Array [
+  "[level:40] Got a \`.js\` file to compile while \`allowJs\` option is not set to \`true\` (file: /foo/bar.js). To fix this:
+  - if you want TypeScript to process JS files, set \`allowJs\` to \`true\` in your TypeScript config (usually tsconfig.json)
+  - if you do not want TypeScript to process your \`.js\` files, in your Jest config change the \`transform\` key which value is \`ts-jest\` so that it does not match \`.js\` files anymore
+",
+]
+`)
+  })
+
   it('should not pass the instrument option to babel-jest', () => {
+    babel = { process: jest.fn(s => `babel:${s}`) }
     args[3] = { instrument: true }
     expect(process()).toBe(`babel:ts:${INPUT}`)
     expect(config.babelJestTransformer.process.mock.calls).toMatchInlineSnapshot(`

--- a/src/util/messages.ts
+++ b/src/util/messages.ts
@@ -12,6 +12,7 @@ export enum Errors {
   NotMappingPathWithEmptyMap = 'Not mapping "{{path}}" because it has no target.',
   MappingOnlyFirstTargetOfPath = 'Mapping only to first target of "{{path}}" because it has more than one ({{count}}).',
   CannotPatchBabelCore6 = 'Error while trying to patch babel-core/lib/transformation/file: {{error}}',
+  GotJsFileButAllowJsFalse = 'Got a `.js` file to compile while `allowJs` option is not set to `true` (file: {{path}}). To fix this:\n  - if you want TypeScript to process JS files, set `allowJs` to `true` in your TypeScript config (usually tsconfig.json)\n  - if you do not want TypeScript to process your `.js` files, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match `.js` files anymore',
 }
 
 export enum Helps {

--- a/src/util/messages.ts
+++ b/src/util/messages.ts
@@ -13,6 +13,8 @@ export enum Errors {
   MappingOnlyFirstTargetOfPath = 'Mapping only to first target of "{{path}}" because it has more than one ({{count}}).',
   CannotPatchBabelCore6 = 'Error while trying to patch babel-core/lib/transformation/file: {{error}}',
   GotJsFileButAllowJsFalse = 'Got a `.js` file to compile while `allowJs` option is not set to `true` (file: {{path}}). To fix this:\n  - if you want TypeScript to process JS files, set `allowJs` to `true` in your TypeScript config (usually tsconfig.json)\n  - if you do not want TypeScript to process your `.js` files, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match `.js` files anymore',
+  GotUnknownFileTypeWithoutBabel = 'Got a unknown file type to compile (file: {{path}}). To fix this, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match this kind of files anymore.',
+  GotUnknownFileTypeWithBabel = 'Got a unknown file type to compile (file: {{path}}). To fix this, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match this kind of files anymore. If you still want Babel to process it, add another entry to the `transform` option with value `babel-jest` which key matches this type of files.',
 }
 
 export enum Helps {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "inlineSources": false,
     "inlineSourceMap": false,
-    "removeComments": true,
+    "noEmit": false,
     "outDir": "dist",
     "rootDir": "src",
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "declaration": true,
+    "declaration": false,
+    "noEmit": true,
     "downlevelIteration": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
@@ -18,7 +19,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "removeComments": false,
+    "removeComments": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": false,


### PR DESCRIPTION
Given a jest config with:
```js
{
  // [...]
  transform: {
    '\\.(js|ts)$': 'ts-jest',
  }
}
```
and a `tsconfig.json` where `allowJs` compiler option is missing or set to `false`, `ts-jest` will be given `.js` files even tho it's not supposed to process them. TypeScript would bail in that case.

This PR make it so that input js code from `.js` files is returned unmodified (in the above described case), and a warning message is shown.

This kinda fixes confusions made such as in #721 