### PR TITLE
refactor(config): compute cache key without reading package.json

### DIFF
--- a/src/config/__snapshots__/config-set.spec.ts.snap
+++ b/src/config/__snapshots__/config-set.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cacheKey should be a string 1`] = `"{\\"digest\\":\\"a0d51ca854194df8191d0e65c0ca4730f510f332\\",\\"jest\\":{\\"__backported\\":true,\\"globals\\":{}},\\"projectDepVersions\\":{\\"dev\\":\\"1.2.5\\",\\"opt\\":\\"1.2.3\\",\\"peer\\":\\"1.2.4\\",\\"std\\":\\"1.2.6\\"},\\"transformers\\":[\\"hoisting-jest-mock@1\\"],\\"tsJest\\":{\\"compiler\\":\\"typescript\\",\\"diagnostics\\":{\\"ignoreCodes\\":[6059,18002,18003],\\"pretty\\":true,\\"throws\\":true},\\"isolatedModules\\":false,\\"packageJson\\":{\\"kind\\":\\"file\\"},\\"transformers\\":{},\\"tsConfig\\":{\\"kind\\":\\"file\\",\\"value\\":\\"\\"}},\\"tsconfig\\":{\\"options\\":{\\"configFilePath\\":\\"\\",\\"declaration\\":false,\\"inlineSourceMap\\":false,\\"inlineSources\\":true,\\"module\\":1,\\"noEmit\\":false,\\"removeComments\\":false,\\"sourceMap\\":true,\\"target\\":1,\\"types\\":[]},\\"raw\\":{\\"compileOnSave\\":false,\\"compilerOptions\\":{\\"composite\\":true,\\"declaration\\":true,\\"types\\":[]},\\"exclude\\":[\\"foo/**/*\\"],\\"include\\":[\\"bar/**/*\\"]}}}"`;
+exports[`cacheKey should be a string 1`] = `"{\\"digest\\":\\"a0d51ca854194df8191d0e65c0ca4730f510f332\\",\\"jest\\":{\\"__backported\\":true,\\"globals\\":{}},\\"transformers\\":[\\"hoisting-jest-mock@1\\"],\\"tsJest\\":{\\"compiler\\":\\"typescript\\",\\"diagnostics\\":{\\"ignoreCodes\\":[6059,18002,18003],\\"pretty\\":true,\\"throws\\":true},\\"isolatedModules\\":false,\\"packageJson\\":{\\"kind\\":\\"file\\"},\\"transformers\\":{},\\"tsConfig\\":{\\"kind\\":\\"file\\",\\"value\\":\\"\\"}},\\"tsconfig\\":{\\"options\\":{\\"configFilePath\\":\\"\\",\\"declaration\\":false,\\"inlineSourceMap\\":false,\\"inlineSources\\":true,\\"module\\":1,\\"noEmit\\":false,\\"removeComments\\":false,\\"sourceMap\\":true,\\"target\\":1,\\"types\\":[]},\\"raw\\":{\\"compileOnSave\\":false,\\"compilerOptions\\":{\\"composite\\":true,\\"declaration\\":true,\\"types\\":[]},\\"exclude\\":[\\"foo/**/*\\"],\\"include\\":[\\"bar/**/*\\"]}}}"`;
 
 exports[`isTestFile should return a boolean value whether the file matches test pattern 1`] = `true`;
 
@@ -19,9 +19,6 @@ Object {
     "cacheDirectory": undefined,
     "globals": Object {},
     "name": undefined,
-  },
-  "projectDepVersions": Object {
-    "some-module": "1.2.3",
   },
   "transformers": Array [
     "hoisting-jest-mock@1",

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -16,7 +16,7 @@ import { mocked } from '../util'
 import { IGNORE_DIAGNOSTIC_CODES, MATCH_NOTHING, TS_JEST_OUT_DIR } from './config-set'
 // eslint-disable-next-line no-duplicate-imports
 import type { ConfigSet } from './config-set'
-import { Deprecations, Errors, interpolate } from '../util/messages'
+import { Deprecations } from '../util/messages'
 
 jest.mock('../util/backports')
 jest.mock('../index')
@@ -809,13 +809,7 @@ describe('tsCacheDir', () => {
   const cacheDir = join(process.cwd(), cacheName)
   const partialTsJestCacheDir = join(cacheDir, 'ts-jest')
 
-  it.each([
-    undefined,
-    Object.create(null),
-    { 'ts-jest': { packageJson: undefined } },
-    { 'ts-jest': { packageJson: { name: 'foo' } } },
-    { 'ts-jest': { packageJson: 'src/__mocks__/package-foo.json' } },
-  ])(
+  it.each([undefined, Object.create(null)])(
     'should return value from which is the combination of ts jest config and jest config when running test with cache',
     (data) => {
       expect(
@@ -831,73 +825,6 @@ describe('tsCacheDir', () => {
       ).toEqual(0)
     },
   )
-
-  it('should throw error when running test with cache and cannot resolve package.json path', () => {
-    const packageJsonPath = 'src/__mocks__/not-exist.json'
-
-    expect(
-      () =>
-        createConfigSet({
-          jestConfig: {
-            cache: true,
-            cacheDirectory: cacheDir,
-            globals: {
-              'ts-jest': { packageJson: packageJsonPath },
-            },
-          },
-          resolve: null,
-        }).tsCacheDir,
-    ).toThrowError(
-      new Error(
-        interpolate(Errors.FileNotFound, {
-          inputPath: 'src/__mocks__/not-exist.json',
-          resolvedPath: join(process.cwd(), packageJsonPath),
-        }),
-      ),
-    )
-  })
-
-  it(
-    'should return value and show warning when running test with cache and package.json path is' +
-      ' resolved but the path does not exist',
-    () => {
-      const packageJsonPath = 'src/__mocks__/not-exist.json'
-      const logger = testing.createLoggerMock()
-
-      expect(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        createConfigSet({
-          jestConfig: {
-            cache: true,
-            cacheDirectory: cacheDir,
-            globals: {
-              'ts-jest': { packageJson: packageJsonPath },
-            },
-          },
-          logger,
-        }).tsCacheDir!.indexOf(partialTsJestCacheDir),
-      ).toEqual(0)
-      expect(logger.target.lines[2]).toMatchInlineSnapshot(`
-        "[level:40] Unable to find the root of the project where ts-jest has been installed.
-        "
-      `)
-
-      logger.target.clear()
-    },
-  )
-
-  it('should return value from root packageJson when running test with cache and real path rootDir is the same as tsJest root', () => {
-    expect(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      createConfigSet({
-        jestConfig: {
-          cache: true,
-          cacheDirectory: cacheDir,
-        },
-        resolve: null,
-      }).tsCacheDir!.indexOf(partialTsJestCacheDir),
-    ).toEqual(0)
-  })
 
   it('should return undefined when running test without cache', () => {
     expect(createConfigSet({ resolve: null }).tsCacheDir).toBeUndefined()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
It is not necessary to get all dependencies' versions in `package.json` for computing cache key. This PR is to remove the getting project's dependencies from computing cache key.

Closes #1892 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**