### PR TITLE
fix: update call to globIgnore (#1002)

### DIFF
--- a/scripts/lib/bundle.js
+++ b/scripts/lib/bundle.js
@@ -25,6 +25,7 @@ function readPackageDigest() {
 
 function computePackageDigest(noWriteFile = false) {
   const files = globIgnore(join(rootDir, '**'), {
+    absolute: true,
     ignore: readFileSync(join(rootDir, '.npmignore'))
       .toString('utf8')
       .split(/\n/g)


### PR DESCRIPTION
globIgnore now requires the 'absolute' option to be specified.