### PR TITLE
fix(config): verify testMatchPatterns contain RegExp instance or string

### DIFF
--- a/src/config/__snapshots__/config-set.spec.ts.snap
+++ b/src/config/__snapshots__/config-set.spec.ts.snap
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`jest should returns correct config and go thru backports 1`] = `
+exports[`jest should return correct config and go thru backports 1`] = `
 Object {
   "__backported": true,
   "globals": Object {},
@@ -123,6 +123,32 @@ Array [
     "messageText": "If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.",
     "start": undefined,
   },
+]
+`;
+
+exports[`testMatchPatterns should return an array of patterns based on testRegex and testMatch from jestConfig 1`] = `
+Array [
+  "**/__tests__/**/*.[jt]s?(x)",
+  "**/?(*.)+(spec|test).[jt]s?(x)",
+]
+`;
+
+exports[`testMatchPatterns should return an array of patterns based on testRegex and testMatch from jestConfig 2`] = `
+Array [
+  /\\.\\*\\\\\\.\\(spec\\|test\\)\\\\\\.\\[jt\\]sx\\?\\$/,
+]
+`;
+
+exports[`testMatchPatterns should return an array of patterns based on testRegex and testMatch from jestConfig 3`] = `
+Array [
+  "**/?(*.)+(spec|test).[tj]s?(x)",
+]
+`;
+
+exports[`testMatchPatterns should return an array of patterns based on testRegex and testMatch from jestConfig 4`] = `
+Array [
+  "**/?(*.)+(spec|test).[tj]s?(x)",
+  "**/?(*.)+(foo|bar).[tj]s?(x)",
 ]
 `;
 

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -122,7 +122,7 @@ describe('projectPackageJson', () => {
 })
 
 describe('jest', () => {
-  it('should returns correct config and go thru backports', () => {
+  it('should return correct config and go thru backports', () => {
     expect(createConfigSet().jest).toMatchSnapshot()
     expect(backports.backportJestConfig).toHaveBeenCalledTimes(1)
   })
@@ -147,6 +147,37 @@ describe('jest', () => {
         parentConfig: { __parent: true } as any,
       }).jest,
     ).toMatchSnapshot()
+  })
+})
+
+describe('testMatchPatterns', () => {
+  it.each([
+    {
+      jestConfig: {
+        testRegex: [{}],
+        testMatch: [],
+      } as any,
+    },
+    {
+      jestConfig: {
+        testMatch: [],
+        testRegex: [/.*\.(spec|test)\.[jt]sx?$/],
+      } as any,
+    },
+    {
+      jestConfig: {
+        testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
+        testRegex: [],
+      } as any,
+    },
+    {
+      jestConfig: {
+        testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
+        testRegex: ['**/?(*.)+(foo|bar).[tj]s?(x)'],
+      } as any,
+    },
+  ])('should return an array of patterns based on testRegex and testMatch from jestConfig', config => {
+    expect(createConfigSet(config).testMatchPatterns).toMatchSnapshot()
   })
 })
 

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -25,6 +25,7 @@ import {
 
 import { digest as MY_DIGEST, version as MY_VERSION } from '..'
 import { createCompilerInstance } from '../compiler/instance'
+import { DEFAULT_JEST_TEST_MATCH } from '../constants'
 import { internals as internalAstTransformers } from '../transformers'
 import {
   AstTransformerDesc,
@@ -197,7 +198,18 @@ export class ConfigSet {
    */
   @Memoize()
   get testMatchPatterns(): (string | RegExp)[] {
-    return [...this.jest.testMatch, ...this.jest.testRegex]
+    const matchablePatterns = [...this.jest.testMatch, ...this.jest.testRegex].filter(pattern => {
+      /**
+       * jest config testRegex doesn't always deliver the correct RegExp object
+       * See https://github.com/facebook/jest/issues/9778
+       */
+      return pattern instanceof RegExp || typeof pattern === 'string'
+    })
+    if (!matchablePatterns.length) {
+      matchablePatterns.push(...DEFAULT_JEST_TEST_MATCH)
+    }
+
+    return matchablePatterns
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,25 @@
+/**
+ * @internal
+ */
 export const LINE_FEED = '\n'
-
+/**
+ * @internal
+ */
 export const EXTENSION_REGEX = /\.[^.]+$/
+/**
+ * @internal
+ */
 export const TS_TSX_REGEX = /\.tsx?$/
+/**
+ * @internal
+ */
 export const JS_JSX_REGEX = /\.jsx?$/
+/**
+ * @internal
+ */
 export const JSON_REGEX = /\.json$/i
+/**
+ * @internal
+ * See https://jestjs.io/docs/en/configuration#testmatch-arraystring
+ */
+export const DEFAULT_JEST_TEST_MATCH = ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)']


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Jest config which is passed to transformer doesn’t always contain the correct value of `testRegex`, see https://github.com/facebook/jest/issues/9778. Since we rely on this, we should add a filter to make sure we get out the patterns which are `RegExp` instance or type `string`. 

Also we add a fallback to default `testMatch` value, see https://jestjs.io/docs/en/configuration#testmatch-arraystring in case no patterns valid by the check above.

Fix #1552 
## Test plan

- Added unit tests.
- Green CI


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
