### PR TITLE
Enhanced ts-jest cli to fix warning message.

### DIFF
--- a/src/cli/cli.spec.ts
+++ b/src/cli/cli.spec.ts
@@ -137,6 +137,11 @@ Jest configuration written to "${normalize('/foo/bar/jest.config.js')}".
           `module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      packageJson: 'package.json',
+    },
+  },
 };`,
         ],
       ])

--- a/src/cli/cli.spec.ts
+++ b/src/cli/cli.spec.ts
@@ -166,6 +166,7 @@ module.exports = {
   ...tsjPreset,
   globals: {
     'ts-jest': {
+      packageJson: 'package.json',
       tsconfig: 'tsconfig.test.json',
       babelConfig: true,
     },

--- a/src/cli/config/init.ts
+++ b/src/cli/config/init.ts
@@ -95,14 +95,15 @@ export const run: CliCommand = async (args: Arguments /* , logger: Logger */) =>
     }
     if (!jsdom) content.push("  testEnvironment: 'node',")
 
+    content.push('  globals: {')
+    content.push("    'ts-jest': {")
+    content.push("      packageJson: 'package.json',")
     if (tsconfig || shouldPostProcessWithBabel) {
-      content.push('  globals: {')
-      content.push("    'ts-jest': {")
       if (tsconfig) content.push(`      tsconfig: ${stringifyJson5(tsconfig)},`)
       if (shouldPostProcessWithBabel) content.push('      babelConfig: true,')
-      content.push('    },')
-      content.push('  },')
     }
+    content.push('    },')
+    content.push('  },')
     content.push('};')
 
     // join all together


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Before this patch, when I run jest test with jest.config.js generated
`ts-jest config:init`, it shows below warning message:

```
ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
```

This patch addresses the issue https://github.com/kulshekhar/ts-jest/issues/959

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

A test case in src/cli/cli.spec.ts is updated to reflect this changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


<!-- ## Other information -->

