### PR TITLE
fix: support Jest 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "yargs-parser": "10.x"
   },
   "peerDependencies": {
-    "jest": ">=22 <24"
+    "jest": ">=22 <=24"
   },
   "devDependencies": {
     "@commitlint/cli": "7.x",

--- a/src/util/version-checkers.spec.ts
+++ b/src/util/version-checkers.spec.ts
@@ -15,8 +15,8 @@ jest.mock('./get-package-version')
 
 const pv = mocked(_pv)
 
-describeChecker(VersionCheckers.jest, 'jest', ['22.1.3', '23.4.5'], [undefined, '21.0.0', '24.0.0'])
-describeChecker(VersionCheckers.babelJest, 'babel-jest', ['22.1.3', '23.4.5'], [undefined, '21.0.0', '24.0.0'])
+describeChecker(VersionCheckers.jest, 'jest', ['22.1.3', '23.4.5'], [undefined, '21.0.0', '25.0.0'])
+describeChecker(VersionCheckers.babelJest, 'babel-jest', ['22.1.3', '23.4.5'], [undefined, '21.0.0', '25.0.0'])
 describeChecker(
   VersionCheckers.babelCoreLegacy,
   'babel-core',

--- a/src/util/version-checkers.ts
+++ b/src/util/version-checkers.ts
@@ -10,9 +10,9 @@ const logger = rootLogger.child({ namespace: 'versions' })
  * @internal
  */
 export enum ExpectedVersions {
-  Jest = '>=22 <24',
+  Jest = '>=22 <=24',
   TypeScript = '>=2.7 <4',
-  BabelJest = '>=22 <24',
+  BabelJest = '>=22 <=24',
   BabelCoreLegacy = '>=6 <7 || 7.0.0-bridge.0',
   BabelCore = '>=7.0.0-beta.0 <8',
 }


### PR DESCRIPTION
Trying in a simplest possible way to remove the warning that `ts-jest` is not tested/compatible with Jest 24 and make it compatible. https://github.com/kulshekhar/ts-jest/issues/961

