### PR TITLE
Add jest-config to dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "glob-gitignore": "latest",
     "husky": "3.x",
     "jest": "25.x",
+    "jest-config": "25.x",
     "js-yaml": "latest",
     "lint-staged": "latest",
     "lodash.merge": "4.x",


### PR DESCRIPTION
It seems that ts-jest is requiring jest-config somewhere? While yarn1 and npm use flat dependency tree, pnpm does not.

### Additional Suggestion

[dependency-check](https://www.npmjs.com/package/dependency-check) or [depcheck](https://www.npmjs.com/package/depcheck) may help you detect missing dependencies from package.json.

---

I did not update package-lock.json because I'm lazy, I edited the file directly on GitHub website. If updating package-lock.json is required, then please consider this an issue instead of a pull request.