### PR TITLE
docs:fix-doc-typos-and-links Fix slack links and typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via [slack](https://bit.ly/ts-jest-slack) or [issue](https://github.com/kulshekhar/ts-jest/issues) with the owners of this repository before making a change.
+When contributing to this repository, please first discuss the change you wish to make via [slack](https://bit.ly/3bRHFPQ) or [issue](https://github.com/kulshekhar/ts-jest/issues) with the owners of this repository before making a change.
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It supports all features of TypeScript including type-checking. [Read more about
 
 [<img src="./docs/assets/img/documentation.png" align="left" height="24"> View the online documentation (usage & technical)](https://kulshekhar.github.io/ts-jest)
 
-[<img src="./docs/assets/img/slack.png" align="left" height="24"> Ask for some help in the `ts-jest` community of Slack](https://join.slack.com/t/ts-jest/shared_invite/enQtNDE1ODQ0OTEzMTczLWI5NTQ4ZmEzOTYxYzM2NjhiZDM2ZTI3MGYyYjA2Y2E1YTMxMjUyYTcxNTlmNjAyZTc2Nzk4YTRmZmRhYmZmYTg)
+[<img src="./docs/assets/img/slack.png" align="left" height="24"> Ask for some help in the `ts-jest` community of Slack](https://bit.ly/3bRHFPQ)
 
 <!--
 [<img src="./docs/assets/img/troubleshooting.png" align="left" height="24"> Before reporting any issue, be sure to check the troubleshooting page](https://kulshekhar.github.io/ts-jest/user/troubleshooting)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ It supports all features of TypeScript including type-checking. [Read more about
 
 ---
 
-<img src="assets/img/slack.png" align="left" height="24"> [Ask for some help in the `ts-jest` community of Slack](https://bit.ly/ts-jest-slack)
+<img src="assets/img/slack.png" align="left" height="24"> [Ask for some help in the `ts-jest` community of Slack](https://bit.ly/3bRHFPQ)
 
 <!--
 <img src="assets/img/troubleshooting.png" align="left" height="24"> [Before reporting any issue, be sure to check the troubleshooting page](user/troubleshooting)

--- a/docs/user/config/diagnostics.md
+++ b/docs/user/config/diagnostics.md
@@ -2,7 +2,7 @@
 title: Diagnostics option
 ---
 
-The `diagnostics` option allows to configure error reporting.
+The `diagnostics` option configures error reporting.
 It can both be enabled/disabled entirely or limited to a specific type of errors and/or files.
 
 If a diagnostic is not filtered out, `ts-jest` will fail the compilation and your test.
@@ -15,7 +15,7 @@ This might lead to slightly better performance, especially if you're not using J
 
 ### Advanced configuration
 
-The option's value can also accept an object for more advanced configuration. Each config. key is optional:
+The `diagnostics` option's value can also accept an object for more advanced configuration. Each config. key is optional:
 
 - **`warnOnly`**: If specified and `true`, diagnostics will be reported but won't stop compilation (default: _disabled_).
 - **`ignoreCodes`**: List of TypeScript error codes to ignore. Complete list can be found [there](https://github.com/Microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json). By default here are the ones ignored:


### PR DESCRIPTION
**What**
Fixing broken slack links and some minor typos in documentation

**Discussion**
https://ts-jest.slack.com/archives/CC6B0LYJD/p1582074011015000

**Test Steps**
1. Review documentation changes
2. Test slack bit.ly link: `https://bit.ly/3bRHFPQ`