### PR TITLE
refactor(config): set private for projectPackageJson, projectDependencies, createTsError getters

### DIFF
--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -132,22 +132,23 @@ export class ConfigSet {
    * @internal
    */
   @Memoize()
-  get projectPackageJson(): Record<string, any> {
+  private get projectPackageJson(): Record<string, any> {
     const {
       tsJest: { packageJson },
     } = this
-    if (packageJson && packageJson.kind === 'inline') {
-      return packageJson.value
-    }
-    if (packageJson && packageJson.kind === 'file' && packageJson.value) {
-      const path = this.resolvePath(packageJson.value)
-      if (existsSync(path)) {
-        return require(path)
+    if (packageJson) {
+      if (packageJson.kind === 'inline') {
+        return packageJson.value
+      } else if (packageJson.kind === 'file' && packageJson.value) {
+        const path = this.resolvePath(packageJson.value)
+        if (existsSync(path)) {
+          return require(path)
+        }
+
+        this.logger.warn(Errors.UnableToFindProjectRoot)
+
+        return {}
       }
-
-      this.logger.warn(Errors.UnableToFindProjectRoot)
-
-      return {}
     }
     const tsJestRoot = resolve(__dirname, '..', '..')
     let pkgPath = resolve(tsJestRoot, '..', '..', 'package.json')
@@ -170,7 +171,7 @@ export class ConfigSet {
    * @internal
    */
   @Memoize()
-  get projectDependencies(): Record<string, string> {
+  private get projectDependencies(): Record<string, string> {
     const { projectPackageJson: pkg } = this
     const names = Object.keys({
       ...pkg.optionalDependencies,
@@ -643,7 +644,7 @@ export class ConfigSet {
    * @internal
    */
   @Memoize()
-  get createTsError(): (diagnostics: readonly Diagnostic[]) => TSError {
+  private get createTsError(): (diagnostics: readonly Diagnostic[]) => TSError {
     const {
       diagnostics: { pretty },
     } = this.tsJest


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`projectPackageJson`, `projectDependencies`, `createTsError` getters are only used within `config-set.ts`, so it makes sense to set them as private getter

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Adjusted unit test, Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
