### PR TITLE
Update babel getter to work with babel-jest@24

### DIFF
--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -336,16 +336,16 @@ export class ConfigSet {
       base = { ...base, ...babelConfig.value }
     }
 
-    // loadOptions is from babel 7+, and OptionManager is backward compatible but deprecated 6 API
-    const { OptionManager, loadOptions, version } = importer.babelCore(ImportReasons.BabelJest)
+    // loadPartialConfig is from babel 7+, and OptionManager is backward compatible but deprecated 6 API
+    const { OptionManager, loadPartialConfig, version } = importer.babelCore(ImportReasons.BabelJest)
     // cwd is only supported from babel >= 7
     if (version && semver.satisfies(version, '>=6 <7')) {
       delete base.cwd
     }
     // call babel to load options
     let config: BabelConfig
-    if (typeof loadOptions === 'function') {
-      config = loadOptions(base) as BabelConfig
+    if (typeof loadPartialConfig === 'function') {
+      config = loadPartialConfig(base).options as BabelConfig
     } else {
       config = new OptionManager().init(base) as BabelConfig
     }

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -345,7 +345,8 @@ export class ConfigSet {
     // call babel to load options
     let config: BabelConfig
     if (typeof loadPartialConfig === 'function') {
-      config = loadPartialConfig(base).options as BabelConfig
+      const partialConfig = loadPartialConfig(base)
+      config = partialConfig && partialConfig.options as BabelConfig
     } else {
       config = new OptionManager().init(base) as BabelConfig
     }


### PR DESCRIPTION
babel-jest@24 will also use loadPartialConfig to be able to mix its own options into the config in an API-conforming manner. However, loadPartialConfig will throw an assertion error if the config has not only been loaded, but also had its plugins instantiatied. loadOptions() does the whole thing, including instantiating the plugins, so it can't be used for multiple config loading passes, only the final pass.

Verified by monkey-patching the local `ts-jest` install; looks like this:

```js
            var _a = importer_1.importer.babelCore(messages_1.ImportReasons.BabelJest), OptionManager = _a.OptionManager, loadOptions = _a.loadPartialConfig, version = _a.version;
            if (version && semver_1.default.satisfies(version, '>=6 <7')) {
                delete base.cwd;
            }
            var config;
            if (typeof loadOptions === 'function') {
                console.warn('loadOptions', base)
                config = loadOptions(base).options;
            }
```

---

HOWEVER, this will just load a top level babelrc _and_ stop babel-jest from searching for more config files because the partial config includes `babelrc: false` and `configFile: false`. The `babel` getter is not aware of which filename is going to be processed so this will likely break unless everything shares the same babel config and the babel config is in the `process.cwd()`.

This is more of a starting point instead of a full fix.