### PR TITLE
fix(config): don't set include property value of tsconfig to empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ For example:
 {
    // ...other configs
    "files": [
-       "my-custom-typings.d.ts".
+       "my-custom-typings.d.ts",
        "my-global-module.ts"
    ]
 }

--- a/docs/user/config/isolatedModules.md
+++ b/docs/user/config/isolatedModules.md
@@ -43,3 +43,31 @@ module.exports = {
 ```
 
 </div></div>
+
+# Performance
+
+Using `isolatedModules: false` comes with a cost of performance comparing to `isolatedModules: true`. There is a way
+to improve the performance when using this mode by changing the value of `include` in `tsconfig` which is used by `ts-jest`.
+The least amount of files which are provided in `include`, the more performance the test run can gain.
+
+### Example
+
+```json5
+// tsconfig.json
+{
+  // ...other configs
+  include: [
+    "my-typings/*",
+    "my-global-modules/*",
+  ]
+}
+```
+
+## Caveats
+
+Limiting the amount of files loaded via `include` can greatly boost performance when running tests. However, the trade off 
+is `ts-jest` might not recognize all files which are intended to use with `jest`. One can run into issues with custom typings,
+global modules, etc... 
+
+The suggested solution is what is needed for the test environment should be captured by 
+glob patterns in `include`, to gain both performance boost and avoid breaking behaviors.

--- a/e2e/__external-repos__/custom-typings/tsconfig.json
+++ b/e2e/__external-repos__/custom-typings/tsconfig.json
@@ -3,8 +3,5 @@
     "target": "es5",
     "module": "commonjs",
     "esModuleInterop": true
-  },
-  "files": [
-    "jquery.d.ts"
-  ]
+  }
 }

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -468,8 +468,9 @@ describe('typescript', () => {
     createConfigSet({ tsJestConfig: tsJest, parentConfig }).parsedTsConfig
 
   it('should read file list from default tsconfig', () => {
-    // since the default is to lookup for tsconfig, but we set include to [] so we should not have this file in the list
-    expect(get().fileNames).toEqual([])
+    // since the default is to lookup for tsconfig,
+    // we should have this file in the list
+    expect(get().fileNames).toContain(normalizeSlashes(__filename))
   })
 
   it.each(['tsConfig', 'tsconfig'])('should include compiler config from `%s` option key', (key: string) => {
@@ -610,11 +611,6 @@ describe('readTsConfig', () => {
       const conf = cs.readTsConfig()
       expect(conf.options.configFilePath).toBeUndefined()
       expect(readConfig).not.toHaveBeenCalled()
-      expect(parseConfig.mock.calls[0][0]).toEqual(
-        expect.objectContaining({
-          include: [],
-        }),
-      )
       expect(parseConfig.mock.calls[0][2]).toBe('/root')
       expect(parseConfig.mock.calls[0][4]).toBeUndefined()
     })
@@ -661,11 +657,6 @@ describe('readTsConfig', () => {
         expect(conf.options.path).toBe('/root/tsconfig.json')
         expect(findConfig.mock.calls[0][0]).toBe('/root')
         expect(readConfig.mock.calls[0][0]).toBe('/root/tsconfig.json')
-        expect(parseConfig.mock.calls[0][0]).toEqual(
-          expect.objectContaining({
-            include: [],
-          }),
-        )
         expect(parseConfig.mock.calls[0][2]).toBe('/root')
         expect(parseConfig.mock.calls[0][4]).toBe('/root/tsconfig.json')
         expect(conf.options.allowSyntheticDefaultImports).toEqual(true)
@@ -677,11 +668,6 @@ describe('readTsConfig', () => {
         expect(conf.options.path).toBe('/foo/tsconfig.bar.json')
         expect(findConfig).not.toBeCalled()
         expect(readConfig.mock.calls[0][0]).toBe('/foo/tsconfig.bar.json')
-        expect(parseConfig.mock.calls[0][0]).toEqual(
-          expect.objectContaining({
-            include: [],
-          }),
-        )
         expect(parseConfig.mock.calls[0][2]).toBe('/foo')
         expect(parseConfig.mock.calls[0][4]).toBe('/foo/tsconfig.bar.json')
         expect(conf.errors).toMatchSnapshot()
@@ -710,11 +696,6 @@ describe('readTsConfig', () => {
         expect(conf.options.path).toBe('/root/tsconfig.json')
         expect(findConfig.mock.calls[0][0]).toBe('/root')
         expect(readConfig.mock.calls[0][0]).toBe('/root/tsconfig.json')
-        expect(parseConfig.mock.calls[0][0]).toEqual(
-          expect.objectContaining({
-            include: [],
-          }),
-        )
         expect(parseConfig.mock.calls[0][2]).toBe('/root')
         expect(parseConfig.mock.calls[0][4]).toBe('/root/tsconfig.json')
         expect(conf.options.allowSyntheticDefaultImports).toEqual(true)
@@ -754,11 +735,6 @@ describe('readTsConfig', () => {
         expect(conf.options.path).toBe('/root/tsconfig.json')
         expect(findConfig.mock.calls[0][0]).toBe('/root')
         expect(readConfig.mock.calls[0][0]).toBe('/root/tsconfig.json')
-        expect(parseConfig.mock.calls[0][0]).toEqual(
-          expect.objectContaining({
-            include: [],
-          }),
-        )
         expect(parseConfig.mock.calls[0][2]).toBe('/root')
         expect(parseConfig.mock.calls[0][4]).toBe('/root/tsconfig.json')
         expect(conf.options.allowSyntheticDefaultImports).toBeUndefined()
@@ -770,11 +746,6 @@ describe('readTsConfig', () => {
         expect(conf.options.path).toBe('/foo/tsconfig.bar.json')
         expect(findConfig).not.toBeCalled()
         expect(readConfig.mock.calls[0][0]).toBe('/foo/tsconfig.bar.json')
-        expect(parseConfig.mock.calls[0][0]).toEqual(
-          expect.objectContaining({
-            include: [],
-          }),
-        )
         expect(parseConfig.mock.calls[0][2]).toBe('/foo')
         expect(parseConfig.mock.calls[0][4]).toBe('/foo/tsconfig.bar.json')
         expect(conf.errors).toEqual([])
@@ -803,11 +774,6 @@ describe('readTsConfig', () => {
         expect(conf.options.path).toBe('/root/tsconfig.json')
         expect(findConfig.mock.calls[0][0]).toBe('/root')
         expect(readConfig.mock.calls[0][0]).toBe('/root/tsconfig.json')
-        expect(parseConfig.mock.calls[0][0]).toEqual(
-          expect.objectContaining({
-            include: [],
-          }),
-        )
         expect(parseConfig.mock.calls[0][2]).toBe('/root')
         expect(parseConfig.mock.calls[0][4]).toBe('/root/tsconfig.json')
         expect(conf.errors).toEqual([])
@@ -819,11 +785,6 @@ describe('readTsConfig', () => {
         expect(conf.options.path).toBe('/foo/tsconfig.bar.json')
         expect(findConfig).not.toBeCalled()
         expect(readConfig.mock.calls[0][0]).toBe('/foo/tsconfig.bar.json')
-        expect(parseConfig.mock.calls[0][0]).toEqual(
-          expect.objectContaining({
-            include: [],
-          }),
-        )
         expect(parseConfig.mock.calls[0][2]).toBe('/foo')
         expect(parseConfig.mock.calls[0][4]).toBe('/foo/tsconfig.bar.json')
         expect(conf.errors).toEqual([])

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -712,7 +712,7 @@ export class ConfigSet {
     resolvedConfigFile?: string | null,
     noProject?: boolean | null,
   ): ParsedCommandLine {
-    let config = { compilerOptions: {}, include: [] }
+    let config = { compilerOptions: {} }
     let basePath = normalizeSlashes(this.rootDir)
     let configFileName: string | undefined
     const ts = this.compilerModule
@@ -741,11 +741,6 @@ export class ConfigSet {
       ...config.compilerOptions,
       ...compilerOptions,
     }
-    /**
-     * Always set include to empty array so fileNames after parseJsonConfigFileContent only contains the least minimum initial
-     * files to utilize LanguageService incremental feature
-     */
-    config.include = []
 
     // parse json, merge config extending others, ...
     const result = ts.parseJsonConfigFileContent(config, ts.sys, basePath, undefined, configFileName)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

- Revert #1562 

- Add doc to instruct how to boost performance and caveats

Close #1604 
Close #1607 
Close #1608


## Test plan

Green CI


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
