### PR TITLE
feat(config): show warning message for nodejs ts target version mismatch

### DIFF
--- a/e2e/__tests__/__snapshots__/logger.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/logger.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TS_JEST_LOG should pass and create log file when using template "default" 1`] = `
+exports[`ts-jest logging TS_JEST_LOG should pass and create log file when using template "default" 1`] = `
 Array [
   "[level:20] creating jest presets not handling JavaScript files",
   "[level:20] creating Importer singleton",
@@ -37,7 +37,7 @@ Array [
 ]
 `;
 
-exports[`TS_JEST_LOG should pass and create log file when using template "with-babel-7" 1`] = `
+exports[`ts-jest logging TS_JEST_LOG should pass and create log file when using template "with-babel-7" 1`] = `
 Array [
   "[level:20] creating jest presets not handling JavaScript files",
   "[level:20] creating Importer singleton",
@@ -80,7 +80,7 @@ Array [
 ]
 `;
 
-exports[`TS_JEST_LOG should pass and create log file when using template "with-babel-7-string-config" 1`] = `
+exports[`ts-jest logging TS_JEST_LOG should pass and create log file when using template "with-babel-7-string-config" 1`] = `
 Array [
   "[level:20] creating jest presets not handling JavaScript files",
   "[level:20] creating Importer singleton",
@@ -124,7 +124,7 @@ Array [
 ]
 `;
 
-exports[`With unsupported version test should pass using template "with-unsupported-version" 1`] = `
+exports[`ts-jest logging with unsupported version test should pass using template "with-unsupported-version" 1`] = `
   √ jest
   ↳ exit code: 0
   ===[ STDOUT ]===================================================================
@@ -141,4 +141,11 @@ exports[`With unsupported version test should pass using template "with-unsuppor
   Time:        XXs
   Ran all test suites.
   ================================================================================
+`;
+
+exports[`ts-jest logging typescript target is higher than es2019 for NodeJs 12 should pass using template "default" 1`] = `
+Array [
+  "[level:40] There is a mismatch between your NodeJs version v12.16.3 and your TypeScript target es2020. This might lead to some unexpected errors when running tests with \`ts-jest\`. To fix this, you can check https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping",
+  "[level:40] [94mmessage[0m[90m TS151001: [0mIf you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.",
+]
 `;

--- a/e2e/__tests__/logger.test.ts
+++ b/e2e/__tests__/logger.test.ts
@@ -4,35 +4,68 @@ import { existsSync } from 'fs'
 import { PackageSets, allValidPackageSets } from '../__helpers__/templates'
 import { configureTestCase } from '../__helpers__/test-case'
 
-describe('With unsupported version test', () => {
-  const testCase = configureTestCase('simple')
+describe('ts-jest logging', () => {
+  describe('with unsupported version test', () => {
+    const testCase = configureTestCase('simple')
 
-  testCase.runWithTemplates([PackageSets.unsupportedVersion], 0, (runTest, { testLabel }) => {
-    it(testLabel, () => {
-      const result = runTest()
-      expect(result.status).toBe(0)
-      expect(result).toMatchSnapshot()
+    testCase.runWithTemplates([PackageSets.unsupportedVersion], 0, (runTest, { testLabel }) => {
+      it(testLabel, () => {
+        const result = runTest()
+        expect(result.status).toBe(0)
+        expect(result).toMatchSnapshot()
+      })
     })
   })
-})
 
-describe('TS_JEST_LOG', () => {
-  const testCase = configureTestCase('simple', {
-    env: { TS_JEST_LOG: 'ts-jest.log' },
-    noCache: true,
-  })
+  describe('TS_JEST_LOG', () => {
+    const testCase = configureTestCase('simple', {
+      env: { TS_JEST_LOG: 'ts-jest.log' },
+      noCache: true,
+    })
 
-  testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { templateName }) => {
-    it(`should pass and create log file when using template "${templateName}"`, () => {
-      const result = runTest()
-      expect(result.status).toBe(0)
-      expect(existsSync(result.logFilePath)).toBe(true)
-      const filteredEntries = result.logFileEntries
-        // keep only debug and above
-        .filter(m => (m.context[LogContexts.logLevel] || 0) >= LogLevels.debug)
-        // simplify entires
-        .map(e => result.normalize(`[level:${e.context[LogContexts.logLevel]}] ${e.message}`))
-      expect(filteredEntries).toMatchSnapshot()
+    testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { templateName }) => {
+      it(`should pass and create log file when using template "${templateName}"`, () => {
+        const result = runTest()
+        expect(result.status).toBe(0)
+        expect(existsSync(result.logFilePath)).toBe(true)
+        const filteredEntries = result.logFileEntries
+          // keep only debug and above
+          .filter(m => (m.context[LogContexts.logLevel] || 0) >= LogLevels.debug)
+          // simplify entires
+          .map(e => result.normalize(`[level:${e.context[LogContexts.logLevel]}] ${e.message}`))
+        expect(filteredEntries).toMatchSnapshot()
+      })
     })
   })
+
+  /**
+   * Since we only run e2e for node 12 so we need this if here. We follow latest LTS Node version so once latest LTS version
+   * changes, we also need to change this test.
+   */
+  if (process.version.startsWith('v12')) {
+    describe('typescript target is higher than es2019 for NodeJs 12', () => {
+      const testCase = configureTestCase('simple', {
+        env: { TS_JEST_LOG: 'ts-jest.log' },
+        noCache: true,
+        tsJestConfig: {
+          tsConfig: {
+            target: 'es2020'
+          }
+        }
+      })
+
+      testCase.runWithTemplates([PackageSets.default], 0, (runTest, { testLabel }) => {
+        it(testLabel, () => {
+          const result = runTest()
+          expect(result.status).toBe(0)
+          const filteredEntries = result.logFileEntries
+            // keep only debug and above
+            .filter(m => (m.context[LogContexts.logLevel] || 0) === LogLevels.warn)
+            // simplify entires
+            .map(e => result.normalize(`[level:${e.context[LogContexts.logLevel]}] ${e.message}`))
+          expect(filteredEntries).toMatchSnapshot()
+        })
+      })
+    })
+  }
 })

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -1,11 +1,10 @@
+const jestBaseConfig = require('../jest-base')
+
+/** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
+  ...jestBaseConfig,
   rootDir: '..',
-  transform: {
-    '\\.ts$': '<rootDir>/dist/index.js',
-  },
   testMatch: ['<rootDir>/e2e/__tests__/**/*.test.ts'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
-  testEnvironment: 'node',
   snapshotSerializers: [
     '<rootDir>/e2e/__serializers__/run-result.ts',
     '<rootDir>/e2e/__serializers__/processed-source.ts',

--- a/jest-base.js
+++ b/jest-base.js
@@ -1,0 +1,12 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '\\.ts$': '<rootDir>/dist/index.js',
+  },
+  testEnvironment: 'node',
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,10 @@
+const baseConfig = require('./jest-base')
+
+/** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
+  ...baseConfig,
   rootDir: '.',
   setupFilesAfterEnv: ['<rootDir>/src/__helpers__/setup.ts'],
-  transform: {
-    '\\.ts$': '<rootDir>/dist/index.js',
-  },
   testMatch: ['<rootDir>/src/**/*.spec.ts'],
   testPathIgnorePatterns: ['<rootDir>/src/__mocks__/*'],
   collectCoverageFrom: [
@@ -14,8 +15,6 @@ module.exports = {
     '!<rootDir>/src/**/__*__/*',
     '!<rootDir>/src/util/testing.ts',
   ],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
-  testEnvironment: 'node',
   snapshotSerializers: ['<rootDir>/src/__serializers__/processed-source.ts'],
   cacheDirectory: '<rootDir>/.cache/unit',
 }

--- a/src/util/messages.ts
+++ b/src/util/messages.ts
@@ -18,6 +18,7 @@ export const enum Errors {
   GotUnknownFileTypeWithBabel = 'Got a unknown file type to compile (file: {{path}}). To fix this, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match this kind of files anymore. If you still want Babel to process it, add another entry to the `transform` option with value `babel-jest` which key matches this type of files.',
   ConfigNoModuleInterop = 'If you have issues related to imports, you should consider setting `esModuleInterop` to `true` in your TypeScript configuration file (usually `tsconfig.json`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.',
   UnableToFindProjectRoot = 'Unable to find the root of the project where ts-jest has been installed.',
+  MismatchNodeTargetMapping = 'There is a mismatch between your NodeJs version {{nodeJsVer}} and your TypeScript target {{compilationTarget}}. This might lead to some unexpected errors when running tests with `ts-jest`. To fix this, you can check https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping',
 }
 
 /**

--- a/src/util/version-checkers.ts
+++ b/src/util/version-checkers.ts
@@ -9,7 +9,7 @@ const logger = rootLogger.child({ namespace: 'versions' })
 /**
  * @internal
  */
-export const enum ExpectedVersions {
+const enum ExpectedVersions {
   Jest = '>=26 <27',
   TypeScript = '>=3.8 <4',
   BabelJest = '>=26 <27',
@@ -49,6 +49,7 @@ function checkVersion(
 ): boolean | never {
   const version = getPackageVersion(name)
   const success = !!version && satisfies(version, expectedRange)
+
   logger.debug(
     {
       actualVersion: version,
@@ -58,6 +59,7 @@ function checkVersion(
     name,
     success ? 'OK' : 'NOT OK',
   )
+
   if (!action || success) return success
 
   const message = interpolate(version ? Errors.UntestedDependencyVersion : Errors.MissingDependency, {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,15 +30,5 @@
       "node",
       "react"
     ]
-  },
-  "include": [
-    "e2e/__helpers__",
-    "e2e/__serializers__",
-    "e2e/__tests__",
-    "scripts/",
-    "src/",
-    "utils/",
-    "presets",
-    "./*.js"
-  ]
+  }
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": []
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Often I see `ts-jest` users run into the problem and turned out that ones set the `target` version in their `tsconfig` to be incompatible with their NodeJs version. This can result in some features of TypeScript when transpiling to `commonjs` aren't supported by a specific NodeJs version.

This PR is to add a warning message for NodeJs 10/12 users that they should use recommended `target` by TypeScript team at https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test and e2e test. Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information

- Created a base jest config `jest-base.js` and e2e test as well as unit test config extend from it.

- Created a `tsconfig.spec.json` to use for unit test/e2e test to speed up CI following the doc https://kulshekhar.github.io/ts-jest/user/config/isolatedModules#example-1
