### PR TITLE
Updating typo in compiler docs

### DIFF
--- a/docs/user/config/compiler.md
+++ b/docs/user/config/compiler.md
@@ -34,7 +34,7 @@ module.exports = {
   "jest": {
     "globals": {
       "ts-jest": {
-        "compiler": "ttypescript"
+        "compiler": "typescript"
       }
     }
   }


### PR DESCRIPTION
## Summary

Simply just fixing a typo in the docs 🙂

`ttypescript` -> `typescript`


## Test plan

n/a


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
