### PR TITLE
Update doc to use `tsConfigFile`

### DIFF
--- a/docs/user/config/tsConfig.md
+++ b/docs/user/config/tsConfig.md
@@ -22,7 +22,7 @@ module.exports = {
   // [...]
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.test.json'
+      tsConfigFile: 'tsconfig.test.json'
     }
   }
 };
@@ -37,7 +37,7 @@ module.exports = {
   "jest": {
     "globals": {
       "ts-jest": {
-        "tsConfig": "tsconfig.test.json"
+        "tsConfigFile": "tsconfig.test.json"
       }
     }
   }


### PR DESCRIPTION
The initial doc stated that `tsConfig` allowed to specify a path to a `tsconfig.json` file. I believe the proper key is `tsConfigFile`.

This should fix the doc in here : https://kulshekhar.github.io/ts-jest/user/config/tsConfig#path-to-a-tsconfig-file 