### PR TITLE
chore: rename some files and methods in compiler area

### DIFF
--- a/src/__helpers__/fakers.ts
+++ b/src/__helpers__/fakers.ts
@@ -1,7 +1,7 @@
 import { Config } from '@jest/types'
 import { resolve } from 'path'
 
-import { createCompiler } from '../compiler/instance'
+import { createCompilerInstance } from '../compiler/instance'
 import { ConfigSet } from '../config/config-set'
 import { BabelConfig, TsJestConfig, TsJestGlobalOptions } from '../types'
 import { ImportReasons } from '../util/messages'
@@ -76,5 +76,5 @@ export function makeCompiler({
   }
   const cs = new ConfigSet(getJestConfig(jestConfig, tsJestConfig), parentConfig)
 
-  return createCompiler(cs)
+  return createCompilerInstance(cs)
 }

--- a/src/compiler/__snapshots__/language-service.spec.ts.snap
+++ b/src/compiler/__snapshots__/language-service.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`language service should compile js file for allowJs true with outDir 1`] = `
+exports[`Language service should compile js file for allowJs true with outDir 1`] = `
   ===[ FILE: test-allow-js-with-outDir.js ]=======================================
   "use strict";
   Object.defineProperty(exports, "__esModule", { value: true });
@@ -18,7 +18,7 @@ exports[`language service should compile js file for allowJs true with outDir 1`
   ================================================================================
 `;
 
-exports[`language service should compile js file for allowJs true without outDir 1`] = `
+exports[`Language service should compile js file for allowJs true without outDir 1`] = `
   ===[ FILE: test-allow-js-no-outDir.js ]=========================================
   "use strict";
   Object.defineProperty(exports, "__esModule", { value: true });
@@ -36,7 +36,7 @@ exports[`language service should compile js file for allowJs true without outDir
   ================================================================================
 `;
 
-exports[`language service should compile tsx file for jsx preserve 1`] = `
+exports[`Language service should compile tsx file for jsx preserve 1`] = `
   ===[ FILE: test-jsx-preserve.tsx ]==============================================
   "use strict";
   var App = function () {
@@ -60,7 +60,7 @@ exports[`language service should compile tsx file for jsx preserve 1`] = `
   ================================================================================
 `;
 
-exports[`language service should compile tsx file for other jsx options 1`] = `
+exports[`Language service should compile tsx file for other jsx options 1`] = `
   ===[ FILE: test-jsx-options.tsx ]===============================================
   "use strict";
   var App = function () {
@@ -84,14 +84,14 @@ exports[`language service should compile tsx file for other jsx options 1`] = `
   ================================================================================
 `;
 
-exports[`language service should report diagnostics related to typings with pathRegex config matches file name 1`] = `"test-match-regex-diagnostics.ts(3,7): error TS2322: Type 'number' is not assignable to type 'string'."`;
+exports[`Language service should report diagnostics related to typings with pathRegex config matches file name 1`] = `"test-match-regex-diagnostics.ts(3,7): error TS2322: Type 'number' is not assignable to type 'string'."`;
 
-exports[`language service should throw error when cannot compile 1`] = `
+exports[`Language service should throw error when cannot compile 1`] = `
 "Unable to require \`.d.ts\` file for file: test-cannot-compile.d.ts.
 This is usually the result of a faulty configuration or import. Make sure there is a \`.js\`, \`.json\` or another executable extension available alongside \`test-cannot-compile.d.ts\`."
 `;
 
-exports[`language service should use the cache 3`] = `
+exports[`Language service should use the cache 3`] = `
   ===[ FILE: test-cache.ts ]======================================================
   console.log("hello");
   //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoidGVzdC1jYWNoZS50cyIsIm1hcHBpbmdzIjoiQUFBQSxPQUFPLENBQUMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxDQUFBIiwibmFtZXMiOltdLCJzb3VyY2VzIjpbInRlc3QtY2FjaGUudHMiXSwic291cmNlc0NvbnRlbnQiOlsiY29uc29sZS5sb2coXCJoZWxsb1wiKSJdLCJ2ZXJzaW9uIjozfQ==

--- a/src/compiler/__snapshots__/transpiler.spec.ts.snap
+++ b/src/compiler/__snapshots__/transpiler.spec.ts.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`transpile module with isolatedModule: true should compile js file for allowJs true 1`] = `
-  ===[ FILE: src/compiler/transpile-module.spec.ts.test.js ]======================
+exports[`Transpiler should compile js file for allowJs true 1`] = `
+  ===[ FILE: src/compiler/transpiler.spec.ts.test.js ]============================
   "use strict";
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.default = 42;
-  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoiPGN3ZD4vc3JjL2NvbXBpbGVyL3RyYW5zcGlsZS1tb2R1bGUuc3BlYy50cy50ZXN0LmpzIiwibWFwcGluZ3MiOiI7O0FBQUEsa0JBQWUsRUFBRSxDQUFBIiwibmFtZXMiOltdLCJzb3VyY2VzIjpbIjxjd2Q+L3NyYy9jb21waWxlci90cmFuc3BpbGUtbW9kdWxlLnNwZWMudHMudGVzdC5qcyJdLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCA0MiJdLCJ2ZXJzaW9uIjozfQ==
+  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoiPGN3ZD4vc3JjL2NvbXBpbGVyL3RyYW5zcGlsZXIuc3BlYy50cy50ZXN0LmpzIiwibWFwcGluZ3MiOiI7O0FBQUEsa0JBQWUsRUFBRSxDQUFBIiwibmFtZXMiOltdLCJzb3VyY2VzIjpbIjxjd2Q+L3NyYy9jb21waWxlci90cmFuc3BpbGVyLnNwZWMudHMudGVzdC5qcyJdLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCA0MiJdLCJ2ZXJzaW9uIjozfQ==
   ===[ INLINE SOURCE MAPS ]=======================================================
-  file: <cwd>/src/compiler/transpile-module.spec.ts.test.js
+  file: <cwd>/src/compiler/transpiler.spec.ts.test.js
   mappings: ';;AAAA,kBAAe,EAAE,CAAA'
   names: []
   sources:
-    - <cwd>/src/compiler/transpile-module.spec.ts.test.js
+    - <cwd>/src/compiler/transpiler.spec.ts.test.js
   sourcesContent:
     - export default 42
   version: 3
   ================================================================================
 `;
 
-exports[`transpile module with isolatedModule: true should compile tsx file for jsx preserve 1`] = `
+exports[`Transpiler should compile tsx file for jsx preserve 1`] = `
   ===[ FILE: foo.tsx ]============================================================
   "use strict";
   var App = function () {
@@ -42,7 +42,7 @@ exports[`transpile module with isolatedModule: true should compile tsx file for 
   ================================================================================
 `;
 
-exports[`transpile module with isolatedModule: true should compile tsx file for other jsx options 1`] = `
+exports[`Transpiler should compile tsx file for other jsx options 1`] = `
   ===[ FILE: foo.tsx ]============================================================
   "use strict";
   var App = function () {
@@ -66,24 +66,24 @@ exports[`transpile module with isolatedModule: true should compile tsx file for 
   ================================================================================
 `;
 
-exports[`transpile module with isolatedModule: true should compile using transpileModule and not use cache 1`] = `
-  ===[ FILE: src/compiler/transpile-module.spec.ts ]==============================
+exports[`Transpiler should compile using transpileModule and not use cache 1`] = `
+  ===[ FILE: src/compiler/transpiler.spec.ts ]====================================
   "use strict";
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.default = 42;
-  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoiPGN3ZD4vc3JjL2NvbXBpbGVyL3RyYW5zcGlsZS1tb2R1bGUuc3BlYy50cyIsIm1hcHBpbmdzIjoiOztBQUFBLGtCQUFlLEVBQUUsQ0FBQSIsIm5hbWVzIjpbXSwic291cmNlcyI6WyI8Y3dkPi9zcmMvY29tcGlsZXIvdHJhbnNwaWxlLW1vZHVsZS5zcGVjLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydCBkZWZhdWx0IDQyIl0sInZlcnNpb24iOjN9
+  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoiPGN3ZD4vc3JjL2NvbXBpbGVyL3RyYW5zcGlsZXIuc3BlYy50cyIsIm1hcHBpbmdzIjoiOztBQUFBLGtCQUFlLEVBQUUsQ0FBQSIsIm5hbWVzIjpbXSwic291cmNlcyI6WyI8Y3dkPi9zcmMvY29tcGlsZXIvdHJhbnNwaWxlci5zcGVjLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydCBkZWZhdWx0IDQyIl0sInZlcnNpb24iOjN9
   ===[ INLINE SOURCE MAPS ]=======================================================
-  file: <cwd>/src/compiler/transpile-module.spec.ts
+  file: <cwd>/src/compiler/transpiler.spec.ts
   mappings: ';;AAAA,kBAAe,EAAE,CAAA'
   names: []
   sources:
-    - <cwd>/src/compiler/transpile-module.spec.ts
+    - <cwd>/src/compiler/transpiler.spec.ts
   sourcesContent:
     - export default 42
   version: 3
   ================================================================================
 `;
 
-exports[`transpile module with isolatedModule: true should report diagnostics related to codes with pathRegex config is undefined 1`] = `"foo.ts(2,23): error TS1005: '=>' expected."`;
+exports[`Transpiler should report diagnostics related to codes with pathRegex config is undefined 1`] = `"foo.ts(2,23): error TS1005: '=>' expected."`;
 
-exports[`transpile module with isolatedModule: true should report diagnostics related to codes with pathRegex config matches file name 1`] = `"foo.ts(2,23): error TS1005: '=>' expected."`;
+exports[`Transpiler should report diagnostics related to codes with pathRegex config matches file name 1`] = `"foo.ts(2,23): error TS1005: '=>' expected."`;

--- a/src/compiler/language-service.spec.ts
+++ b/src/compiler/language-service.spec.ts
@@ -11,7 +11,7 @@ import * as compilerUtils from './compiler-utils'
 
 const logTarget = logTargetMock()
 
-describe('language service', () => {
+describe('Language service', () => {
   beforeEach(() => {
     logTarget.clear()
   })

--- a/src/compiler/language-service.ts
+++ b/src/compiler/language-service.ts
@@ -22,7 +22,7 @@ function doTypeChecking(configs: ConfigSet, fileName: string, service: _ts.Langu
 /**
  * @internal
  */
-export const compileUsingLanguageService = (
+export const initializeLanguageServiceInstance = (
   configs: ConfigSet,
   logger: Logger,
   memoryCache: MemoryCache,

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -22,7 +22,11 @@ function doTypeChecking(configs: ConfigSet, fileName: string, program: _ts.Progr
 /**
  * @internal
  */
-export const compileUsingProgram = (configs: ConfigSet, logger: Logger, memoryCache: MemoryCache): CompilerInstance => {
+export const initializeProgramInstance = (
+  configs: ConfigSet,
+  logger: Logger,
+  memoryCache: MemoryCache,
+): CompilerInstance => {
   logger.debug('compileUsingProgram(): create typescript compiler')
 
   const ts = configs.compilerModule

--- a/src/compiler/transpiler.spec.ts
+++ b/src/compiler/transpiler.spec.ts
@@ -8,7 +8,7 @@ import { TS_JEST_OUT_DIR } from '../config/config-set'
 
 const logTarget = logTargetMock()
 
-describe('transpile module with isolatedModule: true', () => {
+describe('Transpiler', () => {
   const baseTsJestConfig = {
     isolatedModules: true,
   }

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -24,7 +24,7 @@ import {
 } from 'typescript'
 
 import { digest as MY_DIGEST, version as MY_VERSION } from '..'
-import { createCompiler } from '../compiler/instance'
+import { createCompilerInstance } from '../compiler/instance'
 import { internals as internalAstTransformers } from '../transformers'
 import {
   AstTransformerDesc,
@@ -435,7 +435,7 @@ export class ConfigSet {
 
   @Memoize()
   get tsCompiler(): TsCompiler {
-    return createCompiler(this)
+    return createCompilerInstance(this)
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

- Rename some methods to be easier to understand what they do
- Rename `transpile-module` to `transpiler`

## Test plan

Green CI


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
