### PR TITLE
chore(index): add `@deprecated` jsdoc to deprecated utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,11 @@ const warn = rootLogger.child({ [LogContexts.logLevel]: LogLevels.warn })
 const helperMoved = <T extends (...args: any[]) => any>(name: string, helper: T) =>
   warn.wrap(interpolate(Deprecateds.HelperMovedToUtils, { helper: name }), helper)
 
+/** @deprecated */
 export const mocked = helperMoved('mocked', mockedCore)
+/** @deprecated */
 export const createJestPreset = helperMoved('createJestPreset', createJestPresetCore)
+/** @deprecated */
 export const pathsToModuleNameMapper = helperMoved('pathsToModuleNameMapper', pathsToModuleNameMapperCore)
 
 // tslint:disable-next-line:no-var-requires


### PR DESCRIPTION
These should be carried into the `index.d.ts` by tsc, and the ideally IDEs should avoid them when more suitable non-deprecated imports of the same name can be found.

Some IDEs will also mark usages of `@deprecated` identifiers w/ a strikethrough, making it easier & quicker to discover that they're deprecated :D