### PR TITLE
fix(compiler): improve performance for Windows by normalizing file path

### DIFF
--- a/src/compiler/compiler-utils.spec.ts
+++ b/src/compiler/compiler-utils.spec.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path'
 import { makeCompiler } from '../__helpers__/fakers'
 import { tempDir } from '../__helpers__/path'
 import { MemoryCache, TSFile } from '../types'
+import { normalizeSlashes } from '../util/normalize-slashes'
 
 import { cacheResolvedModules, getResolvedModulesCache } from './compiler-utils'
 
@@ -44,7 +45,9 @@ describe('cacheResolvedModules', () => {
     compiler.compile(source, fileName)
     cacheResolvedModules(fileName, source, memoryCache, compiler.program!, tmp, logger)
 
-    expect(memoryCache.resolvedModules[fileName].modulePaths).toContain(resolve('src/__mocks__/main.ts'))
+    expect(memoryCache.resolvedModules[fileName].modulePaths).toContain(
+      normalizeSlashes(resolve('src/__mocks__/main.ts')),
+    )
     expect(memoryCache.resolvedModules[fileName].testFileContent).toEqual(source)
     expect(spy).toHaveBeenCalledWith(getResolvedModulesCache(tmp), JSON.stringify(memoryCache.resolvedModules))
   })

--- a/src/compiler/compiler-utils.ts
+++ b/src/compiler/compiler-utils.ts
@@ -1,12 +1,13 @@
 import { Logger } from 'bs-logger'
 import { writeFileSync } from 'fs'
 import micromatch = require('micromatch')
-import { dirname, join, normalize, relative, resolve } from 'path'
+import { dirname, join, relative, resolve } from 'path'
 import * as _ts from 'typescript'
 
 import { ConfigSet } from '../config/config-set'
 import { EXTENSION_REGEX, JSON_REGEX, TS_TSX_REGEX } from '../constants'
 import { MemoryCache, SourceOutput, TSFiles } from '../types'
+import { normalizeSlashes } from '../util/normalize-slashes'
 import { sha1 } from '../util/sha1'
 
 /**
@@ -44,7 +45,7 @@ export function cacheResolvedModules(
     memoryCache.resolvedModules[fileName].modulePaths = importReferences
       .filter((importReference: any) => importReference.parent.parent.resolvedModules?.get(importReference.text))
       .map((importReference: any) => {
-        return normalize(
+        return normalizeSlashes(
           (importReference.parent.parent.resolvedModules.get(importReference.text) as _ts.ResolvedModule)
             .resolvedFileName,
         )
@@ -98,7 +99,7 @@ function getProjectReferenceForFile(
     return (
       program &&
       getResolvedProjectReferences(program)!.find(
-        ref => (ref && ref.commandLine.fileNames.some(file => normalize(file) === filePath)) || false,
+        ref => (ref && ref.commandLine.fileNames.some(file => normalizeSlashes(file) === filePath)) || false,
       )
     )
   }

--- a/src/compiler/language-service.spec.ts
+++ b/src/compiler/language-service.spec.ts
@@ -1,11 +1,11 @@
 import { LogLevels } from 'bs-logger'
 import { removeSync, writeFileSync } from 'fs-extra'
-import { normalize } from 'path'
 
 import { makeCompiler } from '../__helpers__/fakers'
 import { logTargetMock } from '../__helpers__/mocks'
 import { tempDir } from '../__helpers__/path'
 import ProcessedSource from '../__helpers__/processed-source'
+import { normalizeSlashes } from '../util/normalize-slashes'
 
 import * as compilerUtils from './compiler-utils'
 
@@ -128,7 +128,7 @@ describe('Language service', () => {
     compiler.compile(source, fileName)
 
     expect(spy).toHaveBeenCalled()
-    expect(spy.mock.calls[0][0]).toEqual(normalize(fileName))
+    expect(spy.mock.calls[0][0]).toEqual(normalizeSlashes(fileName))
     expect(spy.mock.calls[0][1]).toEqual(source)
 
     spy.mockRestore()

--- a/src/compiler/language-service.ts
+++ b/src/compiler/language-service.ts
@@ -120,33 +120,32 @@ export const initializeLanguageServiceInstance = (
 
   return {
     compileFn: (code: string, fileName: string): SourceOutput => {
-      const normalizedFileName = normalize(fileName)
+      logger.debug({ fileName }, 'compileFn(): compiling using language service')
 
-      logger.debug({ normalizedFileName }, 'compileFn(): compiling using language service')
       // Must set memory cache before attempting to read file.
-      updateMemoryCache(code, normalizedFileName)
+      updateMemoryCache(code, fileName)
       const referencedProject = getAndCacheProjectReference(
-        normalizedFileName,
+        fileName,
         service.getProgram()!,
         memoryCache.files,
         projectReferences,
       )
       if (referencedProject !== undefined) {
-        logger.debug({ normalizedFileName }, 'compileFn(): get compile result from referenced project')
+        logger.debug({ fileName }, 'compileFn(): get compile result from referenced project')
 
-        return getCompileResultFromReferencedProject(normalizedFileName, configs, memoryCache.files, referencedProject)
+        return getCompileResultFromReferencedProject(fileName, configs, memoryCache.files, referencedProject)
       } else {
-        const output: _ts.EmitOutput = service.getEmitOutput(normalizedFileName)
+        const output: _ts.EmitOutput = service.getEmitOutput(fileName)
         // Do type checking by getting TypeScript diagnostics
-        logger.debug(`compileFn(): computing diagnostics for ${normalizedFileName} using language service`)
+        logger.debug(`compileFn(): computing diagnostics for ${fileName} using language service`)
 
-        doTypeChecking(configs, normalizedFileName, service, logger)
+        doTypeChecking(configs, fileName, service, logger)
         /**
          * We don't need the following logic with no cache run because no cache always gives correct typing
          */
         if (cacheDir) {
-          if (isTestFile(configs.testMatchPatterns, normalizedFileName)) {
-            cacheResolvedModules(normalizedFileName, code, memoryCache, service.getProgram()!, cacheDir, logger)
+          if (isTestFile(configs.testMatchPatterns, fileName)) {
+            cacheResolvedModules(fileName, code, memoryCache, service.getProgram()!, cacheDir, logger)
           } else {
             /* istanbul ignore next (covered by e2e) */
             Object.entries(memoryCache.resolvedModules)
@@ -157,13 +156,13 @@ export const initializeLanguageServiceInstance = (
                  * test file for 1st time run after clearing cache because
                  */
                 return (
-                  entry[1].modulePaths.find(modulePath => modulePath === normalizedFileName) &&
+                  entry[1].modulePaths.find(modulePath => modulePath === fileName) &&
                   !hasOwn.call(memoryCache.outputs, entry[0])
                 )
               })
               .forEach(entry => {
                 logger.debug(
-                  `compileFn(): computing diagnostics for test file that imports ${normalizedFileName} using language service`,
+                  `compileFn(): computing diagnostics for test file that imports ${fileName} using language service`,
                 )
 
                 const testFileName = entry[0]
@@ -174,13 +173,13 @@ export const initializeLanguageServiceInstance = (
         }
         /* istanbul ignore next (this should never happen but is kept for security) */
         if (output.emitSkipped) {
-          throw new TypeError(`${relative(cwd, normalizedFileName)}: Emit skipped for language service`)
+          throw new TypeError(`${relative(cwd, fileName)}: Emit skipped for language service`)
         }
         // Throw an error when requiring `.d.ts` files.
         if (!output.outputFiles.length) {
           throw new TypeError(
             interpolate(Errors.UnableToRequireDefinitionFile, {
-              file: basename(normalizedFileName),
+              file: basename(fileName),
             }),
           )
         }

--- a/src/compiler/transpiler.spec.ts
+++ b/src/compiler/transpiler.spec.ts
@@ -170,14 +170,18 @@ describe('Transpiler', () => {
   it('should have correct source maps', () => {
     const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsConfig: false } })
     const source = 'const f = (v: number) => v\nconst t: number = f(5)'
+    const fileName = 'test-source-map-transpiler.ts'
+    writeFileSync(fileName, source, 'utf8')
 
-    const compiled = compiler.compile(source, __filename)
+    const compiled = compiler.compile(source, fileName)
 
-    expect(new ProcessedSource(compiled, __filename).outputSourceMaps).toMatchObject({
-      file: __filename,
-      sources: [__filename],
+    expect(new ProcessedSource(compiled, fileName).outputSourceMaps).toMatchObject({
+      file: fileName,
+      sources: [fileName],
       sourcesContent: [source],
     })
+
+    removeSync(fileName)
   })
 
   it('should not report diagnostics related to typings', () => {

--- a/src/compiler/transpiler.ts
+++ b/src/compiler/transpiler.ts
@@ -1,5 +1,4 @@
 import { Logger } from 'bs-logger'
-import { normalize } from 'path'
 import * as _ts from 'typescript'
 
 import { ConfigSet } from '../config/config-set'
@@ -36,31 +35,24 @@ export const initializeTranspilerInstance = (
 
   return {
     compileFn: (code: string, fileName: string): SourceOutput => {
-      const normalizedFileName = normalize(fileName)
-
-      updateFileInCache(code, normalizedFileName)
-      const referencedProject = getAndCacheProjectReference(
-        normalizedFileName,
-        program,
-        memoryCache.files,
-        projectReferences,
-      )
+      updateFileInCache(code, fileName)
+      const referencedProject = getAndCacheProjectReference(fileName, program, memoryCache.files, projectReferences)
       /* istanbul ignore next (referencedProject object is too complex to mock so we leave this for e2e) */
       if (referencedProject !== undefined) {
-        logger.debug({ normalizedFileName }, 'compileFn(): get compile result from referenced project')
+        logger.debug({ fileName }, 'compileFn(): get compile result from referenced project')
 
-        return getCompileResultFromReferencedProject(normalizedFileName, configs, memoryCache.files, referencedProject)
+        return getCompileResultFromReferencedProject(fileName, configs, memoryCache.files, referencedProject)
       } else {
-        logger.debug({ normalizedFileName }, 'compileFn(): compiling as isolated module')
+        logger.debug({ fileName }, 'compileFn(): compiling as isolated module')
 
         const result: _ts.TranspileOutput = ts.transpileModule(code, {
-          fileName: normalizedFileName,
+          fileName,
           transformers: configs.tsCustomTransformers,
           compilerOptions: options,
-          reportDiagnostics: configs.shouldReportDiagnostic(normalizedFileName),
+          reportDiagnostics: configs.shouldReportDiagnostic(fileName),
         })
-        if (result.diagnostics && configs.shouldReportDiagnostic(normalizedFileName)) {
-          configs.raiseDiagnostics(result.diagnostics, normalizedFileName, logger)
+        if (result.diagnostics && configs.shouldReportDiagnostic(fileName)) {
+          configs.raiseDiagnostics(result.diagnostics, fileName, logger)
         }
 
         return [result.outputText, result.sourceMapText!]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Use `normalizeSlashes` instead of `normalize` to normalize file path. This can improve slightly performance for Windows


## Test plan

Green CI


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
