### PR TITLE
refactor(config): mark babelConfig and filterDiagnostics getters as private getters

### DIFF
--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -448,7 +448,7 @@ export class ConfigSet {
    * @internal
    */
   @Memoize()
-  get babel(): BabelConfig | undefined {
+  private get babel(): BabelConfig | undefined {
     const {
       tsJest: { babelConfig },
     } = this
@@ -587,7 +587,7 @@ export class ConfigSet {
    * @internal
    */
   @Memoize()
-  get filterDiagnostics(): (diagnostics: Diagnostic[], filePath?: string) => Diagnostic[] {
+  private get filterDiagnostics(): (diagnostics: Diagnostic[], filePath?: string) => Diagnostic[] {
     const {
       tsJest: {
         diagnostics: { ignoreCodes },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Mark `babelConfig` and `filterDiagnostics` as private getters because they are not used outside `config-set.ts`

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Adjusted unit tests, green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
