### PR TITLE
chore(dev-infra): enable rule @typescript-eslint/prefer-ts-expect-error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -155,7 +155,6 @@ module.exports = {
         default: 'array',
       },
     ],
-    '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/ban-types': [
       'error',
       {
@@ -229,6 +228,7 @@ module.exports = {
     '@typescript-eslint/prefer-function-type': 'error',
     '@typescript-eslint/prefer-namespace-keyword': 'error',
     '@typescript-eslint/prefer-readonly': 'error',
+    '@typescript-eslint/prefer-ts-expect-error': 'error',
     '@typescript-eslint/restrict-template-expressions': 'off',
     '@typescript-eslint/require-await': 'off',
     '@typescript-eslint/triple-slash-reference': [

--- a/e2e/__cases__/hoisting/enable-automock/enable-automock.spec.ts
+++ b/e2e/__cases__/hoisting/enable-automock/enable-automock.spec.ts
@@ -4,6 +4,6 @@ import hello from './enable-automock'
 
 test('original implementation', () => {
   // now we have the mocked implementation,
-  // @ts-ignore
+  // @ts-expect-error
   expect(hello._isMockFunction).toBeTruthy()
 })

--- a/e2e/__tests__/__snapshots__/hoisting.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/hoisting.test.ts.snap
@@ -191,14 +191,14 @@ exports[`Hoisting jest.enableAutomock() should pass using template "default": io
   var enable_automock_1 = require("./enable-automock");
   test('original implementation', function () {
       // now we have the mocked implementation,
-      // @ts-ignore
+      // @ts-expect-error
       expect(enable_automock_1.default._isMockFunction).toBeTruthy();
   });
-  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoiPGN3ZD4vZW5hYmxlLWF1dG9tb2NrLnNwZWMudHMiLCJtYXBwaW5ncyI6Ijs7QUFBQSxJQUFJLENBQUMsY0FBYyxFQUFFLENBQUE7QUFFckIscURBQXFDO0FBRXJDLElBQUksQ0FBQyx5QkFBeUIsRUFBRTtJQUM5Qix5Q0FBeUM7SUFDekMsYUFBYTtJQUNiLE1BQU0sQ0FBQyx5QkFBSyxDQUFDLGVBQWUsQ0FBQyxDQUFDLFVBQVUsRUFBRSxDQUFBO0FBQzVDLENBQUMsQ0FBQyxDQUFBIiwibmFtZXMiOltdLCJzb3VyY2VzIjpbIjxjd2Q+L2VuYWJsZS1hdXRvbW9jay5zcGVjLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImplc3QuZW5hYmxlQXV0b21vY2soKVxuXG5pbXBvcnQgaGVsbG8gZnJvbSAnLi9lbmFibGUtYXV0b21vY2snXG5cbnRlc3QoJ29yaWdpbmFsIGltcGxlbWVudGF0aW9uJywgKCkgPT4ge1xuICAvLyBub3cgd2UgaGF2ZSB0aGUgbW9ja2VkIGltcGxlbWVudGF0aW9uLFxuICAvLyBAdHMtaWdub3JlXG4gIGV4cGVjdChoZWxsby5faXNNb2NrRnVuY3Rpb24pLnRvQmVUcnV0aHkoKVxufSlcbiJdLCJ2ZXJzaW9uIjozfQ==
+  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoiPGN3ZD4vZW5hYmxlLWF1dG9tb2NrLnNwZWMudHMiLCJtYXBwaW5ncyI6Ijs7QUFBQSxJQUFJLENBQUMsY0FBYyxFQUFFLENBQUE7QUFFckIscURBQXFDO0FBRXJDLElBQUksQ0FBQyx5QkFBeUIsRUFBRTtJQUM5Qix5Q0FBeUM7SUFDekMsbUJBQW1CO0lBQ25CLE1BQU0sQ0FBQyx5QkFBSyxDQUFDLGVBQWUsQ0FBQyxDQUFDLFVBQVUsRUFBRSxDQUFBO0FBQzVDLENBQUMsQ0FBQyxDQUFBIiwibmFtZXMiOltdLCJzb3VyY2VzIjpbIjxjd2Q+L2VuYWJsZS1hdXRvbW9jay5zcGVjLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImplc3QuZW5hYmxlQXV0b21vY2soKVxuXG5pbXBvcnQgaGVsbG8gZnJvbSAnLi9lbmFibGUtYXV0b21vY2snXG5cbnRlc3QoJ29yaWdpbmFsIGltcGxlbWVudGF0aW9uJywgKCkgPT4ge1xuICAvLyBub3cgd2UgaGF2ZSB0aGUgbW9ja2VkIGltcGxlbWVudGF0aW9uLFxuICAvLyBAdHMtZXhwZWN0LWVycm9yXG4gIGV4cGVjdChoZWxsby5faXNNb2NrRnVuY3Rpb24pLnRvQmVUcnV0aHkoKVxufSlcbiJdLCJ2ZXJzaW9uIjozfQ==
   ===[ INLINE SOURCE MAPS ]=======================================================
   file: <cwd>/enable-automock.spec.ts
   mappings: >-
-    ;;AAAA,IAAI,CAAC,cAAc,EAAE,CAAA;AAErB,qDAAqC;AAErC,IAAI,CAAC,yBAAyB,EAAE;IAC9B,yCAAyC;IACzC,aAAa;IACb,MAAM,CAAC,yBAAK,CAAC,eAAe,CAAC,CAAC,UAAU,EAAE,CAAA;AAC5C,CAAC,CAAC,CAAA
+    ;;AAAA,IAAI,CAAC,cAAc,EAAE,CAAA;AAErB,qDAAqC;AAErC,IAAI,CAAC,yBAAyB,EAAE;IAC9B,yCAAyC;IACzC,mBAAmB;IACnB,MAAM,CAAC,yBAAK,CAAC,eAAe,CAAC,CAAC,UAAU,EAAE,CAAA;AAC5C,CAAC,CAAC,CAAA
   names: []
   sources:
     - <cwd>/enable-automock.spec.ts
@@ -210,7 +210,7 @@ exports[`Hoisting jest.enableAutomock() should pass using template "default": io
   
       test('original implementation', () => {
         // now we have the mocked implementation,
-        // @ts-ignore
+        // @ts-expect-error
         expect(hello._isMockFunction).toBeTruthy()
       })
   version: 3
@@ -258,10 +258,10 @@ exports[`Hoisting jest.enableAutomock() should pass using template "with-babel-7
   
   test('original implementation', function () {
     // now we have the mocked implementation,
-    // @ts-ignore
+    // @ts-expect-error
     expect(enable_automock_1.default._isMockFunction).toBeTruthy();
   });
-  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJtYXBwaW5ncyI6Ijs7QUFBQSxjQUFLLGNBQUw7Ozs7Ozs7Ozs7Ozs7Ozs7QUFFQSxJQUFBLGlCQUFBLEdBQUEsT0FBQSxDQUFBLG1CQUFBLENBQUE7O0FBRUEsSUFBSSxDQUFDLHlCQUFELEVBQTRCLFlBQUE7QUFDOUI7QUFDQTtBQUNBLEVBQUEsTUFBTSxDQUFDLGlCQUFBLENBQUEsT0FBQSxDQUFNLGVBQVAsQ0FBTixDQUE4QixVQUE5QjtBQUNELENBSkcsQ0FBSiIsIm5hbWVzIjpbXSwic291cmNlcyI6WyI8Y3dkPi9lbmFibGUtYXV0b21vY2suc3BlYy50cyJdLCJzb3VyY2VzQ29udGVudCI6WyJqZXN0LmVuYWJsZUF1dG9tb2NrKClcblxuaW1wb3J0IGhlbGxvIGZyb20gJy4vZW5hYmxlLWF1dG9tb2NrJ1xuXG50ZXN0KCdvcmlnaW5hbCBpbXBsZW1lbnRhdGlvbicsICgpID0+IHtcbiAgLy8gbm93IHdlIGhhdmUgdGhlIG1vY2tlZCBpbXBsZW1lbnRhdGlvbixcbiAgLy8gQHRzLWlnbm9yZVxuICBleHBlY3QoaGVsbG8uX2lzTW9ja0Z1bmN0aW9uKS50b0JlVHJ1dGh5KClcbn0pXG4iXSwidmVyc2lvbiI6M30=
+  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJtYXBwaW5ncyI6Ijs7QUFBQSxjQUFLLGNBQUw7Ozs7Ozs7Ozs7Ozs7Ozs7QUFFQSxJQUFBLGlCQUFBLEdBQUEsT0FBQSxDQUFBLG1CQUFBLENBQUE7O0FBRUEsSUFBSSxDQUFDLHlCQUFELEVBQTRCLFlBQUE7QUFDOUI7QUFDQTtBQUNBLEVBQUEsTUFBTSxDQUFDLGlCQUFBLENBQUEsT0FBQSxDQUFNLGVBQVAsQ0FBTixDQUE4QixVQUE5QjtBQUNELENBSkcsQ0FBSiIsIm5hbWVzIjpbXSwic291cmNlcyI6WyI8Y3dkPi9lbmFibGUtYXV0b21vY2suc3BlYy50cyJdLCJzb3VyY2VzQ29udGVudCI6WyJqZXN0LmVuYWJsZUF1dG9tb2NrKClcblxuaW1wb3J0IGhlbGxvIGZyb20gJy4vZW5hYmxlLWF1dG9tb2NrJ1xuXG50ZXN0KCdvcmlnaW5hbCBpbXBsZW1lbnRhdGlvbicsICgpID0+IHtcbiAgLy8gbm93IHdlIGhhdmUgdGhlIG1vY2tlZCBpbXBsZW1lbnRhdGlvbixcbiAgLy8gQHRzLWV4cGVjdC1lcnJvclxuICBleHBlY3QoaGVsbG8uX2lzTW9ja0Z1bmN0aW9uKS50b0JlVHJ1dGh5KClcbn0pXG4iXSwidmVyc2lvbiI6M30=
   ===[ INLINE SOURCE MAPS ]=======================================================
   mappings: >-
     ;;AAAA,cAAK,cAAL;;;;;;;;;;;;;;;;AAEA,IAAA,iBAAA,GAAA,OAAA,CAAA,mBAAA,CAAA;;AAEA,IAAI,CAAC,yBAAD,EAA4B,YAAA;AAC9B;AACA;AACA,EAAA,MAAM,CAAC,iBAAA,CAAA,OAAA,CAAM,eAAP,CAAN,CAA8B,UAA9B;AACD,CAJG,CAAJ
@@ -276,7 +276,7 @@ exports[`Hoisting jest.enableAutomock() should pass using template "with-babel-7
   
       test('original implementation', () => {
         // now we have the mocked implementation,
-        // @ts-ignore
+        // @ts-expect-error
         expect(hello._isMockFunction).toBeTruthy()
       })
   version: 3
@@ -324,10 +324,10 @@ exports[`Hoisting jest.enableAutomock() should pass using template "with-babel-7
   
   test('original implementation', function () {
     // now we have the mocked implementation,
-    // @ts-ignore
+    // @ts-expect-error
     expect(enable_automock_1.default._isMockFunction).toBeTruthy();
   });
-  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJtYXBwaW5ncyI6Ijs7QUFBQSxjQUFLLGNBQUw7Ozs7Ozs7Ozs7Ozs7Ozs7QUFFQSxJQUFBLGlCQUFBLEdBQUEsT0FBQSxDQUFBLG1CQUFBLENBQUE7O0FBRUEsSUFBSSxDQUFDLHlCQUFELEVBQTRCLFlBQUE7QUFDOUI7QUFDQTtBQUNBLEVBQUEsTUFBTSxDQUFDLGlCQUFBLENBQUEsT0FBQSxDQUFNLGVBQVAsQ0FBTixDQUE4QixVQUE5QjtBQUNELENBSkcsQ0FBSiIsIm5hbWVzIjpbXSwic291cmNlcyI6WyI8Y3dkPi9lbmFibGUtYXV0b21vY2suc3BlYy50cyJdLCJzb3VyY2VzQ29udGVudCI6WyJqZXN0LmVuYWJsZUF1dG9tb2NrKClcblxuaW1wb3J0IGhlbGxvIGZyb20gJy4vZW5hYmxlLWF1dG9tb2NrJ1xuXG50ZXN0KCdvcmlnaW5hbCBpbXBsZW1lbnRhdGlvbicsICgpID0+IHtcbiAgLy8gbm93IHdlIGhhdmUgdGhlIG1vY2tlZCBpbXBsZW1lbnRhdGlvbixcbiAgLy8gQHRzLWlnbm9yZVxuICBleHBlY3QoaGVsbG8uX2lzTW9ja0Z1bmN0aW9uKS50b0JlVHJ1dGh5KClcbn0pXG4iXSwidmVyc2lvbiI6M30=
+  //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJtYXBwaW5ncyI6Ijs7QUFBQSxjQUFLLGNBQUw7Ozs7Ozs7Ozs7Ozs7Ozs7QUFFQSxJQUFBLGlCQUFBLEdBQUEsT0FBQSxDQUFBLG1CQUFBLENBQUE7O0FBRUEsSUFBSSxDQUFDLHlCQUFELEVBQTRCLFlBQUE7QUFDOUI7QUFDQTtBQUNBLEVBQUEsTUFBTSxDQUFDLGlCQUFBLENBQUEsT0FBQSxDQUFNLGVBQVAsQ0FBTixDQUE4QixVQUE5QjtBQUNELENBSkcsQ0FBSiIsIm5hbWVzIjpbXSwic291cmNlcyI6WyI8Y3dkPi9lbmFibGUtYXV0b21vY2suc3BlYy50cyJdLCJzb3VyY2VzQ29udGVudCI6WyJqZXN0LmVuYWJsZUF1dG9tb2NrKClcblxuaW1wb3J0IGhlbGxvIGZyb20gJy4vZW5hYmxlLWF1dG9tb2NrJ1xuXG50ZXN0KCdvcmlnaW5hbCBpbXBsZW1lbnRhdGlvbicsICgpID0+IHtcbiAgLy8gbm93IHdlIGhhdmUgdGhlIG1vY2tlZCBpbXBsZW1lbnRhdGlvbixcbiAgLy8gQHRzLWV4cGVjdC1lcnJvclxuICBleHBlY3QoaGVsbG8uX2lzTW9ja0Z1bmN0aW9uKS50b0JlVHJ1dGh5KClcbn0pXG4iXSwidmVyc2lvbiI6M30=
   ===[ INLINE SOURCE MAPS ]=======================================================
   mappings: >-
     ;;AAAA,cAAK,cAAL;;;;;;;;;;;;;;;;AAEA,IAAA,iBAAA,GAAA,OAAA,CAAA,mBAAA,CAAA;;AAEA,IAAI,CAAC,yBAAD,EAA4B,YAAA;AAC9B;AACA;AACA,EAAA,MAAM,CAAC,iBAAA,CAAA,OAAA,CAAM,eAAP,CAAN,CAA8B,UAA9B;AACD,CAJG,CAAJ
@@ -342,7 +342,7 @@ exports[`Hoisting jest.enableAutomock() should pass using template "with-babel-7
   
       test('original implementation', () => {
         // now we have the mocked implementation,
-        // @ts-ignore
+        // @ts-expect-error
         expect(hello._isMockFunction).toBeTruthy()
       })
   version: 3

--- a/e2e/__tests__/hoisting.test.ts
+++ b/e2e/__tests__/hoisting.test.ts
@@ -1,48 +1,50 @@
 import { allValidPackageSets } from '../__helpers__/templates'
 import { configureTestCase } from '../__helpers__/test-case'
 
-describe('Hoisting jest.mock() & jest.unmock()', () => {
-  const testCase = configureTestCase('hoisting/mock-unmock', {
-    writeIo: true,
-  })
+describe('Hoisting', () => {
+  describe('jest.mock() & jest.unmock()', () => {
+    const testCase = configureTestCase('hoisting/mock-unmock', {
+      writeIo: true,
+    })
 
-  testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { testLabel }) => {
-    it(testLabel, () => {
-      const result = runTest()
-      expect(result.status).toBe(0)
-      expect(result).toMatchSnapshot('output-mockUnmock')
-      expect(result.ioFor('mock-unmock.spec.ts')).toMatchSnapshot('io-mockUnmock')
+    testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { testLabel }) => {
+      it(testLabel, () => {
+        const result = runTest()
+        expect(result.status).toBe(0)
+        expect(result).toMatchSnapshot('output-mockUnmock')
+        expect(result.ioFor('mock-unmock.spec.ts')).toMatchSnapshot('io-mockUnmock')
+      })
     })
   })
-})
 
-describe('Hoisting jest.enableAutomock()', () => {
-  const testCase = configureTestCase('hoisting/enable-automock', { writeIo: true })
+  describe('jest.enableAutomock()', () => {
+    const testCase = configureTestCase('hoisting/enable-automock', { writeIo: true })
 
-  testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { testLabel }) => {
-    it(testLabel, () => {
-      const result = runTest()
-      expect(result.status).toBe(0)
-      expect(result).toMatchSnapshot('output-enableAutomock')
-      expect(result.ioFor('enable-automock.spec.ts')).toMatchSnapshot('io-enableAutomock')
+    testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { testLabel }) => {
+      it(testLabel, () => {
+        const result = runTest()
+        expect(result.status).toBe(0)
+        expect(result).toMatchSnapshot('output-enableAutomock')
+        expect(result.ioFor('enable-automock.spec.ts')).toMatchSnapshot('io-enableAutomock')
+      })
     })
   })
-})
 
-describe('Hoisting jest.disableAutomock()', () => {
-  const testCase = configureTestCase('hoisting/disable-automock', {
-    writeIo: true,
-    jestConfig: {
-      automock: true,
-    }
-  })
+  describe('jest.disableAutomock()', () => {
+    const testCase = configureTestCase('hoisting/disable-automock', {
+      writeIo: true,
+      jestConfig: {
+        automock: true,
+      }
+    })
 
-  testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { testLabel }) => {
-    it(testLabel, () => {
-      const result = runTest()
-      expect(result.status).toBe(0)
-      expect(result).toMatchSnapshot('output-disableAutomock')
-      expect(result.ioFor('disable-automock.spec.ts')).toMatchSnapshot('io-disableAutomock')
+    testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { testLabel }) => {
+      it(testLabel, () => {
+        const result = runTest()
+        expect(result.status).toBe(0)
+        expect(result).toMatchSnapshot('output-disableAutomock')
+        expect(result.ioFor('disable-automock.spec.ts')).toMatchSnapshot('io-disableAutomock')
+      })
     })
   })
 })

--- a/src/compiler/compiler-utils.ts
+++ b/src/compiler/compiler-utils.ts
@@ -28,7 +28,7 @@ export function cacheResolvedModules(
   logger: Logger,
 ): void {
   /* eslint-disable-next-line  @typescript-eslint/ban-ts-comment */
-  // @ts-ignore
+  // @ts-expect-error
   const importReferences = program.getSourceFile(fileName)!.imports
   /**
    * Ugly trick while waiting for https://github.com/microsoft/TypeScript/issues/33994


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
TS 3.9 introduces [ts-expect-error](https://devblogs.microsoft.com/typescript/announcing-typescript-3-9-beta/#ts-expect-error-comments) which helps to prevent using `ts-ignore` inproperly.

This PR is to enable that rule in eslint.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
