### PR TITLE
fix(config): use original jest config object

### DIFF
--- a/e2e/__tests__/__snapshots__/diagnostics.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/diagnostics.test.ts.snap
@@ -242,7 +242,7 @@ exports[`With diagnostics throw using incremental program with unsupported versi
   
       TypeError: ts.createIncrementalCompilerHost is not a function
   
-        at Object.exports.compileUsingProgram (../../__templates__/with-typescript-2-7/node_modules/ts-jest/dist/compiler/program.js:47:19)
+        at Object.exports.compileUsingProgram (../../__templates__/with-typescript-2-7/node_modules/ts-jest/dist/compiler/program.js:46:19)
   
   Test Suites: 1 failed, 1 total
   Tests:       0 total
@@ -264,7 +264,7 @@ exports[`With diagnostics throw using incremental program with unsupported versi
   
       TypeError: ts.createIncrementalCompilerHost is not a function
   
-        at Object.exports.compileUsingProgram (../../__templates__/with-unsupported-version/node_modules/ts-jest/dist/compiler/program.js:47:19)
+        at Object.exports.compileUsingProgram (../../__templates__/with-unsupported-version/node_modules/ts-jest/dist/compiler/program.js:46:19)
   
   Test Suites: 1 failed, 1 total
   Tests:       0 total

--- a/src/__helpers__/fakers.ts
+++ b/src/__helpers__/fakers.ts
@@ -69,7 +69,12 @@ export function makeCompiler({
     ...(tsJestConfig.diagnostics as any),
     pretty: false,
   }
-  jestConfig = { ...jestConfig, testMatch: ['^.+\\.tsx?$'], testRegex: ['^.+\\.[tj]sx?$'] }
+  const testRegex = ['^.+\\.[tj]sx?$']
+  jestConfig = {
+    ...jestConfig,
+    testMatch: ['^.+\\.tsx?$'],
+    testRegex: jestConfig?.testRegex ? testRegex.concat(jestConfig.testRegex) : testRegex,
+  }
   const cs = new ConfigSet(getJestConfig(jestConfig, tsJestConfig), parentConfig)
 
   return createCompiler(cs)

--- a/src/compiler/compiler-utils.ts
+++ b/src/compiler/compiler-utils.ts
@@ -1,5 +1,6 @@
 import { Logger } from 'bs-logger'
 import { writeFileSync } from 'fs'
+import micromatch = require('micromatch')
 import { join, normalize } from 'path'
 import * as _ts from 'typescript'
 
@@ -50,4 +51,10 @@ export function cacheResolvedModules(
     memoryCache.resolvedModules[fileName].testFileContent = fileContent
     writeFileSync(getResolvedModulesCache(cacheDir), JSON.stringify(memoryCache.resolvedModules))
   }
+}
+
+export function isTestFile(testMatchPatterns: [string, RegExp], fileName: string) {
+  return testMatchPatterns.some(pattern =>
+    typeof pattern === 'string' ? micromatch.isMatch(fileName, pattern) : pattern.test(fileName),
+  )
 }

--- a/src/compiler/language-service.ts
+++ b/src/compiler/language-service.ts
@@ -1,6 +1,5 @@
 import { LogContexts, LogLevels, Logger } from 'bs-logger'
 import memoize = require('lodash.memoize')
-import micromatch = require('micromatch')
 import { basename, normalize, relative } from 'path'
 import * as _ts from 'typescript'
 
@@ -8,7 +7,7 @@ import { ConfigSet } from '../config/config-set'
 import { CompilerInstance, MemoryCache, SourceOutput } from '../types'
 import { Errors, interpolate } from '../util/messages'
 
-import { cacheResolvedModules, hasOwn } from './compiler-utils'
+import { cacheResolvedModules, hasOwn, isTestFile } from './compiler-utils'
 
 function doTypeChecking(configs: ConfigSet, fileName: string, service: _ts.LanguageService, logger: Logger) {
   if (configs.shouldReportDiagnostic(fileName)) {
@@ -120,9 +119,8 @@ export const compileUsingLanguageService = (
       /**
        * We don't need the following logic with no cache run because no cache always gives correct typing
        */
-      /* istanbul ignore next (covered by e2e) */
       if (cacheDir) {
-        if (micromatch.isMatch(normalizedFileName, configs.testMatchPatterns)) {
+        if (isTestFile(configs.testMatchPatterns, normalizedFileName)) {
           cacheResolvedModules(normalizedFileName, code, memoryCache, service.getProgram()!, cacheDir, logger)
         } else {
           /* istanbul ignore next (covered by e2e) */

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1,6 +1,5 @@
 import { LogContexts, LogLevels, Logger } from 'bs-logger'
 import memoize = require('lodash.memoize')
-import micromatch = require('micromatch')
 import { basename, normalize, relative } from 'path'
 import * as _ts from 'typescript'
 
@@ -8,7 +7,7 @@ import { ConfigSet } from '../config/config-set'
 import { CompilerInstance, MemoryCache, SourceOutput } from '../types'
 import { Errors, interpolate } from '../util/messages'
 
-import { cacheResolvedModules, hasOwn } from './compiler-utils'
+import { cacheResolvedModules, hasOwn, isTestFile } from './compiler-utils'
 
 function doTypeChecking(configs: ConfigSet, fileName: string, program: _ts.Program, logger: Logger) {
   if (configs.shouldReportDiagnostic(fileName)) {
@@ -166,9 +165,8 @@ export const compileUsingProgram = (configs: ConfigSet, logger: Logger, memoryCa
       /**
        * We don't need the following logic with no cache run because no cache always gives correct typing
        */
-      /* istanbul ignore next (covered by e2e) */
       if (cacheDir) {
-        if (micromatch.isMatch(normalizedFileName, configs.testMatchPatterns)) {
+        if (isTestFile(configs.testMatchPatterns, normalizedFileName)) {
           cacheResolvedModules(normalizedFileName, code, memoryCache, program, cacheDir, logger)
         } else {
           /* istanbul ignore next (covered by e2e) */

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -217,9 +217,9 @@ describe('tsJest', () => {
       expect(cs.tsJest.babelConfig).toBeUndefined()
       expect(cs.babel).toBeUndefined()
       expect(logger.target.lines[2]).toMatchInlineSnapshot(`
-"[level:20] babel is disabled
-"
-`)
+        "[level:20] babel is disabled
+        "
+      `)
     })
 
     it('should be correct for true', () => {
@@ -294,9 +294,9 @@ describe('tsJest', () => {
       expect(cs.tsJest.babelConfig!.kind).toEqual('inline')
       expect(cs.babel).toEqual(expect.objectContaining(babelConfig))
       expect(logger.target.lines[2]).toMatchInlineSnapshot(`
-"[level:20] normalized babel config via ts-jest option
-"
-`)
+        "[level:20] normalized babel config via ts-jest option
+        "
+      `)
     })
 
     it('should be correct for inline config', () => {
@@ -312,9 +312,9 @@ describe('tsJest', () => {
       expect(cs.tsJest.babelConfig!.kind).toEqual('inline')
       expect(cs.babel).toEqual(expect.objectContaining(CONFIG))
       expect(logger.target.lines[2]).toMatchInlineSnapshot(`
-"[level:20] normalized babel config via ts-jest option
-"
-`)
+        "[level:20] normalized babel config via ts-jest option
+        "
+      `)
     })
   }) // babelConfig
 
@@ -425,15 +425,15 @@ describe('makeDiagnostic', () => {
   it('should set category', () => {
     expect(cs.makeDiagnostic(4321, 'foo might be bar', { category: ts.DiagnosticCategory.Error }))
       .toMatchInlineSnapshot(`
-Object {
-  "category": 1,
-  "code": 4321,
-  "file": undefined,
-  "length": undefined,
-  "messageText": "foo might be bar",
-  "start": undefined,
-}
-`)
+      Object {
+        "category": 1,
+        "code": 4321,
+        "file": undefined,
+        "length": undefined,
+        "messageText": "foo might be bar",
+        "start": undefined,
+      }
+    `)
   })
 }) // makeDiagnostic
 
@@ -494,9 +494,9 @@ describe('typescript', () => {
       esModuleInterop: false,
     })
     expect(target.lines.warn.join()).toMatchInlineSnapshot(`
-"[level:40] message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
-"
-`)
+      "[level:40] message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+      "
+    `)
   })
 
   it('should not warn neither set synth. default imports if using babel', () => {
@@ -976,11 +976,11 @@ describe('raiseDiagnostics', () => {
       expect(() => raiseDiagnostics([])).not.toThrow()
       expect(() => raiseDiagnostics([makeDiagnostic()])).not.toThrow()
       expect(logger.target.lines).toMatchInlineSnapshot(`
-      Array [
-        "[level:40] [TS9999] foo
-      ",
-      ]
-    `)
+              Array [
+                "[level:40] [TS9999] foo
+              ",
+              ]
+          `)
     })
   })
 

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -186,6 +186,7 @@ export class ConfigSet {
         ...globals['ts-jest'],
       }
     }
+
     this.logger.debug({ jestConfig: config }, 'normalized jest config')
 
     return config
@@ -195,8 +196,8 @@ export class ConfigSet {
    * @internal
    */
   @Memoize()
-  get testMatchPatterns(): string[] {
-    return this.jest.testMatch.concat(this.jest.testRegex)
+  get testMatchPatterns(): [string, RegExp] {
+    return this.jest.testMatch.concat(this.jest.testRegex) as [string, RegExp]
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Jest config string doesn't contain the correct value for `testRegex` therefore `micromatch` in compiler failed to validate file name against this value, see related issue reported for `jest` team to handle: https://github.com/facebook/jest/issues/9778. 

This PR switches to use original jest config object to get the correct value for `testRegex`, close #1509 


## Test plan

Green CI


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**