### PR TITLE
use semver >= v5.5.0 so semver.coerce is there

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "json5": "2.x",
     "make-error": "1.x",
     "mkdirp": "0.x",
-    "semver": "5.x",
+    "semver": "^5.5",
     "yargs-parser": "10.x"
   },
   "peerDependencies": {


### PR DESCRIPTION
using `semver.coerce` here https://github.com/kulshekhar/ts-jest/blob/v23.10.2/src/util/hacks.ts#L20 
and we have it as 5.x in package.json, but `.coerce` was introduced in semver v5.5.0 https://github.com/npm/node-semver/commit/e7092b4040360f1b24c1119defe45ed3b38a77ef , so need to be more explicit about semver version

cc @huafu 