### PR TITLE
Removes redundant type definition install instruction

### DIFF
--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -13,7 +13,7 @@ You can install `ts-jest` and dependencies all at once with the following comman
 Using `npm`:
 
 ```sh
-npm install --save-dev jest typescript ts-jest @types/jest
+npm install --save-dev jest typescript ts-jest
 ```
 
 </div><div class="col-md-6" markdown="block">
@@ -21,7 +21,7 @@ npm install --save-dev jest typescript ts-jest @types/jest
 Using `yarn`:
 
 ```sh
-yarn add --dev jest typescript ts-jest @types/jest
+yarn add --dev jest typescript ts-jest
 ```
 
 </div></div>


### PR DESCRIPTION
## Summary

New versions of Jest ship with type definitions. Indeed, Jest is being re-written in TypeScript. 

## Test plan

n/a

## Does this PR introduce a breaking change?

n/a

## Other information

n/a
