### PR TITLE
fix(config): invalidate cache when other options in tsconfig change

### DIFF
--- a/e2e/__cases__/ts-jest-checks/index.spec.ts
+++ b/e2e/__cases__/ts-jest-checks/index.spec.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs'
 describe('tsConfig', () => {
   it('should have digest and versions', () => {
     const tr = createTransformer()
-    const cs = tr.configsFor({} as any)
+    const cs = tr.configsFor(Object.create(null))
     expect(cs.tsJestDigest).toHaveLength(40)
     expect(cs.tsJestDigest).toBe(readFileSync(require.resolve('ts-jest/.ts-jest-digest'), 'utf8'))
     expect(cs.versions['ts-jest']).toBe(require('ts-jest/package.json').version)

--- a/src/__mocks__/tsconfig-project-references.json
+++ b/src/__mocks__/tsconfig-project-references.json
@@ -1,7 +1,0 @@
-{
-  "references": [
-    {
-      "path": "./tsconfig-src.json"
-    }
-  ]
-}

--- a/src/__mocks__/tsconfig-src.json
+++ b/src/__mocks__/tsconfig-src.json
@@ -3,5 +3,11 @@
     "composite": true,
     "declaration": true,
     "types": []
-  }
+  },
+  "include": [
+    "bar/**/*"
+  ],
+  "exclude": [
+    "foo/**/*"
+  ]
 }

--- a/src/config/__snapshots__/config-set.spec.ts.snap
+++ b/src/config/__snapshots__/config-set.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cacheKey should be a string 1`] = `"{\\"digest\\":\\"a0d51ca854194df8191d0e65c0ca4730f510f332\\",\\"jest\\":{\\"__backported\\":true,\\"globals\\":{}},\\"projectDepVersions\\":{\\"dev\\":\\"1.2.5\\",\\"opt\\":\\"1.2.3\\",\\"peer\\":\\"1.2.4\\",\\"std\\":\\"1.2.6\\"},\\"transformers\\":[\\"hoisting-jest-mock@1\\"],\\"tsJest\\":{\\"compiler\\":\\"typescript\\",\\"diagnostics\\":{\\"ignoreCodes\\":[6059,18002,18003],\\"pretty\\":true,\\"throws\\":true},\\"isolatedModules\\":false,\\"packageJson\\":{\\"kind\\":\\"file\\"},\\"transformers\\":[]},\\"tsconfig\\":{\\"declaration\\":false,\\"inlineSourceMap\\":false,\\"inlineSources\\":true,\\"module\\":1,\\"noEmit\\":false,\\"removeComments\\":false,\\"sourceMap\\":true,\\"target\\":1}}"`;
+exports[`cacheKey should be a string 1`] = `"{\\"digest\\":\\"a0d51ca854194df8191d0e65c0ca4730f510f332\\",\\"jest\\":{\\"__backported\\":true,\\"globals\\":{}},\\"projectDepVersions\\":{\\"dev\\":\\"1.2.5\\",\\"opt\\":\\"1.2.3\\",\\"peer\\":\\"1.2.4\\",\\"std\\":\\"1.2.6\\"},\\"transformers\\":[\\"hoisting-jest-mock@1\\"],\\"tsJest\\":{\\"compiler\\":\\"typescript\\",\\"diagnostics\\":{\\"ignoreCodes\\":[6059,18002,18003],\\"pretty\\":true,\\"throws\\":true},\\"isolatedModules\\":false,\\"packageJson\\":{\\"kind\\":\\"file\\"},\\"transformers\\":[],\\"tsConfig\\":{\\"kind\\":\\"file\\",\\"value\\":\\"\\"}},\\"tsconfig\\":{\\"options\\":{\\"configFilePath\\":\\"\\",\\"declaration\\":false,\\"inlineSourceMap\\":false,\\"inlineSources\\":true,\\"module\\":1,\\"noEmit\\":false,\\"removeComments\\":false,\\"sourceMap\\":true,\\"target\\":1,\\"types\\":[]},\\"raw\\":{\\"compileOnSave\\":false,\\"compilerOptions\\":{\\"composite\\":true,\\"declaration\\":true,\\"types\\":[]},\\"exclude\\":[\\"foo/**/*\\"],\\"include\\":[\\"bar/**/*\\"]}}}"`;
 
 exports[`isTestFile should return a boolean value whether the file matches test pattern 1`] = `true`;
 
@@ -68,18 +68,38 @@ Object {
     },
     "stringifyContentPathRegex": undefined,
     "transformers": Array [],
-    "tsConfig": undefined,
+    "tsConfig": Object {
+      "kind": "file",
+      "value": "",
+    },
   },
   "tsconfig": Object {
-    "configFilePath": undefined,
-    "declaration": false,
-    "inlineSourceMap": false,
-    "inlineSources": true,
-    "module": 1,
-    "noEmit": false,
-    "removeComments": false,
-    "sourceMap": true,
-    "target": 1,
+    "options": Object {
+      "configFilePath": "",
+      "declaration": false,
+      "inlineSourceMap": false,
+      "inlineSources": true,
+      "module": 1,
+      "noEmit": false,
+      "removeComments": false,
+      "sourceMap": true,
+      "target": 1,
+      "types": Array [],
+    },
+    "raw": Object {
+      "compileOnSave": false,
+      "compilerOptions": Object {
+        "composite": true,
+        "declaration": true,
+        "types": Array [],
+      },
+      "exclude": Array [
+        "foo/**/*",
+      ],
+      "include": Array [
+        "bar/**/*",
+      ],
+    },
   },
 }
 `;

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -689,7 +689,10 @@ export class ConfigSet {
       jest,
       tsJest: this.tsJest,
       babel: this.babel,
-      tsconfig: this.parsedTsConfig.options,
+      tsconfig: {
+        options: this.parsedTsConfig.options,
+        raw: this.parsedTsConfig.raw,
+      },
     })
   }
 
@@ -699,6 +702,7 @@ export class ConfigSet {
   get cacheKey(): string {
     return this.jsonValue.serialized
   }
+
   readonly logger: Logger
   /**
    * @internal
@@ -713,7 +717,7 @@ export class ConfigSet {
   /**
    * @internal
    */
-  makeDiagnostic(
+  private makeDiagnostic(
     code: number,
     messageText: string,
     options: { category?: DiagnosticCategory; file?: SourceFile; start?: number; length?: number } = {},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
At the moment, only `compilerOptions` in `tsconfig.json` is considered in cache key. However, if users change other options like `include` or `exclude`, the cache isn't invalidated. Since `include/exclude` impacts on performance with `ts-jest`, it makes sense to include them into cache key.

This PR is to invalidate cache whenever other options (`include/exclude/projectReferences`) from `tsconfig.json` change 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information

**N.A.**
