### PR TITLE
fix(utils): MaybeMockedConstructor returns T

### DIFF
--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -11,7 +11,7 @@ interface MockWithArgs<T extends MockableFunction> extends jest.MockInstance<Ret
 
 type MaybeMockedConstructor<T> = T extends new (...args: any[]) => infer R
   ? jest.MockInstance<R, ConstructorArgumentsOf<T>>
-  : {} // eslint-disable-line @typescript-eslint/ban-types
+  : T
 type MockedFunction<T extends MockableFunction> = MockWithArgs<T> & { [K in keyof T]: T[K] }
 type MockedFunctionDeep<T extends MockableFunction> = MockWithArgs<T> & MockedObjectDeep<T>
 type MockedObject<T> = MaybeMockedConstructor<T> &


### PR DESCRIPTION
## Summary

At this point, `MaybeMockedConstructor` can return an empty object, causing the source type to be lost. This PR fixes this.

For example, the `mocked(MyClass.prototype)` function actually returns a new type that has the same properties as `MyClass.prototype`, but does not link to `MyClass.prototype`.

Because of this, you cannot click on a specific property and go to the source class. For the same reason, during refactoring, renaming properties in the source class does not rename the corresponding properties in the tests.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


