### PR TITLE
Fixes wrong error message when a module exists but fails loading

### DIFF
--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -354,7 +354,7 @@ export class ConfigSet {
     let hooksFile = process.env.TS_JEST_HOOKS
     if (hooksFile) {
       hooksFile = resolve(this.cwd, hooksFile)
-      return importer.tryThese(hooksFile) || {}
+      return importer.tryTheseOr(hooksFile, {})
     }
     return {}
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,13 +127,6 @@ export interface CreateJestPresetOptions {
 export type ModulePatcher<T = any> = (module: T) => T
 
 /**
- * @internal
- */
-export interface TsJestImporter {
-  tryThese(moduleName: string, ...fallbacks: string[]): any
-}
-
-/**
  * Common TypeScript interfaces between versions.
  */
 export interface TSCommon {

--- a/src/util/messages.ts
+++ b/src/util/messages.ts
@@ -4,6 +4,7 @@
  * @internal
  */
 export enum Errors {
+  LoadingModuleFailed = 'Loading module {{module}} failed with error: {{error}}',
   UnableToLoadOneModule = 'Unable to load the module {{module}}. {{reason}} To fix it:\n{{fix}}',
   UnableToLoadAnyModule = 'Unable to load any of these modules: {{module}}. {{reason}}. To fix it:\n{{fix}}',
   TypesUnavailableWithoutTypeCheck = 'Type information is unavailable with "isolatedModules"',


### PR DESCRIPTION
The importer is responsible of importing and patching modules with configurable fallbacks. If one is missing, it goes to the next one. Previously if a module existed but was failing when loading it with `require`, it'd report as missing instead of failing. Now it bubbles the error correctly.