### PR TITLE
fix(helpers): add second type param to jest.MockInstance

### DIFF
--- a/src/util/testing.ts
+++ b/src/util/testing.ts
@@ -1,32 +1,36 @@
-interface MockWithArgs<T> extends Function, jest.MockInstance<T> {
-  new (...args: ArgumentsOf<T>): T
-  (...args: ArgumentsOf<T>): any
-}
-
 // tslint:disable-next-line:ban-types
 type MethodKeysOf<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]
 // tslint:disable-next-line:ban-types
 type PropertyKeysOf<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
 type ArgumentsOf<T> = T extends (...args: infer A) => any ? A : never
-interface MockWithArgs<T> extends Function, jest.MockInstance<T> {
+interface MockWithArgs<T, Y extends any[]> extends Function, jest.MockInstance<T, Y> {
   new (...args: ArgumentsOf<T>): T
   (...args: ArgumentsOf<T>): any
 }
 
-type MockedFunction<T> = MockWithArgs<T> & { [K in keyof T]: T[K] }
-type MockedFunctionDeep<T> = MockWithArgs<T> & MockedObjectDeep<T>
-type MockedObject<T> = { [K in MethodKeysOf<T>]: MockedFunction<T[K]> } & { [K in PropertyKeysOf<T>]: T[K] }
-type MockedObjectDeep<T> = { [K in MethodKeysOf<T>]: MockedFunctionDeep<T[K]> } &
-  { [K in PropertyKeysOf<T>]: MaybeMockedDeep<T[K]> }
+type MockedFunction<T, Y extends any[]> = MockWithArgs<T, Y> & { [K in keyof T]: T[K] }
+type MockedFunctionDeep<T, Y extends any[]> = MockWithArgs<T, Y> & MockedObjectDeep<T, Y>
+type MockedObject<T, Y extends any[]> = { [K in MethodKeysOf<T>]: MockedFunction<T[K], Y> } &
+  { [K in PropertyKeysOf<T>]: T[K] }
+type MockedObjectDeep<T, Y extends any[]> = { [K in MethodKeysOf<T>]: MockedFunctionDeep<T[K], Y> } &
+  { [K in PropertyKeysOf<T>]: MaybeMockedDeep<T[K], Y> }
 
 // tslint:disable-next-line:ban-types
-export type MaybeMockedDeep<T> = T extends Function ? MockedFunctionDeep<T> : T extends object ? MockedObjectDeep<T> : T
+export type MaybeMockedDeep<T, Y extends any[]> = T extends Function
+  ? MockedFunctionDeep<T, Y>
+  : T extends object
+  ? MockedObjectDeep<T, Y>
+  : T
 // tslint:disable-next-line:ban-types
-export type MaybeMocked<T> = T extends Function ? MockedFunction<T> : T extends object ? MockedObject<T> : T
+export type MaybeMocked<T, Y extends any[]> = T extends Function
+  ? MockedFunction<T, Y>
+  : T extends object
+  ? MockedObject<T, Y>
+  : T
 
 // the typings test helper
-export function mocked<T>(item: T, deep?: false): MaybeMocked<T>
-export function mocked<T>(item: T, deep: true): MaybeMockedDeep<T>
-export function mocked<T>(item: T, _deep = false): MaybeMocked<T> | MaybeMockedDeep<T> {
+export function mocked<T, Y extends any[]>(item: T, deep?: false): MaybeMocked<T, Y>
+export function mocked<T, Y extends any[]>(item: T, deep: true): MaybeMockedDeep<T, Y>
+export function mocked<T, Y extends any[]>(item: T, _deep = false): MaybeMocked<T, Y> | MaybeMockedDeep<T, Y> {
   return item as any
 }


### PR DESCRIPTION
`jest.MockInstance` was updated to accept a second type argument for improved type inference [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32579/files). This is a first attempt to port those changes to this project.

I don't believe this PR is correct (the e2e suite fails) but hopefully someone with better TS knowledge can patch this up.

Closes #998.