### PR TITLE
docs: add missing `astTransformers` config option documentation

### DIFF
--- a/docs/user/config/astTransformers.md
+++ b/docs/user/config/astTransformers.md
@@ -1,0 +1,47 @@
+---
+title: AST transformers option
+---
+
+`ts-jest` by default does hoisting for a few `jest` methods via a TypeScript AST transformer. One can also create custom
+TypeScript AST transformers and provide them to `ts-jest` to include into compilation process.
+
+The option is `astTransformers` and it allows ones to specify which TypeScript AST transformers to use with `ts-jest`.
+
+### Examples
+
+<div class="row"><div class="col-md-6" markdown="block">
+
+```js
+// jest.config.js
+module.exports = {
+  // [...]
+  globals: {
+    'ts-jest': {
+      astTransformers: ['my-custom-transformer'],
+    }
+  }
+};
+```
+
+</div><div class="col-md-6" markdown="block">
+
+```js
+// OR package.json
+{
+  // [...]
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        astTransformers: ['my-custom-transformer'],
+      }
+    }
+  }
+}
+```
+
+</div></div>
+
+### Writing custom TypeScript AST transformers
+
+To write a custom TypeScript AST transformers, one can take a look at the one that `ts-jest` is using at
+https://github.com/kulshekhar/ts-jest/tree/master/src/transformers

--- a/docs/user/config/babelConfig.md
+++ b/docs/user/config/babelConfig.md
@@ -30,7 +30,7 @@ module.exports = {
 
 </div><div class="col-md-6" markdown="block">
 
-```json5
+```js
 // OR package.json
 {
   // [...]
@@ -76,7 +76,7 @@ module.exports = {
 ```
 </div><div class="col-md-6" markdown="block">
 
-```json5
+```js
 // OR package.json
 {
   // [...]
@@ -115,7 +115,7 @@ module.exports = {
 
 </div><div class="col-md-6" markdown="block">
 
-```json5
+```js
 // OR package.json
 {
   // [...]

--- a/docs/user/config/index.md
+++ b/docs/user/config/index.md
@@ -209,6 +209,7 @@ All options have default values which should fit most of the projects. Click on 
 | [**`compiler`**][compiler] | [TypeScript module to use as compiler.][compiler] | `string` | `"typescript"` |
 | [**`tsConfig` or `tsconfig`**][tsConfig] | [TypeScript compiler related configuration.][tsConfig] | `string`\|`object`\|`boolean` | _auto_ |
 | [**`isolatedModules`**][isolatedModules] | [Disable type-checking][isolatedModules] | `boolean` | _disabled_ |
+| [**`astTransformers`**][astTransformers] | [Custom TypeScript AST transformers][astTransformers] | `string[]` | _auto_ |
 | [**`diagnostics`**][diagnostics] | [Diagnostics related configuration.][diagnostics] | `boolean`\|`object` | _enabled_ |
 | [**`babelConfig`**][babelConfig] | [Babel(Jest) related configuration.][babelConfig] | `boolean`\|`string`\|`object` | _disabled_ |
 | [**`stringifyContentPathRegex`**][stringifyContentPathRegex] | [Files which will become modules returning self content.][stringifyContentPathRegex] | `string`\|`RegExp` | _disabled_ |

--- a/docs/user/config/isolatedModules.md
+++ b/docs/user/config/isolatedModules.md
@@ -52,7 +52,7 @@ The least amount of files which are provided in `include`, the more performance 
 
 ### Example
 
-```json5
+```js
 // tsconfig.json
 {
   // ...other configs


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

The config documentation is missing the option `astTransformers`. This PR is to provide the documentation for it.


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Wait for deployment of github page and check :)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information

For some reasons, markdown doesn't show correctly styling on doc page when using `json5` so I adjusted to `js` to get proper styling.