### PR TITLE
Fix preset typings

### DIFF
--- a/e2e/__cases__/module-kinds/ts-jest-tools.spec.ts
+++ b/e2e/__cases__/module-kinds/ts-jest-tools.spec.ts
@@ -1,0 +1,21 @@
+// preset and utils should work all the time
+import * as presets from 'ts-jest/presets'
+import * as utils from 'ts-jest/utils'
+
+test('presets', () => {
+  const presetKeys = ['transform', 'testMatch', 'moduleFileExtensions']
+  expect(Object.keys(presets.defaults)).toEqual(presetKeys)
+  expect(presets.defaults).toEqual(require('ts-jest/presets/default/jest-preset'))
+  expect(presets.defaults).toEqual(require('ts-jest/jest-preset'))
+  expect(Object.keys(presets.jsWithTs)).toEqual(presetKeys)
+  expect(presets.jsWithTs).toEqual(require('ts-jest/presets/js-with-ts/jest-preset'))
+  expect(Object.keys(presets.jsWithBabel)).toEqual(presetKeys)
+  expect(presets.jsWithBabel).toEqual(require('ts-jest/presets/js-with-babel/jest-preset'))
+})
+
+test('utils', () => {
+  expect(Object.keys(utils)).toEqual(['mocked', 'createJestPreset', 'pathsToModuleNameMapper'])
+  expect(typeof utils.mocked).toBe('function')
+  expect(typeof utils.createJestPreset).toBe('function')
+  expect(typeof utils.pathsToModuleNameMapper).toBe('function')
+})

--- a/e2e/__tests__/module-kinds/__snapshots__/amd.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/amd.test.ts.snap
@@ -8,6 +8,7 @@ exports[`run with options: {"module":"amd","allowSyntheticDefaultImports":false}
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
@@ -33,8 +34,8 @@ exports[`run with options: {"module":"amd","allowSyntheticDefaultImports":false}
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -47,6 +48,7 @@ exports[`run with options: {"module":"amd","allowSyntheticDefaultImports":true} 
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -67,8 +69,8 @@ exports[`run with options: {"module":"amd","allowSyntheticDefaultImports":true} 
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -81,6 +83,7 @@ exports[`run with options: {"module":"amd","esModuleInterop":true} 1`] = `
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   import-star.spec.ts:5:10 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof lib' has no compatible call signatures.
@@ -112,8 +115,8 @@ exports[`run with options: {"module":"amd","esModuleInterop":true} 1`] = `
   
   PASS ./import-default.spec.ts
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -128,6 +131,7 @@ exports[`run with options: {"module":"amd"} 1`] = `
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -148,8 +152,8 @@ exports[`run with options: {"module":"amd"} 1`] = `
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.

--- a/e2e/__tests__/module-kinds/__snapshots__/commonjs.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/commonjs.test.ts.snap
@@ -6,6 +6,7 @@ exports[`run with options: {"module":"commonjs","allowSyntheticDefaultImports":f
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
@@ -31,8 +32,8 @@ exports[`run with options: {"module":"commonjs","allowSyntheticDefaultImports":f
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -45,6 +46,7 @@ exports[`run with options: {"module":"commonjs","allowSyntheticDefaultImports":t
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -65,8 +67,8 @@ exports[`run with options: {"module":"commonjs","allowSyntheticDefaultImports":t
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -79,6 +81,7 @@ exports[`run with options: {"module":"commonjs","esModuleInterop":true} 1`] = `
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   import-star.spec.ts:5:10 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof lib' has no compatible call signatures.
@@ -110,8 +113,8 @@ exports[`run with options: {"module":"commonjs","esModuleInterop":true} 1`] = `
   
   PASS ./import-default.spec.ts
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -124,6 +127,7 @@ exports[`run with options: {"module":"commonjs"} 1`] = `
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
@@ -149,8 +153,8 @@ exports[`run with options: {"module":"commonjs"} 1`] = `
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.

--- a/e2e/__tests__/module-kinds/__snapshots__/es2015.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/es2015.test.ts.snap
@@ -8,6 +8,7 @@ exports[`run with options: {"module":"es2015","allowSyntheticDefaultImports":fal
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
@@ -33,8 +34,8 @@ exports[`run with options: {"module":"es2015","allowSyntheticDefaultImports":fal
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -47,6 +48,7 @@ exports[`run with options: {"module":"es2015","allowSyntheticDefaultImports":tru
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -67,8 +69,8 @@ exports[`run with options: {"module":"es2015","allowSyntheticDefaultImports":tru
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -81,6 +83,7 @@ exports[`run with options: {"module":"es2015","esModuleInterop":true} 1`] = `
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   import-star.spec.ts:5:10 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof lib' has no compatible call signatures.
@@ -112,8 +115,8 @@ exports[`run with options: {"module":"es2015","esModuleInterop":true} 1`] = `
   
   PASS ./import-default.spec.ts
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -128,6 +131,7 @@ exports[`run with options: {"module":"es2015"} 1`] = `
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -148,8 +152,8 @@ exports[`run with options: {"module":"es2015"} 1`] = `
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.

--- a/e2e/__tests__/module-kinds/__snapshots__/esnext.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/esnext.test.ts.snap
@@ -8,6 +8,7 @@ exports[`run with options: {"module":"esnext","allowSyntheticDefaultImports":fal
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
@@ -33,8 +34,8 @@ exports[`run with options: {"module":"esnext","allowSyntheticDefaultImports":fal
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -47,6 +48,7 @@ exports[`run with options: {"module":"esnext","allowSyntheticDefaultImports":tru
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -67,8 +69,8 @@ exports[`run with options: {"module":"esnext","allowSyntheticDefaultImports":tru
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -81,6 +83,7 @@ exports[`run with options: {"module":"esnext","esModuleInterop":true} 1`] = `
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   import-star.spec.ts:5:10 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof lib' has no compatible call signatures.
@@ -112,8 +115,8 @@ exports[`run with options: {"module":"esnext","esModuleInterop":true} 1`] = `
   
   PASS ./import-default.spec.ts
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -128,6 +131,7 @@ exports[`run with options: {"module":"esnext"} 1`] = `
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -148,8 +152,8 @@ exports[`run with options: {"module":"esnext"} 1`] = `
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.

--- a/e2e/__tests__/module-kinds/__snapshots__/none.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/none.test.ts.snap
@@ -8,6 +8,7 @@ exports[`run with options: {"module":"none","allowSyntheticDefaultImports":false
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
@@ -33,8 +34,8 @@ exports[`run with options: {"module":"none","allowSyntheticDefaultImports":false
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -47,6 +48,7 @@ exports[`run with options: {"module":"none","allowSyntheticDefaultImports":true}
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -67,8 +69,8 @@ exports[`run with options: {"module":"none","allowSyntheticDefaultImports":true}
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -81,6 +83,7 @@ exports[`run with options: {"module":"none","esModuleInterop":true} 1`] = `
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   import-star.spec.ts:5:10 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof lib' has no compatible call signatures.
@@ -112,8 +115,8 @@ exports[`run with options: {"module":"none","esModuleInterop":true} 1`] = `
   
   PASS ./import-default.spec.ts
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -128,6 +131,7 @@ exports[`run with options: {"module":"none"} 1`] = `
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -148,8 +152,8 @@ exports[`run with options: {"module":"none"} 1`] = `
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.

--- a/e2e/__tests__/module-kinds/__snapshots__/system.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/system.test.ts.snap
@@ -8,6 +8,7 @@ exports[`run with options: {"module":"system","allowSyntheticDefaultImports":fal
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
@@ -33,8 +34,8 @@ exports[`run with options: {"module":"system","allowSyntheticDefaultImports":fal
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -47,6 +48,7 @@ exports[`run with options: {"module":"system","allowSyntheticDefaultImports":tru
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -67,8 +69,8 @@ exports[`run with options: {"module":"system","allowSyntheticDefaultImports":tru
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -81,6 +83,7 @@ exports[`run with options: {"module":"system","esModuleInterop":true} 1`] = `
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   import-star.spec.ts:5:10 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof lib' has no compatible call signatures.
@@ -112,8 +115,8 @@ exports[`run with options: {"module":"system","esModuleInterop":true} 1`] = `
   
   PASS ./import-default.spec.ts
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -128,6 +131,7 @@ exports[`run with options: {"module":"system"} 1`] = `
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -148,8 +152,8 @@ exports[`run with options: {"module":"system"} 1`] = `
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.

--- a/e2e/__tests__/module-kinds/__snapshots__/umd.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/umd.test.ts.snap
@@ -8,6 +8,7 @@ exports[`run with options: {"module":"umd","allowSyntheticDefaultImports":false}
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
@@ -33,8 +34,8 @@ exports[`run with options: {"module":"umd","allowSyntheticDefaultImports":false}
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -47,6 +48,7 @@ exports[`run with options: {"module":"umd","allowSyntheticDefaultImports":true} 
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -67,8 +69,8 @@ exports[`run with options: {"module":"umd","allowSyntheticDefaultImports":true} 
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -81,6 +83,7 @@ exports[`run with options: {"module":"umd","esModuleInterop":true} 1`] = `
   ===[ STDOUT ]===================================================================
   
   ===[ STDERR ]===================================================================
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   import-star.spec.ts:5:10 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof lib' has no compatible call signatures.
@@ -112,8 +115,8 @@ exports[`run with options: {"module":"umd","esModuleInterop":true} 1`] = `
   
   PASS ./import-default.spec.ts
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.
@@ -128,6 +131,7 @@ exports[`run with options: {"module":"umd"} 1`] = `
   ===[ STDERR ]===================================================================
   ts-jest[config] (WARN) TypeScript diagnostics (customize using \`[jest-config].globals.ts-jest.diagnostics\` option):
   message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./ts-jest-tools.spec.ts
   PASS ./import-legacy.spec.ts
   PASS ./import-star.spec.ts
   FAIL ./import-default.spec.ts
@@ -148,8 +152,8 @@ exports[`run with options: {"module":"umd"} 1`] = `
   
         at Object.<anonymous> (import-default.spec.ts:4:22)
   
-  Test Suites: 1 failed, 2 passed, 3 total
-  Tests:       1 failed, 2 passed, 3 total
+  Test Suites: 1 failed, 3 passed, 4 total
+  Tests:       1 failed, 4 passed, 5 total
   Snapshots:   0 total
   Time:        XXs
   Ran all test suites.

--- a/presets/index.d.ts
+++ b/presets/index.d.ts
@@ -1,5 +1,5 @@
 import { TsJestPresets } from '../dist/types'
 
-export const defaults: TsJesPresets
-export const jsWithTs: TsJesPresets
-export const jsWithBabel: TsJesPresets
+export const defaults: TsJestPresets
+export const jsWithTs: TsJestPresets
+export const jsWithBabel: TsJestPresets

--- a/presets/index.d.ts
+++ b/presets/index.d.ts
@@ -1,4 +1,4 @@
-import { TsJestPresets } from '../dist/types'
+import { TsJestPresets } from '../dist/config/create-jest-preset'
 
 export const defaults: TsJestPresets
 export const jsWithTs: TsJestPresets


### PR DESCRIPTION
- invalid import in `ts-jest/presets` typings
- typos in `ts-jest/presets` typings (thanks @evpozdniakov)
- added tests for this to not reproduce, as well as tests for utils. Added tests also ensure it works with whatever values for `esModuleInterop` or `allowSyntheticDefaultImports`