### PR TITLE
refactor(config): remove support for `tsConfig` option

### DIFF
--- a/docs/user/config/index.md
+++ b/docs/user/config/index.md
@@ -207,7 +207,7 @@ All options have default values which should fit most of the projects. Click on 
 | Option | Description | Type | Default |
 |---|---|---|---|
 | [**`compiler`**][compiler] | [TypeScript module to use as compiler.][compiler] | `string` | `"typescript"` |
-| [**`tsConfig` or `tsconfig`**][tsConfig] | [TypeScript compiler related configuration.][tsConfig] | `string`\|`object`\|`boolean` | _auto_ |
+| [**`tsconfig`**][tsconfig] | [TypeScript compiler related configuration.][tsconfig] | `string`\|`object`\|`boolean` | _auto_ |
 | [**`isolatedModules`**][isolatedModules] | [Disable type-checking][isolatedModules] | `boolean` | _disabled_ |
 | [**`astTransformers`**][astTransformers] | [Custom TypeScript AST transformers][astTransformers] | `object` | _auto_ |
 | [**`diagnostics`**][diagnostics] | [Diagnostics related configuration.][diagnostics] | `boolean`\|`object` | _enabled_ |
@@ -260,7 +260,7 @@ npx ts-jest config:migrate package.json
 </div></div>
 
 [compiler]: compiler
-[tsConfig]: tsConfig
+[tsconfig]: tsconfig
 [isolatedModules]: isolatedModules
 [astTransformers]: astTransformers
 [compilerHost]: compilerHost

--- a/docs/user/config/tsconfig.md
+++ b/docs/user/config/tsconfig.md
@@ -37,7 +37,7 @@ module.exports = {
   "jest": {
     "globals": {
       "ts-jest": {
-        "tsConfig": "tsconfig.test.json"
+        "tsconfig": "tsconfig.test.json"
       }
     }
   }
@@ -76,7 +76,7 @@ module.exports = {
   "jest": {
     "globals": {
       "ts-jest": {
-        "tsConfig": {
+        "tsconfig": {
           "importHelpers": true
         }
       }
@@ -114,7 +114,7 @@ module.exports = {
   "jest": {
     "globals": {
       "ts-jest": {
-        "tsConfig": false
+        "tsconfig": false
       }
     }
   }

--- a/e2e/__tests__/__snapshots__/logger.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/logger.test.ts.snap
@@ -244,63 +244,6 @@ exports[`ts-jest logging deprecation warning with packageJson config should pass
   ================================================================================
 `;
 
-exports[`ts-jest logging deprecation warning with tsConfig config should pass using template "default" 1`] = `
-  √ jest
-  ↳ exit code: 0
-  ===[ STDOUT ]===================================================================
-  
-  ===[ STDERR ]===================================================================
-  ts-jest[config] (WARN) The option \`tsConfig\` is deprecated and will be removed in ts-jest 27, use \`tsconfig\` instead
-  PASS ./Hello.spec.ts
-    Hello Class
-      √ should create a new Hello
-  
-  Test Suites: 1 passed, 1 total
-  Tests:       1 passed, 1 total
-  Snapshots:   0 total
-  Time:        XXs
-  Ran all test suites.
-  ================================================================================
-`;
-
-exports[`ts-jest logging deprecation warning with tsConfig config should pass using template "with-babel-7" 1`] = `
-  √ jest
-  ↳ exit code: 0
-  ===[ STDOUT ]===================================================================
-  
-  ===[ STDERR ]===================================================================
-  ts-jest[config] (WARN) The option \`tsConfig\` is deprecated and will be removed in ts-jest 27, use \`tsconfig\` instead
-  PASS ./Hello.spec.ts
-    Hello Class
-      √ should create a new Hello
-  
-  Test Suites: 1 passed, 1 total
-  Tests:       1 passed, 1 total
-  Snapshots:   0 total
-  Time:        XXs
-  Ran all test suites.
-  ================================================================================
-`;
-
-exports[`ts-jest logging deprecation warning with tsConfig config should pass using template "with-babel-7-string-config" 1`] = `
-  √ jest
-  ↳ exit code: 0
-  ===[ STDOUT ]===================================================================
-  
-  ===[ STDERR ]===================================================================
-  ts-jest[config] (WARN) The option \`tsConfig\` is deprecated and will be removed in ts-jest 27, use \`tsconfig\` instead
-  PASS ./Hello.spec.ts
-    Hello Class
-      √ should create a new Hello
-  
-  Test Suites: 1 passed, 1 total
-  Tests:       1 passed, 1 total
-  Snapshots:   0 total
-  Time:        XXs
-  Ran all test suites.
-  ================================================================================
-`;
-
 exports[`ts-jest logging with unsupported version test with TS_JEST_DISABLE_VER_CHECKER is not set in process.env should pass using template "with-unsupported-version" 1`] = `
   √ jest
   ↳ exit code: 0

--- a/e2e/__tests__/logger.test.ts
+++ b/e2e/__tests__/logger.test.ts
@@ -123,21 +123,5 @@ describe('ts-jest logging', () => {
         })
       })
     })
-
-    describe('with tsConfig config', () => {
-      const testCase = configureTestCase('simple', {
-        tsJestConfig: {
-          tsConfig: true,
-        }
-      })
-
-      testCase.runWithTemplates(allPackageSetsWithPreset, 0, (runTest, { testLabel }) => {
-        it(testLabel, () => {
-          const result = runTest()
-          expect(result.status).toBe(0)
-          expect(result).toMatchSnapshot()
-        })
-      })
-    })
   })
 })

--- a/src/__helpers__/fakers.ts
+++ b/src/__helpers__/fakers.ts
@@ -4,7 +4,7 @@ import { resolve } from 'path'
 
 import { createCompilerInstance } from '../compiler/instance'
 import { ConfigSet } from '../config/config-set'
-import type { BabelConfig, TsCompiler, TsJestConfig, TsJestGlobalOptions } from '../types'
+import type { BabelConfig, TsCompiler, TsJestGlobalOptions } from '../types'
 import type { ImportReasons } from '../utils/messages'
 
 export function filePath(relPath: string): string {
@@ -12,19 +12,6 @@ export function filePath(relPath: string): string {
 }
 
 export const rootDir = filePath('')
-
-export function tsJestConfig(options?: Partial<TsJestConfig>): TsJestConfig {
-  return {
-    isolatedModules: false,
-    compiler: 'typescript',
-    transformers: options?.transformers ?? Object.create(null),
-    babelConfig: undefined,
-    tsConfig: undefined,
-    stringifyContentPathRegex: undefined,
-    diagnostics: { ignoreCodes: [], pretty: false, throws: true },
-    ...options,
-  }
-}
 
 function getJestConfig<T extends Config.ProjectConfig>(
   options?: Partial<Config.InitialOptions | Config.ProjectConfig>,

--- a/src/cli/cli.spec.ts
+++ b/src/cli/cli.spec.ts
@@ -66,43 +66,43 @@ describe('cli', () => {
   it('should output usage', async () => {
     expect.assertions(2)
     await expect(runCli()).resolves.toMatchInlineSnapshot(`
-Object {
-  "exitCode": 0,
-  "log": "",
-  "stderr": "",
-  "stdout": "
-Usage:
-  ts-jest command [options] [...args]
+            Object {
+              "exitCode": 0,
+              "log": "",
+              "stderr": "",
+              "stdout": "
+            Usage:
+              ts-jest command [options] [...args]
 
-Commands:
-  config:init           Creates initial Jest configuration
-  config:migrate        Migrates a given Jest configuration
-  help [command]        Show this help, or help about a command
+            Commands:
+              config:init           Creates initial Jest configuration
+              config:migrate        Migrates a given Jest configuration
+              help [command]        Show this help, or help about a command
 
-Example:
-  ts-jest help config:migrate
-",
-}
-`)
+            Example:
+              ts-jest help config:migrate
+            ",
+            }
+          `)
     await expect(runCli('hello:motto')).resolves.toMatchInlineSnapshot(`
-Object {
-  "exitCode": 0,
-  "log": "",
-  "stderr": "",
-  "stdout": "
-Usage:
-  ts-jest command [options] [...args]
+            Object {
+              "exitCode": 0,
+              "log": "",
+              "stderr": "",
+              "stdout": "
+            Usage:
+              ts-jest command [options] [...args]
 
-Commands:
-  config:init           Creates initial Jest configuration
-  config:migrate        Migrates a given Jest configuration
-  help [command]        Show this help, or help about a command
+            Commands:
+              config:init           Creates initial Jest configuration
+              config:migrate        Migrates a given Jest configuration
+              help [command]        Show this help, or help about a command
 
-Example:
-  ts-jest help config:migrate
-",
-}
-`)
+            Example:
+              ts-jest help config:migrate
+            ",
+            }
+          `)
   })
 })
 
@@ -229,31 +229,31 @@ Jest configuration written to "${normalize('/foo/bar/package.json')}".
     it('should output help', async () => {
       const res = await runCli('help', noOption[0])
       expect(res).toMatchInlineSnapshot(`
-Object {
-  "exitCode": 0,
-  "log": "",
-  "stderr": "",
-  "stdout": "
-Usage:
-  ts-jest config:init [options] [<config-file>]
+        Object {
+          "exitCode": 0,
+          "log": "",
+          "stderr": "",
+          "stdout": "
+        Usage:
+          ts-jest config:init [options] [<config-file>]
 
-Arguments:
-  <config-file>         Can be a js or json Jest config file. If it is a
-                        package.json file, the configuration will be read from
-                        the \\"jest\\" property.
-                        Default: jest.config.js
+        Arguments:
+          <config-file>         Can be a js or json Jest config file. If it is a
+                                package.json file, the configuration will be read from
+                                the \\"jest\\" property.
+                                Default: jest.config.js
 
-Options:
-  --force               Discard any existing Jest config
-  --js ts|babel         Process .js files with ts-jest if 'ts' or with
-                        babel-jest if 'babel'
-  --no-jest-preset      Disable the use of Jest presets
-  --tsconfig <file>     Path to the tsconfig.json file
-  --babel               Pipe babel-jest after ts-jest
-  --jsdom               Use jsdom as test environment instead of node
-",
-}
-`)
+        Options:
+          --force               Discard any existing Jest config
+          --js ts|babel         Process .js files with ts-jest if 'ts' or with
+                                babel-jest if 'babel'
+          --no-jest-preset      Disable the use of Jest presets
+          --tsconfig <file>     Path to the tsconfig.json file
+          --babel               Pipe babel-jest after ts-jest
+          --jsdom               Use jsdom as test environment instead of node
+        ",
+        }
+      `)
     })
   }) // init
 
@@ -306,30 +306,30 @@ Options:
       )
       const res = await runCli(...noOption, pkgPaths.current)
       expect(res).toMatchInlineSnapshot(`
-Object {
-  "exitCode": 0,
-  "log": "",
-  "stderr": "
-Migrated Jest configuration:
+        Object {
+          "exitCode": 0,
+          "log": "",
+          "stderr": "
+        Migrated Jest configuration:
 
 
-Detected preset 'default' as the best matching preset for your configuration.
-Visit https://kulshekhar.github.io/ts-jest/user/config/#jest-preset for more information about presets.
+        Detected preset 'default' as the best matching preset for your configuration.
+        Visit https://kulshekhar.github.io/ts-jest/user/config/#jest-preset for more information about presets.
 
-",
-  "stdout": "\\"jest\\": {
-  \\"globals\\": {
-    \\"ts-jest\\": {
-      \\"tsConfig\\": {
-        \\"target\\": \\"es6\\"
-      }
-    }
-  },
-  \\"preset\\": \\"ts-jest\\"
-}
-",
-}
-`)
+        ",
+          "stdout": "\\"jest\\": {
+          \\"globals\\": {
+            \\"ts-jest\\": {
+              \\"tsconfig\\": {
+                \\"target\\": \\"es6\\"
+              }
+            }
+          },
+          \\"preset\\": \\"ts-jest\\"
+        }
+        ",
+        }
+      `)
       expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
 
@@ -345,24 +345,24 @@ Visit https://kulshekhar.github.io/ts-jest/user/config/#jest-preset for more inf
       )
       const res = await runCli(...fullOptions, pkgPaths.current)
       expect(res).toMatchInlineSnapshot(`
-Object {
-  "exitCode": 0,
-  "log": "",
-  "stderr": "
-Migrated Jest configuration:
-",
-  "stdout": "\\"jest\\": {
-  \\"globals\\": {
-    \\"ts-jest\\": {
-      \\"tsConfig\\": {
-        \\"target\\": \\"es6\\"
-      }
-    }
-  }
-}
-",
-}
-`)
+        Object {
+          "exitCode": 0,
+          "log": "",
+          "stderr": "
+        Migrated Jest configuration:
+        ",
+          "stdout": "\\"jest\\": {
+          \\"globals\\": {
+            \\"ts-jest\\": {
+              \\"tsconfig\\": {
+                \\"target\\": \\"es6\\"
+              }
+            }
+          }
+        }
+        ",
+        }
+      `)
       expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
 
@@ -387,29 +387,29 @@ Migrated Jest configuration:
       )
       const res = await runCli(...noOption, pkgPaths.current)
       expect(res.stdout).toMatchInlineSnapshot(`
-"\\"jest\\": {
-  \\"globals\\": {
-    \\"ts-jest\\": {
-      \\"tsConfig\\": {
-        \\"target\\": \\"es6\\"
-      }
-    }
-  },
-  \\"moduleFileExtensions\\": [
-    \\"js\\",
-    \\"ts\\",
-    \\"tsx\\"
-  ],
-  \\"testMatch\\": [
-    \\"**/?(*.)+(spec|test).js?(x)\\",
-    \\"**/?(*.)+(spec|test).ts?(x)\\",
-    \\"**/__tests__/**/*.js?(x)\\",
-    \\"**/__tests__/**/*.ts?(x)\\"
-  ],
-  \\"preset\\": \\"ts-jest\\"
-}
-"
-`)
+        "\\"jest\\": {
+          \\"globals\\": {
+            \\"ts-jest\\": {
+              \\"tsconfig\\": {
+                \\"target\\": \\"es6\\"
+              }
+            }
+          },
+          \\"moduleFileExtensions\\": [
+            \\"js\\",
+            \\"ts\\",
+            \\"tsx\\"
+          ],
+          \\"testMatch\\": [
+            \\"**/?(*.)+(spec|test).js?(x)\\",
+            \\"**/?(*.)+(spec|test).ts?(x)\\",
+            \\"**/__tests__/**/*.js?(x)\\",
+            \\"**/__tests__/**/*.ts?(x)\\"
+          ],
+          \\"preset\\": \\"ts-jest\\"
+        }
+        "
+      `)
     })
 
     it('should reset testMatch if testRegex is used', async () => {
@@ -426,13 +426,13 @@ Migrated Jest configuration:
       )
       const res = await runCli(...noOption, pkgPaths.current)
       expect(res.stdout).toMatchInlineSnapshot(`
-"\\"jest\\": {
-  \\"testRegex\\": \\"foo-pattern\\",
-  \\"preset\\": \\"ts-jest\\",
-  \\"testMatch\\": null
-}
-"
-`)
+        "\\"jest\\": {
+          \\"testRegex\\": \\"foo-pattern\\",
+          \\"preset\\": \\"ts-jest\\",
+          \\"testMatch\\": null
+        }
+        "
+      `)
     })
 
     it('should detect best preset', async () => {
@@ -444,31 +444,31 @@ Migrated Jest configuration:
       jest.doMock(pkgPaths.nextCfg, () => ({}), { virtual: true })
       let res = await runCli(...noOption, pkgPaths.currentCfg)
       expect(res.stdout).toMatchInlineSnapshot(`
-"module.exports = {
-  preset: 'ts-jest',
-}
-"
-`)
+        "module.exports = {
+          preset: 'ts-jest',
+        }
+        "
+      `)
 
       // js-with-ts from args
       jest.doMock(pkgPaths.nextCfg, () => ({}), { virtual: true })
       res = await runCli(...noOption, '--allow-js', pkgPaths.currentCfg)
       expect(res.stdout).toMatchInlineSnapshot(`
-"module.exports = {
-  preset: 'ts-jest/presets/js-with-ts',
-}
-"
-`)
+        "module.exports = {
+          preset: 'ts-jest/presets/js-with-ts',
+        }
+        "
+      `)
 
       // js-with-ts from previous transform
       jest.doMock(pkgPaths.nextCfg, () => ({ transform: { '^.+\\.[tj]sx?$': 'ts-jest' } }), { virtual: true })
       res = await runCli(...noOption, pkgPaths.currentCfg)
       expect(res.stdout).toMatchInlineSnapshot(`
-"module.exports = {
-  preset: 'ts-jest/presets/js-with-ts',
-}
-"
-`)
+        "module.exports = {
+          preset: 'ts-jest/presets/js-with-ts',
+        }
+        "
+      `)
 
       // js-with-babel from previous transform
       jest.doMock(pkgPaths.nextCfg, () => ({ transform: { '^.+\\.jsx?$': 'babel-jest', '^.+\\.tsx?$': 'ts-jest' } }), {
@@ -476,11 +476,11 @@ Migrated Jest configuration:
       })
       res = await runCli(...noOption, pkgPaths.currentCfg)
       expect(res.stdout).toMatchInlineSnapshot(`
-"module.exports = {
-  preset: 'ts-jest/presets/js-with-babel',
-}
-"
-`)
+        "module.exports = {
+          preset: 'ts-jest/presets/js-with-babel',
+        }
+        "
+      `)
 
       // defaults when previous transform is ambiguous
       jest.doMock(
@@ -490,15 +490,15 @@ Migrated Jest configuration:
       )
       res = await runCli(...noOption, pkgPaths.currentCfg)
       expect(res.stdout).toMatchInlineSnapshot(`
-"module.exports = {
-  transform: {
-    '^src/js/.+\\\\\\\\.jsx?$': 'babel-jest',
-    '^src/ts/.+\\\\\\\\.tsx?$': 'ts-jest',
-  },
-  preset: 'ts-jest',
-}
-"
-`)
+        "module.exports = {
+          transform: {
+            '^src/js/.+\\\\\\\\.jsx?$': 'babel-jest',
+            '^src/ts/.+\\\\\\\\.tsx?$': 'ts-jest',
+          },
+          preset: 'ts-jest',
+        }
+        "
+      `)
     })
 
     it('should normalize transform values', async () => {
@@ -519,41 +519,41 @@ Migrated Jest configuration:
       )
       const res = await runCli(...noOption, pkgPaths.current)
       expect(res.stdout).toMatchInlineSnapshot(`
-"\\"jest\\": {
-  \\"transform\\": {
-    \\"<rootDir>/src/.+\\\\\\\\.[jt]s$\\": \\"ts-jest\\",
-    \\"foo\\\\\\\\.ts\\": \\"ts-jest\\",
-    \\"bar\\\\\\\\.ts\\": \\"ts-jest\\"
-  },
-  \\"preset\\": \\"ts-jest\\"
-}
-"
-`)
+        "\\"jest\\": {
+          \\"transform\\": {
+            \\"<rootDir>/src/.+\\\\\\\\.[jt]s$\\": \\"ts-jest\\",
+            \\"foo\\\\\\\\.ts\\": \\"ts-jest\\",
+            \\"bar\\\\\\\\.ts\\": \\"ts-jest\\"
+          },
+          \\"preset\\": \\"ts-jest\\"
+        }
+        "
+      `)
     })
 
     it('should output help', async () => {
       const res = await runCli('help', noOption[0])
       expect(res).toMatchInlineSnapshot(`
-Object {
-  "exitCode": 0,
-  "log": "",
-  "stderr": "",
-  "stdout": "
-Usage:
-  ts-jest config:migrate [options] <config-file>
+        Object {
+          "exitCode": 0,
+          "log": "",
+          "stderr": "",
+          "stdout": "
+        Usage:
+          ts-jest config:migrate [options] <config-file>
 
-Arguments:
-  <config-file>         Can be a js or json Jest config file. If it is a
-                        package.json file, the configuration will be read from
-                        the \\"jest\\" property.
+        Arguments:
+          <config-file>         Can be a js or json Jest config file. If it is a
+                                package.json file, the configuration will be read from
+                                the \\"jest\\" property.
 
-Options:
-  --js ts|babel         Process .js files with ts-jest if 'ts' or with
-                        babel-jest if 'babel'
-  --no-jest-preset      Disable the use of Jest presets
-",
-}
-`)
+        Options:
+          --js ts|babel         Process .js files with ts-jest if 'ts' or with
+                                babel-jest if 'babel'
+          --no-jest-preset      Disable the use of Jest presets
+        ",
+        }
+      `)
     })
   }) // migrate
 }) // config

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -60,8 +60,8 @@ describe('parsedTsConfig', () => {
     expect(get().fileNames).toContain(normalizeSlashes(__filename))
   })
 
-  it.each(['tsConfig', 'tsconfig'])('should include compiler config from `%s` option key', (key: string) => {
-    expect(get({ [key]: { baseUrl: 'src/config' } }).options.baseUrl).toBe(normalizeSlashes(__dirname))
+  it('should include compiler config from `%s` option key', () => {
+    expect(get({ tsconfig: { baseUrl: 'src/config' } }).options.baseUrl).toBe(normalizeSlashes(__dirname))
   })
 
   it('should include compiler config from base config', () => {

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -274,10 +274,7 @@ export class ConfigSet {
     this.logger.debug({ diagnostics: this._diagnostics }, 'normalized diagnostics config via ts-jest option')
 
     // tsconfig
-    if (options.tsConfig) {
-      this.logger.warn(Deprecations.TsConfig)
-    }
-    const tsconfigOpt = options.tsConfig ?? options.tsconfig
+    const tsconfigOpt = options.tsconfig
     const configFilePath = typeof tsconfigOpt === 'string' ? this.resolvePath(tsconfigOpt) : undefined
     this.parsedTsConfig = this._resolveTsConfig(
       typeof tsconfigOpt === 'object' ? tsconfigOpt : undefined,

--- a/src/transformers/path-mapping.spec.ts
+++ b/src/transformers/path-mapping.spec.ts
@@ -50,10 +50,10 @@ describe('path-mapping', () => {
     },
   ])(
     'should replace alias path with relative path which is resolved from paths tsconfig with js/ts extension',
-    (tsConfig) => {
+    (tsconfig) => {
       const configSet = createConfigSet({
         tsJestConfig: {
-          tsConfig,
+          tsconfig,
         },
         logger,
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,19 +44,6 @@ export interface TsJestGlobalOptions {
    * - `{...}`: an object with inline compiler options
    *
    * @default undefined uses the default tsconfig file
-   * @alias tsconfig
-   */
-  tsConfig?: boolean | string | _ts.CompilerOptions
-
-  /**
-   * Compiler options. It can be:
-   * - `true` (or `undefined`, it's the default): use default tsconfig file
-   * - `false`: do NOT use default config file
-   * - `path/to/tsconfig.json`: path to a specific tsconfig file (<rootDir> can be used)
-   * - `{...}`: an object with inline compiler options
-   *
-   * @default undefined uses the default tsconfig file
-   * @alias tsConfig
    */
   tsconfig?: boolean | string | _ts.CompilerOptions
 
@@ -176,7 +163,7 @@ type TsJestConfig$babelConfig = TsJestConfig$babelConfig$file | TsJestConfig$bab
  * @internal
  */
 export interface TsJestConfig {
-  tsConfig: TsJestConfig$tsConfig
+  tsconfig: TsJestConfig$tsConfig
   isolatedModules: boolean
   compiler: string
   diagnostics: TsJestDiagnosticsCfg

--- a/src/utils/__snapshots__/backports.spec.ts.snap
+++ b/src/utils/__snapshots__/backports.spec.ts.snap
@@ -66,7 +66,7 @@ exports[`backportJestConfig with "globals.__TS_CONFIG__" set to { foo: 'bar' } s
 Object {
   "globals": Object {
     "ts-jest": Object {
-      "tsConfig": Object {
+      "tsconfig": Object {
         "foo": "bar",
       },
     },
@@ -76,7 +76,7 @@ Object {
 
 exports[`backportJestConfig with "globals.__TS_CONFIG__" set to { foo: 'bar' } should warn the user 1`] = `
 Array [
-  "[level:40] \\"[jest-config].globals.__TS_CONFIG__\\" is deprecated, use \\"[jest-config].globals.ts-jest.tsConfig\\" instead.
+  "[level:40] \\"[jest-config].globals.__TS_CONFIG__\\" is deprecated, use \\"[jest-config].globals.ts-jest.tsconfig\\" instead.
 ",
   "[level:40] Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
 ",
@@ -245,7 +245,7 @@ exports[`backportJestConfig with "globals.ts-jest.tsConfigFile" set to 'tsconfig
 Object {
   "globals": Object {
     "ts-jest": Object {
-      "tsConfig": "tsconfig.build.json",
+      "tsconfig": "tsconfig.build.json",
     },
   },
 }
@@ -253,7 +253,7 @@ Object {
 
 exports[`backportJestConfig with "globals.ts-jest.tsConfigFile" set to 'tsconfig.build.json' should warn the user 1`] = `
 Array [
-  "[level:40] \\"[jest-config].globals.ts-jest.tsConfigFile\\" is deprecated, use \\"[jest-config].globals.ts-jest.tsConfig\\" instead.
+  "[level:40] \\"[jest-config].globals.ts-jest.tsConfigFile\\" is deprecated, use \\"[jest-config].globals.ts-jest.tsconfig\\" instead.
 ",
   "[level:40] Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
 ",

--- a/src/utils/backports.ts
+++ b/src/utils/backports.ts
@@ -31,9 +31,9 @@ export const backportJestConfig = <T extends Config.InitialOptions | Config.Proj
   }
 
   if ('__TS_CONFIG__' in globals) {
-    warnConfig('globals.__TS_CONFIG__', 'globals.ts-jest.tsConfig')
+    warnConfig('globals.__TS_CONFIG__', 'globals.ts-jest.tsconfig')
     if (typeof globals.__TS_CONFIG__ === 'object') {
-      mergeTsJest.tsConfig = globals.__TS_CONFIG__
+      mergeTsJest.tsconfig = globals.__TS_CONFIG__
     }
     delete globals.__TS_CONFIG__
   }
@@ -53,9 +53,9 @@ export const backportJestConfig = <T extends Config.InitialOptions | Config.Proj
   }
 
   if ('tsConfigFile' in tsJest) {
-    warnConfig('globals.ts-jest.tsConfigFile', 'globals.ts-jest.tsConfig')
+    warnConfig('globals.ts-jest.tsConfigFile', 'globals.ts-jest.tsconfig')
     if (tsJest.tsConfigFile) {
-      mergeTsJest.tsConfig = tsJest.tsConfigFile
+      mergeTsJest.tsconfig = tsJest.tsConfigFile
     }
     delete tsJest.tsConfigFile
   }

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -16,7 +16,6 @@ export const enum Errors {
   GotUnknownFileTypeWithoutBabel = 'Got a unknown file type to compile (file: {{path}}). To fix this, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match this kind of files anymore.',
   GotUnknownFileTypeWithBabel = 'Got a unknown file type to compile (file: {{path}}). To fix this, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match this kind of files anymore. If you still want Babel to process it, add another entry to the `transform` option with value `babel-jest` which key matches this type of files.',
   ConfigNoModuleInterop = 'If you have issues related to imports, you should consider setting `esModuleInterop` to `true` in your TypeScript configuration file (usually `tsconfig.json`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.',
-  UnableToFindProjectRoot = 'Unable to find the root of the project where ts-jest has been installed.',
   MismatchNodeTargetMapping = 'There is a mismatch between your NodeJs version {{nodeJsVer}} and your TypeScript target {{compilationTarget}}. This might lead to some unexpected errors when running tests with `ts-jest`. To fix this, you can check https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping',
 }
 
@@ -38,7 +37,6 @@ export const enum Deprecations {
   ConfigOptionUseBabelRcNote = 'See `babel-jest` related issue: https://github.com/facebook/jest/issues/3845',
   HelperMovedToUtils = "The `{{helper}}` helper has been moved to `ts-jest/utils`. Use `import { {{helper}} } from 'ts-jest/utils'` instead.",
   AstTransformerArrayConfig = 'The configuration for astTransformers as string[] is deprecated and will be removed in ts-jest 27. Please define your custom AST transformers in a form of an object. More information you can check online documentation https://kulshekhar.github.io/ts-jest/user/config/astTransformers',
-  TsConfig = 'The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead',
   PackageJson = 'The option `packageJson` is deprecated and will be removed in ts-jest 27. This option is not used by internal `ts-jest`',
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Remove support for `tsConfig`.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Adjusted tests and docs
Green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->
One currently use `tsConfig` should change to `tsconfig` in your `jest.config.js` or `package.json`

## Other information
**N.A.**
