### PR TITLE
refactor(config): set jest getter to private getter

### DIFF
--- a/src/config/__snapshots__/config-set.spec.ts.snap
+++ b/src/config/__snapshots__/config-set.spec.ts.snap
@@ -10,31 +10,6 @@ exports[`isTestFile should return a boolean value whether the file matches test 
 
 exports[`isTestFile should return a boolean value whether the file matches test pattern 4`] = `true`;
 
-exports[`jest should merge parent config if any with globals is an empty object 1`] = `
-Object {
-  "__backported": true,
-  "globals": Object {
-    "ts-jest": Object {
-      "__parent": true,
-    },
-  },
-}
-`;
-
-exports[`jest should merge parent config if any with globals is undefined 1`] = `
-Object {
-  "__backported": true,
-  "globals": undefined,
-}
-`;
-
-exports[`jest should return correct config and go thru backports 1`] = `
-Object {
-  "__backported": true,
-  "globals": Object {},
-}
-`;
-
 exports[`jsonValue should create jsonValue based on each config and version 1`] = `
 Object {
   "babel": undefined,
@@ -195,7 +170,61 @@ Object {
 }
 `;
 
-exports[`tsJest should return correct defaults 1`] = `
+exports[`tsJest jest should merge parent config if any with globals is an empty object 1`] = `
+Object {
+  "babelConfig": undefined,
+  "compiler": "typescript",
+  "diagnostics": Object {
+    "ignoreCodes": Array [
+      6059,
+      18002,
+      18003,
+    ],
+    "pretty": true,
+    "throws": true,
+  },
+  "isolatedModules": false,
+  "packageJson": Object {
+    "kind": "file",
+    "value": undefined,
+  },
+  "stringifyContentPathRegex": undefined,
+  "transformers": Object {},
+  "tsConfig": Object {
+    "kind": "file",
+    "value": undefined,
+  },
+}
+`;
+
+exports[`tsJest jest should merge parent config if any with globals is undefined 1`] = `
+Object {
+  "babelConfig": undefined,
+  "compiler": "typescript",
+  "diagnostics": Object {
+    "ignoreCodes": Array [
+      6059,
+      18002,
+      18003,
+    ],
+    "pretty": true,
+    "throws": true,
+  },
+  "isolatedModules": false,
+  "packageJson": Object {
+    "kind": "file",
+    "value": undefined,
+  },
+  "stringifyContentPathRegex": undefined,
+  "transformers": Object {},
+  "tsConfig": Object {
+    "kind": "file",
+    "value": undefined,
+  },
+}
+`;
+
+exports[`tsJest jest should return correct config and go thru backports 1`] = `
 Object {
   "babelConfig": undefined,
   "compiler": "typescript",

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -38,35 +38,6 @@ beforeEach(() => {
   jest.clearAllMocks()
 })
 
-describe('jest', () => {
-  it('should return correct config and go thru backports', () => {
-    expect(createConfigSet().jest).toMatchSnapshot()
-    expect(backports.backportJestConfig).toHaveBeenCalledTimes(1)
-  })
-
-  it('should merge parent config if any with globals is an empty object', () => {
-    expect(
-      createConfigSet({
-        jestConfig: {
-          globals: {},
-        } as any,
-        parentConfig: { __parent: true } as any,
-      }).jest,
-    ).toMatchSnapshot()
-  })
-
-  it('should merge parent config if any with globals is undefined', () => {
-    expect(
-      createConfigSet({
-        jestConfig: {
-          globals: undefined,
-        } as any,
-        parentConfig: { __parent: true } as any,
-      }).jest,
-    ).toMatchSnapshot()
-  })
-})
-
 describe('isTestFile', () => {
   it.each([
     {
@@ -102,9 +73,33 @@ describe('tsJest', () => {
   const getConfigSet = (tsJest?: TsJestGlobalOptions) => createConfigSet({ tsJestConfig: tsJest })
   const getTsJest = (tsJest?: TsJestGlobalOptions) => getConfigSet(tsJest).tsJest
 
-  it('should return correct defaults', () => {
-    expect(getConfigSet().jest.globals).toEqual({})
-    expect(getTsJest()).toMatchSnapshot()
+  describe('jest', () => {
+    it('should return correct config and go thru backports', () => {
+      expect(createConfigSet().tsJest).toMatchSnapshot()
+      expect(backports.backportJestConfig).toHaveBeenCalledTimes(1)
+    })
+
+    it('should merge parent config if any with globals is an empty object', () => {
+      expect(
+        createConfigSet({
+          jestConfig: {
+            globals: {},
+          } as any,
+          parentConfig: { __parent: true } as any,
+        }).tsJest,
+      ).toMatchSnapshot()
+    })
+
+    it('should merge parent config if any with globals is undefined', () => {
+      expect(
+        createConfigSet({
+          jestConfig: {
+            globals: undefined,
+          } as any,
+          parentConfig: { __parent: true } as any,
+        }).tsJest,
+      ).toMatchSnapshot()
+    })
   })
 
   describe('packageJson', () => {
@@ -936,12 +931,13 @@ describe('tsCacheDir', () => {
   const partialTsJestCacheDir = join(cacheDir, 'ts-jest')
 
   it.each([
-    { packageJson: undefined },
-    { packageJson: { name: 'foo' } },
-    { packageJson: 'src/__mocks__/package-foo.json' },
+    undefined,
+    Object.create(null),
+    { 'ts-jest': { packageJson: undefined } },
+    { 'ts-jest': { packageJson: { name: 'foo' } } },
+    { 'ts-jest': { packageJson: 'src/__mocks__/package-foo.json' } },
   ])(
-    'should return value from which is the combination of ts jest config and jest config when running test with cache' +
-      ' and package.json exists',
+    'should return value from which is the combination of ts jest config and jest config when running test with cache',
     (data) => {
       expect(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -949,8 +945,8 @@ describe('tsCacheDir', () => {
           jestConfig: {
             cache: true,
             cacheDirectory: cacheDir,
+            globals: data,
           },
-          tsJestConfig: data,
           resolve: null,
         }).tsCacheDir!.indexOf(partialTsJestCacheDir),
       ).toEqual(0)
@@ -966,8 +962,10 @@ describe('tsCacheDir', () => {
           jestConfig: {
             cache: true,
             cacheDirectory: cacheDir,
+            globals: {
+              'ts-jest': { packageJson: packageJsonPath },
+            },
           },
-          tsJestConfig: { packageJson: packageJsonPath },
           resolve: null,
         }).tsCacheDir,
     ).toThrowError(
@@ -993,9 +991,11 @@ describe('tsCacheDir', () => {
           jestConfig: {
             cache: true,
             cacheDirectory: cacheDir,
+            globals: {
+              'ts-jest': { packageJson: packageJsonPath },
+            },
           },
           logger,
-          tsJestConfig: { packageJson: packageJsonPath },
         }).tsCacheDir!.indexOf(partialTsJestCacheDir),
       ).toEqual(0)
       expect(logger.target.lines[2]).toMatchInlineSnapshot(`
@@ -1044,8 +1044,10 @@ describe('tsCacheDir', () => {
       jestConfig: {
         cache: true,
         cacheDirectory: cacheDir,
+        globals: {
+          'ts-jest': { tsConfig: false },
+        },
       },
-      tsJestConfig: { tsConfig: false } as any,
       projectPackageJson: pkg,
     })
 

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -192,11 +192,10 @@ export class ConfigSet {
    * @internal
    */
   @Memoize()
-  get jest(): Config.ProjectConfig {
+  private get jest(): Config.ProjectConfig {
     const config = backportJestConfig(this.logger, this._jestConfig)
     if (this.parentOptions) {
-      const globals: any = config.globals ?? {}
-      // TODO: implement correct deep merging instead
+      const globals: Config.ConfigGlobals = config.globals ?? Object.create(null)
       globals['ts-jest'] = {
         ...this.parentOptions,
         ...globals['ts-jest'],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Set `get jest()` to private since it is not used outside `config-set.ts`.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Adjusted unit tests, green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
