### PR TITLE
refactor(transformer): correctly detect jest import name bindings

### DIFF
--- a/e2e/__cases__/hoisting/import-jest.spec.ts
+++ b/e2e/__cases__/hoisting/import-jest.spec.ts
@@ -1,4 +1,4 @@
-import {jest} from '@jest/globals'
+import {test,jest} from '@jest/globals'
 import {jest as aliasedJest} from '@jest/globals'
 import * as JestGlobals from '@jest/globals'
 

--- a/src/config/__snapshots__/config-set.spec.ts.snap
+++ b/src/config/__snapshots__/config-set.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cacheKey should be a string 1`] = `"{\\"digest\\":\\"a0d51ca854194df8191d0e65c0ca4730f510f332\\",\\"jest\\":{\\"__backported\\":true,\\"globals\\":{}},\\"transformers\\":[\\"hoisting-jest-mock@3\\"],\\"tsJest\\":{\\"compiler\\":\\"typescript\\",\\"diagnostics\\":{\\"ignoreCodes\\":[6059,18002,18003],\\"pretty\\":true,\\"throws\\":true},\\"isolatedModules\\":false,\\"packageJson\\":{\\"kind\\":\\"file\\"},\\"transformers\\":{},\\"tsConfig\\":{\\"kind\\":\\"file\\",\\"value\\":\\"\\"}},\\"tsconfig\\":{\\"options\\":{\\"configFilePath\\":\\"\\",\\"declaration\\":false,\\"inlineSourceMap\\":false,\\"inlineSources\\":true,\\"module\\":1,\\"noEmit\\":false,\\"removeComments\\":false,\\"sourceMap\\":true,\\"target\\":1,\\"types\\":[]},\\"raw\\":{\\"compileOnSave\\":false,\\"compilerOptions\\":{\\"composite\\":true,\\"declaration\\":true,\\"types\\":[]},\\"exclude\\":[\\"foo/**/*\\"],\\"include\\":[\\"bar/**/*\\"]}}}"`;
+exports[`cacheKey should be a string 1`] = `"{\\"digest\\":\\"a0d51ca854194df8191d0e65c0ca4730f510f332\\",\\"jest\\":{\\"__backported\\":true,\\"globals\\":{}},\\"transformers\\":[\\"hoisting-jest-mock@4\\"],\\"tsJest\\":{\\"compiler\\":\\"typescript\\",\\"diagnostics\\":{\\"ignoreCodes\\":[6059,18002,18003],\\"pretty\\":true,\\"throws\\":true},\\"isolatedModules\\":false,\\"packageJson\\":{\\"kind\\":\\"file\\"},\\"transformers\\":{},\\"tsConfig\\":{\\"kind\\":\\"file\\",\\"value\\":\\"\\"}},\\"tsconfig\\":{\\"options\\":{\\"configFilePath\\":\\"\\",\\"declaration\\":false,\\"inlineSourceMap\\":false,\\"inlineSources\\":true,\\"module\\":1,\\"noEmit\\":false,\\"removeComments\\":false,\\"sourceMap\\":true,\\"target\\":1,\\"types\\":[]},\\"raw\\":{\\"compileOnSave\\":false,\\"compilerOptions\\":{\\"composite\\":true,\\"declaration\\":true,\\"types\\":[]},\\"exclude\\":[\\"foo/**/*\\"],\\"include\\":[\\"bar/**/*\\"]}}}"`;
 
 exports[`isTestFile should return a boolean value whether the file matches test pattern 1`] = `true`;
 
@@ -21,7 +21,7 @@ Object {
     "name": undefined,
   },
   "transformers": Array [
-    "hoisting-jest-mock@3",
+    "hoisting-jest-mock@4",
   ],
   "tsJest": Object {
     "babelConfig": undefined,

--- a/src/transformers/__snapshots__/hoist-jest.spec.ts.snap
+++ b/src/transformers/__snapshots__/hoist-jest.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`hoisting should hoist correctly jest methods 1`] = `
 "\\"use strict\\";
 Object.defineProperty(exports, \\"__esModule\\", { value: true });
+var globals_1 = require(\\"@jest/globals\\");
 // These will all be hoisted above imports
 jest.unmock('react');
 jest.deepUnmock('../__test_modules__/Unmocked');
@@ -69,6 +70,7 @@ console.log(d_1.default);
 console.log(e);
 console.log(virtualModule);
 console.log(jestBackticks_1.default);
+console.log(globals_1.it);
 "
 `;
 
@@ -95,5 +97,6 @@ console.log(a_1.default);
 console.log(b_1.default);
 console.log(c_1.default);
 console.log(d_1.default);
+console.log(globals_1.it);
 "
 `;

--- a/src/transformers/hoist-jest.spec.ts
+++ b/src/transformers/hoist-jest.spec.ts
@@ -7,6 +7,7 @@ const CODE_WITH_HOISTING_NO_JEST_GLOBALS = `
 import React from 'react'
 import Unmocked from '../__test_modules__/Unmocked'
 import Mocked from '../__test_modules__/Mocked'
+import {it} from '@jest/globals'
 import a from '../__test_modules__/a'
 import b from '../__test_modules__/b'
 import c from '../__test_modules__/c'
@@ -81,12 +82,13 @@ console.log(d)
 console.log(e)
 console.log(virtualModule)
 console.log(jestBackticks)
+console.log(it)
 `
 const CODE_WITH_HOISTING_HAS_JEST_GLOBALS = `
   import a from '../__test_modules__/a'
   import b from '../__test_modules__/b'
 
-  import {jest} from '@jest/globals'
+  import {it, jest} from '@jest/globals'
   import {jest as aliasedJest} from '@jest/globals'
   import * as JestGlobals from '@jest/globals'
 
@@ -110,6 +112,7 @@ const CODE_WITH_HOISTING_HAS_JEST_GLOBALS = `
   console.log(b)
   console.log(c)
   console.log(d)
+  console.log(it)
 `
 
 const logger = testing.createLoggerMock()

--- a/src/transformers/hoist-jest.ts
+++ b/src/transformers/hoist-jest.ts
@@ -29,7 +29,7 @@ export const name = 'hoisting-jest-mock'
  *
  * @internal
  */
-export const version = 3
+export const version = 4
 
 /**
  * The factory of hoisting transformer factory
@@ -147,9 +147,14 @@ export function factory(cs: ConfigSet): (ctx: TransformationContext) => Transfor
           ts.isNamedImports(resultNode.importClause.namedBindings))
       ) {
         const { namedBindings } = resultNode.importClause
-        importNames.push(
-          ts.isNamespaceImport(namedBindings) ? namedBindings.name.text : namedBindings.elements[0].name.text,
-        )
+        const jestImportName = ts.isNamespaceImport(namedBindings)
+          ? namedBindings.name.text
+          : namedBindings.elements.find(
+              (element) => element.name.text === JEST_GLOBAL_NAME || element.propertyName?.text === JEST_GLOBAL_NAME,
+            )?.name.text
+        if (jestImportName) {
+          importNames.push(jestImportName)
+        }
       }
       // check if we have something to hoist in this level
       if (hoisted[level] && hoisted[level].length) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
In #1937, we added support for `@jest/globals`. However, the logic to detect jest import name bindings wasn't correct. It failed with the case `import {test,jest} from '@jest/globals'`. This PR will fix that issue.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Adjusted unit test, e2e test. Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
