### PR TITLE
feat(config): define 'ts-jest' on ConfigGlobals interface in @jest/types

### DIFF
--- a/docs/user/config/index.md
+++ b/docs/user/config/index.md
@@ -181,6 +181,23 @@ module.exports = {
 
 </div></div>
 
+#### IDE `ts-jest` config suggestion
+
+To ultilize IDE suggestion, you can use `JSDOC` to provide suggested `ts-jest` configs for your Jest config:
+
+```js
+/** @type {import('@jest/types').Config.InitialOptions} */
+/** @typedef {import('ts-jest')} */
+module.exports = {
+  // [...]
+  globals: {
+    'ts-jest': {
+      // ts-jest configuration goes here and your IDE will suggest which configs when typing
+    }
+  }
+};
+```
+
 ### Options
 
 All options have default values which should fit most of the projects. Click on the option's name to see details and example(s).

--- a/e2e/__helpers__/test-case/runtime.ts
+++ b/e2e/__helpers__/test-case/runtime.ts
@@ -92,7 +92,7 @@ export function run(name: string, options: RunTestOptions = {}): RunResult {
     merge(extraConfig, options.jestConfig)
   }
   if (options.tsJestConfig) {
-    const globalConfig: any = extraConfig.globals || (extraConfig.globals = {})
+    const globalConfig: any = extraConfig.globals || (extraConfig.globals = {'ts-jest': {}})
     const tsJestConfig = globalConfig['ts-jest'] || (globalConfig['ts-jest'] = {})
     merge(tsJestConfig, options.tsJestConfig)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4978,12 +4978,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -8451,13 +8445,10 @@
       "dev": true
     },
     "run-async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "run-node": {
       "version": "1.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,15 @@ import { Deprecateds, interpolate } from './util/messages'
 import { mocked as mockedCore } from './util/testing'
 import { VersionCheckers } from './util/version-checkers'
 
+declare module '@jest/types' {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Config {
+    interface ConfigGlobals {
+      'ts-jest': TsJestGlobalOptions
+    }
+  }
+}
+
 // deprecate helpers
 const warn = rootLogger.child({ [LogContexts.logLevel]: LogLevels.warn })
 const helperMoved = <T extends (...args: any[]) => any>(name: string, helper: T) =>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

- Define `ts-jest` on jest `ConfigGlobals` interface to ultilize TypeScript declaration merging.
- Adjust docs to instruct users how to do it.

Close #1588 , thanks @G-Rath for suggested solution 👍 


## Test plan

Build `ts-jest` then copy `dist` folder to `node_modules/ts-jest/dist` of an example project and follow the docs. Check if your IDE gives the suggestion of `ts-jest` config options.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
