### PR TITLE
chore: upgrade yargs parser to v16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2010,7 +2010,8 @@
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
@@ -2769,8 +2770,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -6872,6 +6872,17 @@
         "redent": "^2.0.0",
         "trim-newlines": "^2.0.0",
         "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
     },
     "merge-stream": {
@@ -9464,11 +9475,19 @@
       }
     },
     "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
     "bs-logger": "0.x",
     "buffer-from": "1.x",
     "fast-json-stable-stringify": "2.x",
-    "lodash.memoize": "4.x",
     "json5": "2.x",
+    "lodash.memoize": "4.x",
     "make-error": "1.x",
     "mkdirp": "0.x",
     "resolve": "1.x",
     "semver": "^5.5",
-    "yargs-parser": "10.x"
+    "yargs-parser": "^16.1.0"
   },
   "peerDependencies": {
     "jest": ">=25 <26"
@@ -99,6 +99,7 @@
     "@types/resolve": "latest",
     "@types/semver": "latest",
     "@types/yargs": "latest",
+    "@types/yargs-parser": "^15.0.0",
     "conventional-changelog-cli": "2.x",
     "cross-spawn": "latest",
     "eslint": "latest",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,6 @@
 import { LogContexts, Logger } from 'bs-logger'
 import { Arguments } from 'yargs'
-import yargsParser = require('yargs-parser')
+import * as yargsParser from 'yargs-parser'
 
 import { rootLogger } from '../util/logger'
 

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -15,8 +15,3 @@ declare module 'jest-config' {
   import 'jest'
   export const defaults: jest.InitialOptions
 }
-
-declare module 'yargs-parser' {
-  import yargs from 'yargs'
-  export = yargs.parse
-}


### PR DESCRIPTION
Upgraded yargs-parser to v16 and moved to using types from DefinitelyTyped (Using v15 since v16 is not available but looks like API-wise nothing has changed since 15).

Closes https://github.com/kulshekhar/ts-jest/issues/1374