### PR TITLE
fix: #825 handle symlinked modules (ala pnpm) correctly

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -162,6 +162,7 @@ export function createCompiler(configs: ConfigSet): TsCompiler {
       readDirectory: ts.sys.readDirectory,
       getDirectories: ts.sys.getDirectories,
       directoryExists: ts.sys.directoryExists,
+      realpath: ts.sys.realpath,
       getNewLine: () => '\n',
       getCurrentDirectory: () => cwd,
       getCompilationSettings: () => compilerOptions,


### PR DESCRIPTION
I was having problems with ts-jest failing to compile in my `pnpm` monorepo with weird errors because it apparently wasn't finding dependencies of `@types` packages, despite the fact that `tsc` works fine. This change fixes it.

The reason is that `pnpm` symlinks packages like this:
```
> ls -l node_modules/@types/
express -> ../../../../node_modules/.registry/@types/express/4.17.0/node_modules/@types/express
```

The transitive dependencies are not in the consuming package's `node_modules` or its parents, instead they are in `../../../node_modules/.registry/@types/express/4.17.0/node_modules/`, so it's necessary to resolve the symlink to its  referent in order to find the  dependencies. When ts-jest doesn't implement this resolution, TypeScript assumes all the files are not symlinks and doesn't find the dependencies. Depending on how dependencies  are structured this results in missing type information which causes strict type checking to  fail.