### PR TITLE
perf(transformer): remove createProgram from transpiler 

### DIFF
--- a/src/compiler/transpiler.ts
+++ b/src/compiler/transpiler.ts
@@ -10,9 +10,8 @@ import type { CompilerInstance, SourceOutput } from '../types'
 export const initializeTranspilerInstance = (configs: ConfigSet, logger: Logger): CompilerInstance => {
   logger.debug('initializeTranspilerInstance(): create typescript compiler')
 
-  const { options, fileNames } = configs.parsedTsConfig
+  const { options } = configs.parsedTsConfig
   const ts = configs.compilerModule
-  const program = ts.createProgram(fileNames, options)
 
   return {
     compileFn: (code: string, fileName: string): SourceOutput => {
@@ -31,6 +30,6 @@ export const initializeTranspilerInstance = (configs: ConfigSet, logger: Logger)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return [result.outputText, result.sourceMapText!]
     },
-    program,
+    program: undefined,
   }
 }


### PR DESCRIPTION
## Summary

I found that Typescript's `createProgram` API is called even when `isolatedModule` is set. 
This is a major slow down (100 msecs vs 10~50 secs) for test start up and it doesn't seem to make sense for `isolatedModule` anyway. 
Longer test start up -> longer feedback cycle -> lower productivity. 


## Test plan

N/A. The `program` isn't used by any part of ts-jest, at least not in its critical path.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Maybe

I just don't know enough about the use case of `program` for `isolatedModule`.


## Other information


I tried to gather the history around this but couldn't find any notes regarding `transpiler`'s need for `program`. 
If the `createProgram` turned out to be desirable thing here, I am happy to create another PR to introduce a flag to disable it.

Otherwise, I believe majority of `isolatedModule` users will benefit from this PR greatly. 