### PR TITLE
refactor(config): deprecate option `tsConfig` in favor of `tsconfig`

### DIFF
--- a/e2e/__cases__/deep/src/Tests/jest.config.js
+++ b/e2e/__cases__/deep/src/Tests/jest.config.js
@@ -17,7 +17,7 @@ module.exports = Object.assign({}, cfg, {
   testEnvironment: "node",
   globals: {
     "ts-jest": {
-      tsConfig: "./tsconfig.json",
+      tsconfig: "./tsconfig.json",
     },
   },
 })

--- a/e2e/__external-repos__/simple-project-references/jest.config.js
+++ b/e2e/__external-repos__/simple-project-references/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   globals: {
     'ts-jest': {
       isolatedModules: true,
-      tsConfig: 'tsconfig-tests.json'
+      tsconfig: 'tsconfig-tests.json'
     },
   },
 }

--- a/e2e/__external-repos__/simple/with-dependency/package.json
+++ b/e2e/__external-repos__/simple/with-dependency/package.json
@@ -31,7 +31,7 @@
     "globals": {
       "ts-jest": {
         "diagnostics": true,
-        "tsConfig": "<rootDir>/tsconfig.json"
+        "tsconfig": "<rootDir>/tsconfig.json"
       }
     }
   },

--- a/e2e/__templates__/default/jest.config.js
+++ b/e2e/__templates__/default/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globals: { 'ts-jest': { tsConfig: {} } },
+  globals: { 'ts-jest': { tsconfig: {} } },
 }

--- a/e2e/__templates__/with-babel-7-string-config/jest.config.js
+++ b/e2e/__templates__/with-babel-7-string-config/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globals: { 'ts-jest': { tsConfig: {}, babelConfig: 'babel.config.js' } },
+  globals: { 'ts-jest': { tsconfig: {}, babelConfig: 'babel.config.js' } },
 }

--- a/e2e/__templates__/with-babel-7/jest.config.js
+++ b/e2e/__templates__/with-babel-7/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globals: { 'ts-jest': { tsConfig: {}, babelConfig: true } },
+  globals: { 'ts-jest': { tsconfig: {}, babelConfig: true } },
 }

--- a/e2e/__templates__/with-unsupported-version/jest.config.js
+++ b/e2e/__templates__/with-unsupported-version/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globals: { 'ts-jest': { tsConfig: {}, diagnostics: { ignoreCodes: [5023, 5024] } } },
+  globals: { 'ts-jest': { tsconfig: {}, diagnostics: { ignoreCodes: [5023, 5024] } } },
 }

--- a/e2e/__tests__/ast-transformers.test.ts
+++ b/e2e/__tests__/ast-transformers.test.ts
@@ -22,7 +22,7 @@ describe('AST transformers', () => {
 
   describe('path mapping', () => {
     const tsJestConfig = {
-      tsConfig: {
+      tsconfig: {
         baseUrl: '.',
         paths: {
           '@share/*': ['share/*']
@@ -53,8 +53,8 @@ describe('AST transformers', () => {
       const testCase = configureTestCase('ast-transformers/path-mapping', {
         tsJestConfig: {
           ...tsJestConfig,
-          tsConfig: {
-            ...tsJestConfig.tsConfig,
+          tsconfig: {
+            ...tsJestConfig.tsconfig,
             rootDirs: ['./'],
           },
         },

--- a/e2e/__tests__/logger.test.ts
+++ b/e2e/__tests__/logger.test.ts
@@ -66,7 +66,7 @@ describe('ts-jest logging', () => {
         env: { TS_JEST_LOG: 'ts-jest.log' },
         noCache: true,
         tsJestConfig: {
-          tsConfig: {
+          tsconfig: {
             target: 'es2020' as any
           }
         }

--- a/e2e/__tests__/module-kinds/helpers.ts
+++ b/e2e/__tests__/module-kinds/helpers.ts
@@ -9,7 +9,7 @@ import { configureTestCase } from '../../__helpers__/test-case'
 // ESNext = 6
 
 const testCaseForCompilerOpt = (config: any) => configureTestCase('module-kinds', {
-    tsJestConfig: { tsConfig: config, diagnostics: { warnOnly: true } },
+    tsJestConfig: { tsconfig: config, diagnostics: { warnOnly: true } },
     noCache: true,
   })
 

--- a/e2e/__tests__/source-map.test.ts
+++ b/e2e/__tests__/source-map.test.ts
@@ -48,7 +48,7 @@ describe('Source map', () => {
   describe('with tsconfig mapRoot', () => {
     runSourceMapTests({
       ...BASE_CONFIG,
-      tsConfig: {
+      tsconfig: {
         mapRoot: './'
       }
     })

--- a/e2e/__tests__/test-helpers.test.ts
+++ b/e2e/__tests__/test-helpers.test.ts
@@ -8,7 +8,7 @@ test('test-helpers', () => {
 test('with esModuleInterop set to false', () => {
   const test = configureTestCase('test-helpers', {
     noCache: true,
-    tsJestConfig: { tsConfig: { esModuleInterop: false, allowSyntheticDefaultImports: false } },
+    tsJestConfig: { tsconfig: { esModuleInterop: false, allowSyntheticDefaultImports: false } },
   })
   expect(test.run(1)).toMatchSnapshot()
 })

--- a/jest-base.js
+++ b/jest-base.js
@@ -2,7 +2,7 @@
 module.exports = {
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.spec.json',
+      tsconfig: 'tsconfig.spec.json',
     },
   },
   transform: {

--- a/src/compiler/language-service.spec.ts
+++ b/src/compiler/language-service.spec.ts
@@ -10,7 +10,7 @@ import ProcessedSource from '../__helpers__/processed-source'
 const logTarget = logTargetMock()
 
 describe('Language service', () => {
-  const baseTsJestConfig = { tsConfig: require.resolve('../../tsconfig.spec.json') }
+  const baseTsJestConfig = { tsconfig: require.resolve('../../tsconfig.spec.json') }
 
   beforeEach(() => {
     logTarget.clear()
@@ -22,7 +22,7 @@ describe('Language service', () => {
 
     it('should compile js file for allowJs true with outDir', () => {
       const compiler = makeCompiler({
-        tsJestConfig: { tsConfig: { allowJs: true, outDir: '$$foo$$' } },
+        tsJestConfig: { tsconfig: { allowJs: true, outDir: '$$foo$$' } },
       })
 
       const compiled = compiler.compile(source, fileName)
@@ -32,7 +32,7 @@ describe('Language service', () => {
 
     it('should compile js file for allowJs true without outDir', () => {
       const compiler = makeCompiler({
-        tsJestConfig: { tsConfig: { allowJs: true } },
+        tsJestConfig: { tsconfig: { allowJs: true } },
       })
       const compiled = compiler.compile(source, fileName)
 
@@ -51,7 +51,7 @@ describe('Language service', () => {
     it('should compile tsx file for jsx preserve', () => {
       const compiler = makeCompiler({
         tsJestConfig: {
-          tsConfig: {
+          tsconfig: {
             jsx: 'preserve' as any,
           },
         },
@@ -65,7 +65,7 @@ describe('Language service', () => {
     it('should compile tsx file for other jsx options', () => {
       const compiler = makeCompiler({
         tsJestConfig: {
-          tsConfig: {
+          tsconfig: {
             jsx: 'react' as any,
           },
         },
@@ -81,7 +81,7 @@ describe('Language service', () => {
     const fileName = 'test-source-map.ts'
 
     it('should have correct source maps without mapRoot', () => {
-      const compiler = makeCompiler({ tsJestConfig: { tsConfig: require.resolve('../../tsconfig.spec.json') } })
+      const compiler = makeCompiler({ tsJestConfig: { tsconfig: require.resolve('../../tsconfig.spec.json') } })
       const compiled = compiler.compile(source, fileName)
 
       expect(new ProcessedSource(compiled, fileName).outputSourceMaps).toMatchObject({
@@ -94,7 +94,7 @@ describe('Language service', () => {
     it('should have correct source maps with mapRoot', () => {
       const compiler = makeCompiler({
         tsJestConfig: {
-          tsConfig: {
+          tsconfig: {
             mapRoot: './',
           },
         },

--- a/src/compiler/transpiler.spec.ts
+++ b/src/compiler/transpiler.spec.ts
@@ -10,7 +10,7 @@ describe('Transpiler', () => {
   it('should compile js file for allowJs true', () => {
     const fileName = 'foo.js'
     const compiler = makeCompiler({
-      tsJestConfig: { ...baseTsJestConfig, tsConfig: { allowJs: true, outDir: TS_JEST_OUT_DIR } },
+      tsJestConfig: { ...baseTsJestConfig, tsconfig: { allowJs: true, outDir: TS_JEST_OUT_DIR } },
     })
     const source = 'export default 42'
 
@@ -31,7 +31,7 @@ describe('Transpiler', () => {
       const compiler = makeCompiler({
         tsJestConfig: {
           ...baseTsJestConfig,
-          tsConfig: {
+          tsconfig: {
             jsx: 'preserve' as any,
           },
         },
@@ -45,7 +45,7 @@ describe('Transpiler', () => {
       const compiler = makeCompiler({
         tsJestConfig: {
           ...baseTsJestConfig,
-          tsConfig: {
+          tsconfig: {
             jsx: 'react' as any,
           },
         },
@@ -61,7 +61,7 @@ describe('Transpiler', () => {
     const fileName = 'test-source-map-transpiler.ts'
 
     it('should have correct source maps without mapRoot', () => {
-      const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsConfig: false } })
+      const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsconfig: false } })
       const compiled = compiler.compile(source, fileName)
 
       expect(new ProcessedSource(compiled, fileName).outputSourceMaps).toMatchObject({
@@ -75,7 +75,7 @@ describe('Transpiler', () => {
       const compiler = makeCompiler({
         tsJestConfig: {
           ...baseTsJestConfig,
-          tsConfig: {
+          tsconfig: {
             mapRoot: './',
           },
         },
@@ -92,7 +92,7 @@ describe('Transpiler', () => {
 
   describe('diagnostics', () => {
     it('should not report diagnostics related to typings', () => {
-      const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsConfig: false } })
+      const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsconfig: false } })
 
       expect(() =>
         compiler.compile(
@@ -107,7 +107,7 @@ const v: boolean = t
     })
 
     it('should report diagnostics related to codes with pathRegex config is undefined', () => {
-      const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsConfig: false } })
+      const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsconfig: false } })
 
       expect(() =>
         compiler.compile(
@@ -122,7 +122,7 @@ const t: string = f(5)
 
     it('should report diagnostics related to codes with pathRegex config matches file name', () => {
       const compiler = makeCompiler({
-        tsJestConfig: { ...baseTsJestConfig, tsConfig: false, diagnostics: { pathRegex: 'foo.ts' } },
+        tsJestConfig: { ...baseTsJestConfig, tsconfig: false, diagnostics: { pathRegex: 'foo.ts' } },
       })
 
       expect(() =>
@@ -138,7 +138,7 @@ const t: string = f(5)
 
     it('should not report diagnostics related to codes with pathRegex config does not match file name', () => {
       const compiler = makeCompiler({
-        tsJestConfig: { ...baseTsJestConfig, tsConfig: false, diagnostics: { pathRegex: 'bar.ts' } },
+        tsJestConfig: { ...baseTsJestConfig, tsconfig: false, diagnostics: { pathRegex: 'bar.ts' } },
       })
 
       expect(() =>

--- a/src/config/__snapshots__/config-set.spec.ts.snap
+++ b/src/config/__snapshots__/config-set.spec.ts.snap
@@ -366,3 +366,8 @@ Array [
   },
 ]
 `;
+
+exports[`tsJest tsconfig should show warning message with tsConfig option 1`] = `
+"[level:40] The option \`tsConfig\` is deprecated and will be removed in ts-jest 27, use \`tsconfig\` instead
+"
+`;

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -100,6 +100,62 @@ describe('tsJest', () => {
     })
   })
 
+  describe('tsconfig', () => {
+    const logger = testing.createLoggerMock()
+
+    beforeEach(() => {
+      logger.target.clear()
+    })
+
+    it('should show warning message with tsConfig option', () => {
+      const cs = createConfigSet({
+        jestConfig: {
+          globals: {
+            'ts-jest': {
+              tsConfig: {
+                resolveJsonModule: true,
+              },
+            },
+          },
+        } as any,
+        logger,
+        resolve: null,
+      })
+
+      expect(cs.tsJest.tsConfig).toEqual({
+        kind: 'inline',
+        value: {
+          resolveJsonModule: true,
+        },
+      })
+      expect(logger.target.lines[1]).toMatchSnapshot()
+    })
+
+    it('should not show warning message with tsconfig option', () => {
+      const cs = createConfigSet({
+        jestConfig: {
+          globals: {
+            'ts-jest': {
+              tsconfig: {
+                resolveJsonModule: true,
+              },
+            },
+          },
+        } as any,
+        logger,
+        resolve: null,
+      })
+
+      expect(cs.tsJest.tsConfig).toEqual({
+        kind: 'inline',
+        value: {
+          resolveJsonModule: true,
+        },
+      })
+      expect(logger.target.lines[1]).not.toContain(Deprecations.TsConfig)
+    })
+  })
+
   describe('packageJson', () => {
     it('should be correct when packageJson is true', () => {
       const EXPECTED = {
@@ -347,23 +403,23 @@ describe('parsedTsConfig', () => {
   })
 
   it('should include compiler config from base config', () => {
-    expect(get(void 0, { tsConfig: { target: 'esnext' as any } }).options.target).toBe(ts.ScriptTarget.ESNext)
+    expect(get(void 0, { tsconfig: { target: 'esnext' as any } }).options.target).toBe(ts.ScriptTarget.ESNext)
   })
 
   it('should override some options', () => {
-    expect(get({ tsConfig: { module: 'esnext' as any, inlineSources: false } }).options).toMatchObject({
+    expect(get({ tsconfig: { module: 'esnext' as any, inlineSources: false } }).options).toMatchObject({
       module: ts.ModuleKind.CommonJS,
       inlineSources: true,
     })
   })
 
   it('should include default outDir $$ts-jest$$ when allowJs is enabled and no outDir from config', () => {
-    expect(get(void 0, { tsConfig: { allowJs: true } }).options.outDir).toBe(TS_JEST_OUT_DIR)
+    expect(get(void 0, { tsconfig: { allowJs: true } }).options.outDir).toBe(TS_JEST_OUT_DIR)
   })
 
   it('should be able to read extends', () => {
     const cs = createConfigSet({
-      tsJestConfig: { tsConfig: 'tsconfig.build.json' },
+      tsJestConfig: { tsconfig: 'tsconfig.build.json' },
       resolve: null,
     })
     expect(cs.parsedTsConfig.options).toMatchObject({
@@ -378,7 +434,7 @@ describe('parsedTsConfig', () => {
     target.clear()
     const cs = createConfigSet({
       tsJestConfig: {
-        tsConfig: { module: 'ES6', esModuleInterop: false } as any,
+        tsconfig: { module: 'ES6', esModuleInterop: false } as any,
         diagnostics: { warnOnly: true, pretty: false },
       },
       resolve: null,
@@ -399,7 +455,7 @@ describe('parsedTsConfig', () => {
     target.clear()
     const cs = createConfigSet({
       tsJestConfig: {
-        tsConfig: { module: 'amd', esModuleInterop: false } as any,
+        tsconfig: { module: 'amd', esModuleInterop: false } as any,
         diagnostics: { warnOnly: true, pretty: false },
         babelConfig: { babelrc: false },
       },
@@ -842,13 +898,13 @@ describe('tsJestDigest', () => {
 
 describe('shouldStringifyContent', () => {
   it('should return correct value is defined', () => {
-    const cs = createConfigSet({ tsJestConfig: { tsConfig: false, stringifyContentPathRegex: '\\.str$' } as any })
+    const cs = createConfigSet({ tsJestConfig: { tsconfig: false, stringifyContentPathRegex: '\\.str$' } as any })
     expect(cs.shouldStringifyContent('/foo/bar.ts')).toBe(false)
     expect(cs.shouldStringifyContent('/foo/bar.str')).toBe(true)
   })
 
   it('should return correct value when stringifyContentPathRegex is undefined', () => {
-    const cs = createConfigSet({ tsJestConfig: { tsConfig: false } as any })
+    const cs = createConfigSet({ tsJestConfig: { tsconfig: false } as any })
     expect(cs.shouldStringifyContent('/foo/bar.ts')).toBe(false)
   })
 }) // shouldStringifyContent
@@ -900,7 +956,7 @@ describe('tsCacheDir', () => {
         cache: true,
         cacheDirectory: cacheDir,
         globals: {
-          'ts-jest': { tsConfig: false },
+          'ts-jest': { tsconfig: false },
         },
       },
       projectPackageJson: pkg,
@@ -915,10 +971,10 @@ describe('tsCacheDir', () => {
 
 describe('shouldReportDiagnostic', () => {
   it('should return correct value', () => {
-    let cs = createConfigSet({ tsJestConfig: { tsConfig: false, diagnostics: { pathRegex: '/foo/' } } as any })
+    let cs = createConfigSet({ tsJestConfig: { tsconfig: false, diagnostics: { pathRegex: '/foo/' } } as any })
     expect(cs.shouldReportDiagnostic('/foo/index.ts')).toBe(true)
     expect(cs.shouldReportDiagnostic('/bar/index.ts')).toBe(false)
-    cs = createConfigSet({ tsJestConfig: { tsConfig: false } as any })
+    cs = createConfigSet({ tsJestConfig: { tsconfig: false } as any })
     expect(cs.shouldReportDiagnostic('/foo/index.ts')).toBe(true)
     expect(cs.shouldReportDiagnostic('/bar/index.ts')).toBe(true)
   })
@@ -931,7 +987,7 @@ describe('tsCompiler', () => {
         testRegex: [],
         testMatch: [],
       },
-      tsJestConfig: { tsConfig: false } as any,
+      tsJestConfig: { tsconfig: false } as any,
     })
     const compiler = cs.tsCompiler
     expect(compiler.cwd).toBe(cs.cwd)
@@ -1153,7 +1209,7 @@ describe('babelJestTransformer', () => {
 describe('cacheKey', () => {
   it('should be a string', () => {
     const cs = createConfigSet({
-      tsJestConfig: { tsConfig: require.resolve('../__mocks__/tsconfig-src.json') },
+      tsJestConfig: { tsconfig: require.resolve('../__mocks__/tsconfig-src.json') },
       projectDependencies: {
         opt: '1.2.3',
         peer: '1.2.4',
@@ -1180,7 +1236,7 @@ describe('cacheKey', () => {
 describe('jsonValue', () => {
   it('should create jsonValue based on each config and version', () => {
     const cs = createConfigSet({
-      tsJestConfig: { tsConfig: require.resolve('../__mocks__/tsconfig-src.json') },
+      tsJestConfig: { tsconfig: require.resolve('../__mocks__/tsconfig-src.json') },
       projectDependencies: {
         'some-module': '1.2.3',
       },

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -174,6 +174,9 @@ export class ConfigSet {
     const options: TsJestGlobalOptions = { ...globals['ts-jest'] }
 
     // tsconfig
+    if (options.tsConfig) {
+      this.logger.warn(Deprecations.TsConfig)
+    }
     const tsConfig: TsJestConfig['tsConfig'] = this.getInlineOrFileConfigOpt(
       options.tsConfig ?? options.tsconfig ?? true,
     )

--- a/src/transformers/path-mapping.spec.ts
+++ b/src/transformers/path-mapping.spec.ts
@@ -103,7 +103,7 @@ describe('path-mapping', () => {
     ({ code, extension }) => {
       const configSet = createConfigSet({
         tsJestConfig: {
-          tsConfig: {
+          tsconfig: {
             baseUrl: '.',
             paths: {
               '@utils/*': ['src/utils/*'],

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -38,6 +38,7 @@ export const enum Deprecations {
   ConfigOptionUseBabelRcNote = 'See `babel-jest` related issue: https://github.com/facebook/jest/issues/3845',
   HelperMovedToUtils = "The `{{helper}}` helper has been moved to `ts-jest/utils`. Use `import { {{helper}} } from 'ts-jest/utils'` instead.",
   AstTransformerArrayConfig = 'The configuration for astTransformers as string[] is deprecated and will be removed in ts-jest 27. Please define your custom AST transformers in a form of an object. More information you can check online documentation https://kulshekhar.github.io/ts-jest/user/config/astTransformers',
+  TsConfig = 'The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead',
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
To avoid confusion, we should use `tsconfig` instead of `tsConfig`. This PR sets a warning log to instruct users to use `tsconfig`, as well as changing internal codes to use `tsconfig`.

The option `tsConfig` will be removed in **v27**

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test, green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
