### PR TITLE
chore: use Map for compiler memory cache

### DIFF
--- a/src/compiler/compiler-utils.ts
+++ b/src/compiler/compiler-utils.ts
@@ -117,7 +117,7 @@ export function getAndCacheProjectReference(
   files: TSFiles,
   projectReferences: ReadonlyArray<_ts.ProjectReference> | undefined,
 ) {
-  const file = files[filePath]
+  const file = files.get(filePath)
   if (file?.projectReference) {
     return file.projectReference.project
   }
@@ -156,7 +156,7 @@ function getAndCacheOutputJSFileName(
   projectReference: _ts.ResolvedProjectReference,
   files: TSFiles,
 ) {
-  const file = files[inputFileName]
+  const file = files.get(inputFileName)
   if (file?.projectReference?.outputFileName) {
     return file.projectReference.outputFileName
   }

--- a/src/compiler/transpiler.ts
+++ b/src/compiler/transpiler.ts
@@ -27,7 +27,7 @@ export const initializeTranspilerInstance = (
     : ts.createProgram([], options)
   /* istanbul ignore next (we leave this for e2e) */
   const updateFileInCache = (contents: string, filePath: string) => {
-    const file = memoryCache.files[filePath]
+    const file = memoryCache.files.get(filePath)
     if (file && file.text !== contents) {
       file.version++
       file.text = contents

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,9 +239,7 @@ export interface AstTransformerDesc {
   factory(cs: ConfigSet): _ts.TransformerFactory<_ts.SourceFile>
 }
 /** where key is filepath */
-export interface TSFiles {
-  [filePath: string]: TSFile
-}
+export type TSFiles = Map<string, TSFile>
 export interface TSFile {
   text?: string
   output?: string


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

`Maps` are about twice as fast for larger data sets in Chrome 80, very much likely this applies to Node as well: https://stackoverflow.com/a/55711780/1850276


## Test plan

Green CI


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
