### PR TITLE
[Chore]: Fix links on docs homepage

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -44,7 +44,7 @@ function IntroHeading({ ...siteConfig }) {
       </p>
       <p>
         It supports all features of TypeScript including type-checking.{' '}
-        <a href="user/babel7-or-ts" className="link">
+        <a href="docs/babel7-or-ts" className="link">
           Read more about Babel 7<code>preset-typescript</code> <strong>vs</strong> TypeScript(and <code>ts-jest</code>)
         </a>
       </p>
@@ -92,12 +92,12 @@ function Home() {
           <h2>Usage</h2>
           <p>
             Refer to the{' '}
-            <a href="user/install" className="link">
+            <a href="docs/installation" className="link">
               {' '}
               installation{' '}
             </a>
             and{' '}
-            <a href="user/config" className="link">
+            <a href="docs/presets" className="link">
               {' '}
               configuration{' '}
             </a>{' '}


### PR DESCRIPTION
Several links on the homepage were directing to 404's b/c they hadn't changed over to docs/, fixed this

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

When browsing the ts-jest website, I wanted to know more about configOptions, but the first two links on the homepage gave me 404's.  After I clicked around a while, I found that the page had moved to Docs.  This is an attempt to remedy that situation

## Test plan

This is a docs only change, it should not change anything functionality wise

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
