### PR TITLE
fix(config): set default outDir to `$$ts-jest` when `allowJs` is enabled without `outDir`

### DIFF
--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -495,6 +495,10 @@ describe('typescript', () => {
     })
   })
 
+  it('should include default outDir $$ts-jest$$ when allowJs is enabled and no outDir from config', () => {
+    expect(get(void 0, { tsConfig: { allowJs: true } }).options.outDir).toBe('$$ts-jest$$')
+  })
+
   it('should be able to read extends', () => {
     const cs = createConfigSet({
       tsJestConfig: { tsConfig: 'tsconfig.build.json' },

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -714,6 +714,10 @@ export class ConfigSet {
         finalOptions.allowSyntheticDefaultImports = true
       }
     }
+    // Make sure when allowJs is enabled, outDir is set otherwise we run into error: Cannot write file ... because it would overwrite input
+    if (finalOptions.allowJs && !finalOptions.outDir) {
+      finalOptions.outDir = '$$ts-jest$$'
+    }
 
     // ensure undefined are removed and other values are overridden
     for (const key of Object.keys(forcedOptions)) {


### PR DESCRIPTION
closes #1471 