### PR TITLE
refactor(config): move `version` and `digest` to `ConfigSet`

### DIFF
--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -4,7 +4,6 @@ import { LogLevels, testing } from 'bs-logger'
 import { join, resolve } from 'path'
 import ts from 'typescript'
 
-import * as _myModule from '..'
 import { logTargetMock } from '../__helpers__/mocks'
 import { createConfigSet, defaultResolve } from '../__helpers__/fakers'
 import type { TsJestGlobalOptions } from '../types'
@@ -13,17 +12,17 @@ import { getPackageVersion } from '../utils/get-package-version'
 import { normalizeSlashes } from '../utils/normalize-slashes'
 import { mocked } from '../utils/testing'
 
-import { IGNORE_DIAGNOSTIC_CODES, TS_JEST_OUT_DIR } from './config-set'
+import { IGNORE_DIAGNOSTIC_CODES, MY_DIGEST, MY_VERSION, TS_JEST_OUT_DIR } from './config-set'
 // eslint-disable-next-line no-duplicate-imports
 import type { ConfigSet } from './config-set'
 import { Deprecations } from '../utils/messages'
+import { digest } from '../__mocks__'
 
 jest.mock('../utils/backports')
 jest.mock('../index')
 jest.mock('../utils/get-package-version')
 
 const backports = mocked(_backports)
-const myModule = mocked(_myModule)
 
 backports.backportJestConfig.mockImplementation((_, config) => ({
   ...config,
@@ -840,7 +839,7 @@ describe('versions', () => {
     it('should return correct version map without babel', () => {
       expect(createConfigSet().versions).toEqual({
         jest: '-',
-        'ts-jest': myModule.version,
+        'ts-jest': MY_VERSION,
         typescript: '-',
       })
     })
@@ -850,7 +849,7 @@ describe('versions', () => {
         '@babel/core': '-',
         'babel-jest': '-',
         jest: '-',
-        'ts-jest': myModule.version,
+        'ts-jest': MY_VERSION,
         typescript: '-',
       })
     })
@@ -870,7 +869,7 @@ describe('versions', () => {
     it('should return correct version map without babel', () => {
       expect(createConfigSet().versions).toEqual({
         jest: pkgVersion('jest'),
-        'ts-jest': myModule.version,
+        'ts-jest': MY_VERSION,
         typescript: pkgVersion('typescript'),
       })
     })
@@ -880,7 +879,7 @@ describe('versions', () => {
         '@babel/core': pkgVersion('@babel/core'),
         'babel-jest': pkgVersion('babel-jest'),
         jest: pkgVersion('jest'),
-        'ts-jest': myModule.version,
+        'ts-jest': MY_VERSION,
         typescript: pkgVersion('typescript'),
       })
     })
@@ -889,7 +888,7 @@ describe('versions', () => {
 
 describe('tsJestDigest', () => {
   it('should be the package digest', () => {
-    expect(createConfigSet().tsJestDigest).toBe(myModule.digest)
+    expect(createConfigSet().tsJestDigest).toBe(MY_DIGEST)
   })
 }) // tsJestDigest
 
@@ -1215,6 +1214,7 @@ describe('cacheKey', () => {
       },
       resolve: null,
     })
+    jest.spyOn(cs, 'tsJestDigest', 'get').mockReturnValueOnce(digest)
     // we tested those and don't want the snapshot to change all the time we upgrade
     const val = cs.jsonValue.value
     delete val.versions
@@ -1239,6 +1239,7 @@ describe('jsonValue', () => {
       },
       resolve: null,
     })
+    jest.spyOn(cs, 'tsJestDigest', 'get').mockReturnValueOnce(digest)
     const val = cs.jsonValue.valueOf()
     expect(cs.toJSON()).toEqual(val)
     // we don't need to verify configFilePath and tsConfig value here

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -27,7 +27,6 @@ import {
   TransformerFactory,
 } from 'typescript'
 
-import { digest as MY_DIGEST, version as MY_VERSION } from '..'
 import { createCompilerInstance } from '../compiler/instance'
 import { DEFAULT_JEST_TEST_MATCH } from '../constants'
 import { internals as internalAstTransformers } from '../transformers'
@@ -55,6 +54,14 @@ import { sha1 } from '../utils/sha1'
 import { TSError } from '../utils/ts-error'
 
 const logger = rootLogger.child({ namespace: 'config' })
+/**
+ * @internal
+ */
+export const MY_VERSION: string = require('../../package.json').version
+/**
+ * @internal
+ */
+export const MY_DIGEST: string = readFileSync(resolve(__dirname, '..', '..', '.ts-jest-digest'), 'utf8')
 
 interface AstTransformerObj<T = Record<string, unknown>> {
   transformModule: AstTransformerDesc

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
 import { LogContexts, LogLevels } from 'bs-logger'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
 
 import { createJestPreset as createJestPresetCore } from './presets/create-jest-preset'
 import { pathsToModuleNameMapper as pathsToModuleNameMapperCore } from './config/paths-to-module-name-mapper'
@@ -31,14 +29,6 @@ export const mocked = helperMoved('mocked', mockedCore)
 export const createJestPreset = helperMoved('createJestPreset', createJestPresetCore)
 /** @deprecated */
 export const pathsToModuleNameMapper = helperMoved('pathsToModuleNameMapper', pathsToModuleNameMapperCore)
-/**
- * @internal
- */
-export const version: string = require('../package.json').version
-/**
- * @internal
- */
-export const digest: string = readFileSync(resolve(__dirname, '..', '.ts-jest-digest'), 'utf8')
 
 export function createTransformer(): TsJestTransformer {
   VersionCheckers.jest.warn()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`version` and `digest` is used by `ConfigSet` only. It makes sense to move these 2 to `ConfigSet`

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
