### PR TITLE
chore: correct set debug log in Bug/Regression template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -24,7 +24,7 @@ Issues without a reproduction link are likely to stall.
 -->
 
 ## Debug log:
-<!-- You can activate the debug logger by setting the environment variable TS_JEST_LOG="ts-jest.log" before running tests. 
+<!-- You can activate the debug logger by setting the environment variable TS_JEST_LOG=ts-jest.log before running tests. 
 The output of the logger will be in **ts-jest.log** in CWD, paste it in the below section: 
 -->
 

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -30,7 +30,7 @@ Issues without a reproduction link are likely to stall.
 -->
 
 ## Debug log:
-<!-- You can activate the debug logger by setting the environment variable TS_JEST_LOG="ts-jest.log" before running tests. 
+<!-- You can activate the debug logger by setting the environment variable TS_JEST_LOG=ts-jest.log before running tests. 
 The output of the logger will be in **ts-jest.log** in CWD, paste it in the below section: 
 -->
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Correct set debug log instruction for Bug and Regression templates. On Windows, `set TS_JEST_LOG="ts-jest.log"` doesn't work but only `set TS_JEST_LOG=ts-jest.log` works. 

For Linux/MacOS both `TS_JEST_LOG="ts-jest.log"` and `TS_JEST_LOG=ts-jest.log` work.

Close #1532 

## Test plan

**N.A.**


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
