### PR TITLE
refactor(config): fall back to `ES2015` when no `target` is defined

### DIFF
--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -38,12 +38,12 @@ describe('parsedTsConfig', () => {
     expect(get().fileNames).toContain(normalizeSlashes(__filename))
   })
 
-  it('should include compiler config from `%s` option key', () => {
-    expect(get({ tsconfig: { baseUrl: 'src/config' } }).options.baseUrl).toBe(normalizeSlashes(__dirname))
-  })
-
   it('should include compiler config from base config', () => {
     expect(get({ tsconfig: { target: 'esnext' } as any }).options.target).toBe(ts.ScriptTarget.ESNext)
+  })
+
+  it('should fallback to ES2015 as default target when no target defined in tsconfig', () => {
+    expect(get().options.target).toBe(ts.ScriptTarget.ES2015)
   })
 
   it('should override some options', () => {
@@ -62,6 +62,7 @@ describe('parsedTsConfig', () => {
       tsJestConfig: { tsconfig: 'tsconfig.build.json' },
       resolve: null,
     })
+
     expect(cs.parsedTsConfig.options).toMatchObject({
       module: ts.ModuleKind.CommonJS,
       rootDir: normalizeSlashes(resolve(__dirname, '..')),
@@ -79,6 +80,7 @@ describe('parsedTsConfig', () => {
       },
       resolve: null,
     })
+
     expect(cs.parsedTsConfig.options).toMatchObject({
       module: ts.ModuleKind.CommonJS,
       allowSyntheticDefaultImports: true,
@@ -101,6 +103,7 @@ describe('parsedTsConfig', () => {
       },
       resolve: null,
     })
+
     expect(cs.parsedTsConfig.options).toMatchObject({
       module: ts.ModuleKind.AMD,
       esModuleInterop: false,

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -301,6 +301,7 @@ export class ConfigSet {
           }
         })
       if (astTransformers.before) {
+        /* istanbul ignore next (already covered in unit test) */
         this.customTransformers.before?.push(...resolveTransformers(astTransformers.before))
       }
       if (astTransformers.after) {
@@ -398,9 +399,9 @@ export class ConfigSet {
     const result = ts.parseJsonConfigFileContent(config, ts.sys, basePath, undefined, configFileName)
     const { _overriddenCompilerOptions: forcedOptions } = this
     const finalOptions = result.options
-    // Target ES5 output by default (instead of ES3).
+    // Target ES2015 output by default (instead of ES3).
     if (finalOptions.target === undefined) {
-      finalOptions.target = ts.ScriptTarget.ES5
+      finalOptions.target = ts.ScriptTarget.ES2015
     }
 
     // check the module interoperability
@@ -424,6 +425,7 @@ export class ConfigSet {
         length: undefined,
       })
       // at least enable synthetic default imports (except if it's set in the input config)
+      /* istanbul ignore next (already covered in unit test) */
       if (!('allowSyntheticDefaultImports' in config.compilerOptions)) {
         finalOptions.allowSyntheticDefaultImports = true
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Default fall back to `ES2015` target when performing code compilation if no `target` is defined in `tsconfig`

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test, green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**
