### PR TITLE
chore: improve codes for config-set.ts

### DIFF
--- a/src/compiler/instance.ts
+++ b/src/compiler/instance.ts
@@ -71,7 +71,7 @@ const compileAndCacheResult = (
 export const createCompilerInstance = (configs: ConfigSet): TsCompiler => {
   const logger = configs.logger.child({ namespace: 'ts-compiler' })
   const {
-    typescript: { options: compilerOptions },
+    parsedTsConfig: { options: compilerOptions },
     tsJest,
   } = configs
   const cacheDir = configs.tsCacheDir
@@ -96,7 +96,7 @@ export const createCompilerInstance = (configs: ConfigSet): TsCompiler => {
     } catch (e) {}
   }
   // Initialize memory cache for typescript compiler
-  configs.typescript.fileNames.forEach(fileName => {
+  configs.parsedTsConfig.fileNames.forEach(fileName => {
     memoryCache.files.set(fileName, {
       version: 0,
     })

--- a/src/compiler/language-service.ts
+++ b/src/compiler/language-service.ts
@@ -37,7 +37,7 @@ export const initializeLanguageServiceInstance = (
   const ts = configs.compilerModule
   const cwd = configs.cwd
   const cacheDir = configs.tsCacheDir
-  const { options, projectReferences, fileNames } = configs.typescript
+  const { options, projectReferences, fileNames } = configs.parsedTsConfig
   const serviceHostTraceCtx = {
     namespace: 'ts:serviceHost',
     call: null,

--- a/src/compiler/transpiler.ts
+++ b/src/compiler/transpiler.ts
@@ -16,7 +16,7 @@ export const initializeTranspilerInstance = (
 ): CompilerInstance => {
   logger.debug('initializeTranspilerInstance(): create typescript compiler')
 
-  const { options, projectReferences, fileNames } = configs.typescript
+  const { options, projectReferences, fileNames } = configs.parsedTsConfig
   const ts = configs.compilerModule
   const program = projectReferences
     ? ts.createProgram({

--- a/src/ts-jest-transformer.spec.ts
+++ b/src/ts-jest-transformer.spec.ts
@@ -28,11 +28,11 @@ describe('configFor', () => {
 describe('process', () => {
   let tr: TsJestTransformer
   let babel: any
-  let typescript: ParsedCommandLine
+  let parsedTsConfig: ParsedCommandLine
   let args: [string, string, any, any]
   const config = {
-    get typescript() {
-      return typescript
+    get parsedTsConfig() {
+      return parsedTsConfig
     },
     shouldStringifyContent: jest.fn(),
     get babelJestTransformer() {
@@ -56,7 +56,7 @@ describe('process', () => {
     config.shouldStringifyContent.mockImplementation(() => false).mockClear()
     babel = null
     config.tsCompiler.compile.mockImplementation(s => `ts:${s}`).mockClear()
-    typescript = { options: {} } as any
+    parsedTsConfig = { options: {} } as any
   })
 
   it('should process ts input without babel', () => {
@@ -79,7 +79,7 @@ Array [
   })
 
   it('should process js input without babel', () => {
-    typescript.options.allowJs = true
+    parsedTsConfig.options.allowJs = true
     args[1] = '/foo/bar.js'
     expect(process()).toBe(`ts:${INPUT}`)
     expect(config.shouldStringifyContent.mock.calls).toMatchInlineSnapshot(`
@@ -132,7 +132,7 @@ Array [
   })
 
   it('should process js input with babel', () => {
-    typescript.options.allowJs = true
+    parsedTsConfig.options.allowJs = true
     babel = { process: jest.fn(s => `babel:${s}`) }
     args[1] = '/foo/bar.js'
     expect(process()).toBe(`babel:ts:${INPUT}`)
@@ -172,7 +172,7 @@ Array [
 
   it('should warn when trying to process js but allowJs is false', () => {
     args[1] = '/foo/bar.js'
-    typescript.options.allowJs = false
+    parsedTsConfig.options.allowJs = false
     const logs = logTargetMock()
     logs.clear()
     expect(process()).toBe(INPUT)

--- a/src/ts-jest-transformer.ts
+++ b/src/ts-jest-transformer.ts
@@ -112,7 +112,7 @@ export class TsJestTransformer implements Transformer {
     } else if (isDefinitionFile) {
       // do not try to compile declaration files
       result = ''
-    } else if (!configs.typescript.options.allowJs && isJsFile) {
+    } else if (!configs.parsedTsConfig.options.allowJs && isJsFile) {
       // we've got a '.js' but the compiler option `allowJs` is not set or set to false
       this.logger.warn({ fileName: filePath }, interpolate(Errors.GotJsFileButAllowJsFalse, { path: filePath }))
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

The variable `input` in `readTsConfig` method of `config-set.ts` isn't in used anywhere so this PR is to remove it. I also rename the getter `typescript` to `parsedTsConfig`, make it clearer to understand.

## Test plan

The removing of this variable shouldn't cause any bugs though. Green CI


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
