### PR TITLE
feat: unforce module `CommonJS` when testing with ESM 

### DIFF
--- a/e2e/__helpers__/test-case/types.ts
+++ b/e2e/__helpers__/test-case/types.ts
@@ -9,7 +9,7 @@ export interface RunTestOptions {
   env?: Record<string, unknown>
   inject?: (() => any) | string
   writeIo?: boolean
-  jestConfig?: Config.ProjectConfig | Record<string, unknown>
+  jestConfig?: Config.InitialOptions
   tsJestConfig?: TsJestGlobalOptions
   noCache?: boolean
   jestConfigPath?: string

--- a/e2e/__helpers__/test-case/utils.ts
+++ b/e2e/__helpers__/test-case/utils.ts
@@ -55,3 +55,5 @@ export function escapeRegex(s: string): string {
 export function enableOptimizations(): boolean {
   return !!process.env.TS_JEST_E2E_OPTIMIZATIONS
 }
+
+export const nodeWithESMSupport = process.version.startsWith('v12') || process.version.startsWith('v14')

--- a/e2e/__tests__/allow-js.test.ts
+++ b/e2e/__tests__/allow-js.test.ts
@@ -3,7 +3,7 @@ import { configureTestCase } from '../__helpers__/test-case'
 
 describe('using babel-jest for js files', () => {
   const testCase = configureTestCase('allow-js/with-outDir', {
-    jestConfig: { testMatch: null, testRegex: '(foo|bar)\\.spec\\.[jt]s$' },
+    jestConfig: { testRegex: '(foo|bar)\\.spec\\.[jt]s$' },
   })
 
   testCase.runWithTemplates(allValidPackageSets, 0, (runTest, { testLabel }) => {
@@ -19,7 +19,6 @@ describe('using ts-jest for js files with outDir', () => {
   const testCase = configureTestCase('allow-js/with-outDir', {
     jestConfig: {
       preset: 'ts-jest/presets/js-with-ts',
-      testMatch: null,
       testRegex: 'esm\\.spec\\.[jt]s$',
     },
   })
@@ -37,7 +36,6 @@ describe('using ts-jest for js files without outDir', () => {
   const testCase = configureTestCase('allow-js/without-outDir', {
     jestConfig: {
       preset: 'ts-jest/presets/js-with-ts',
-      testMatch: null,
       testRegex: 'esm\\.spec\\.[jt]s$',
     },
   })

--- a/e2e/__tests__/module-kinds/__snapshots__/amd.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/amd.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`run with options: {"module":"amd","allowSyntheticDefaultImports":false} 1`] = `
+exports[`Module amd run with options: {"module":"amd","allowSyntheticDefaultImports":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -44,7 +44,7 @@ exports[`run with options: {"module":"amd","allowSyntheticDefaultImports":false}
   ================================================================================
 `;
 
-exports[`run with options: {"module":"amd","allowSyntheticDefaultImports":true} 1`] = `
+exports[`Module amd run with options: {"module":"amd","allowSyntheticDefaultImports":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -78,7 +78,7 @@ exports[`run with options: {"module":"amd","allowSyntheticDefaultImports":true} 
   ================================================================================
 `;
 
-exports[`run with options: {"module":"amd","esModuleInterop":false} 1`] = `
+exports[`Module amd run with options: {"module":"amd","esModuleInterop":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -113,7 +113,7 @@ exports[`run with options: {"module":"amd","esModuleInterop":false} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"amd","esModuleInterop":true} 1`] = `
+exports[`Module amd run with options: {"module":"amd","esModuleInterop":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -158,7 +158,7 @@ exports[`run with options: {"module":"amd","esModuleInterop":true} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"amd"} 1`] = `
+exports[`Module amd run with options: {"module":"amd"} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================

--- a/e2e/__tests__/module-kinds/__snapshots__/commonjs.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/commonjs.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`run with options: {"module":"commonjs","allowSyntheticDefaultImports":false} 1`] = `
+exports[`Module commonjs run with options: {"module":"commonjs","allowSyntheticDefaultImports":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -43,7 +43,7 @@ exports[`run with options: {"module":"commonjs","allowSyntheticDefaultImports":f
   ================================================================================
 `;
 
-exports[`run with options: {"module":"commonjs","allowSyntheticDefaultImports":true} 1`] = `
+exports[`Module commonjs run with options: {"module":"commonjs","allowSyntheticDefaultImports":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -77,7 +77,7 @@ exports[`run with options: {"module":"commonjs","allowSyntheticDefaultImports":t
   ================================================================================
 `;
 
-exports[`run with options: {"module":"commonjs","esModuleInterop":false} 1`] = `
+exports[`Module commonjs run with options: {"module":"commonjs","esModuleInterop":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -120,7 +120,7 @@ exports[`run with options: {"module":"commonjs","esModuleInterop":false} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"commonjs","esModuleInterop":true} 1`] = `
+exports[`Module commonjs run with options: {"module":"commonjs","esModuleInterop":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -165,7 +165,7 @@ exports[`run with options: {"module":"commonjs","esModuleInterop":true} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"commonjs"} 1`] = `
+exports[`Module commonjs run with options: {"module":"commonjs"} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================

--- a/e2e/__tests__/module-kinds/__snapshots__/es2015-esm.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/es2015-esm.test.ts.snap
@@ -1,0 +1,1021 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Module es2015 with preset default-esm run with options: {"module":"es2015","allowSyntheticDefaultImports":false} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'esModuleInterop' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset default-esm run with options: {"module":"es2015","allowSyntheticDefaultImports":true} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset default-esm run with options: {"module":"es2015","esModuleInterop":false} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset default-esm run with options: {"module":"es2015","esModuleInterop":true} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  PASS ./import-legacy.spec.ts
+  ts-jest[ts-compiler] (WARN) import-star.spec.ts:5:10 - error TS2349: This expression is not callable.
+    Type 'typeof lib' has no call signatures.
+  
+  5   expect(lib()).toBe('foo')
+             ~~~
+  
+    import-star.spec.ts:1:1
+      1 import * as lib from './lib'
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset default-esm run with options: {"module":"es2015"} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015","allowSyntheticDefaultImports":false} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015","allowSyntheticDefaultImports":false} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015","allowSyntheticDefaultImports":true} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015","allowSyntheticDefaultImports":true} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015","esModuleInterop":false} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015","esModuleInterop":false} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015","esModuleInterop":true} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-star.spec.ts:5:10 - error TS2349: This expression is not callable.
+    Type 'typeof lib' has no call signatures.
+  
+  5   expect(lib()).toBe('foo')
+             ~~~
+  
+    import-star.spec.ts:1:1
+      1 import * as lib from './lib'
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015","esModuleInterop":true} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-star.spec.ts:5:10 - error TS2349: This expression is not callable.
+    Type 'typeof lib' has no call signatures.
+  
+  5   expect(lib()).toBe('foo')
+             ~~~
+  
+    import-star.spec.ts:1:1
+      1 import * as lib from './lib'
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015"} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-babel-esm run with options: {"module":"es2015"} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-ts-esm run with options: {"module":"es2015","allowSyntheticDefaultImports":false} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'esModuleInterop' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-ts-esm run with options: {"module":"es2015","allowSyntheticDefaultImports":true} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-ts-esm run with options: {"module":"es2015","esModuleInterop":false} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-ts-esm run with options: {"module":"es2015","esModuleInterop":true} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  PASS ./import-legacy.spec.ts
+  ts-jest[ts-compiler] (WARN) import-star.spec.ts:5:10 - error TS2349: This expression is not callable.
+    Type 'typeof lib' has no call signatures.
+  
+  5   expect(lib()).toBe('foo')
+             ~~~
+  
+    import-star.spec.ts:1:1
+      1 import * as lib from './lib'
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module es2015 with preset js-with-ts-esm run with options: {"module":"es2015"} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;

--- a/e2e/__tests__/module-kinds/__snapshots__/es2015.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/es2015.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`run with options: {"module":"es2015","allowSyntheticDefaultImports":false} 1`] = `
+exports[`Module es2015 run with options: {"module":"es2015","allowSyntheticDefaultImports":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -44,7 +44,7 @@ exports[`run with options: {"module":"es2015","allowSyntheticDefaultImports":fal
   ================================================================================
 `;
 
-exports[`run with options: {"module":"es2015","allowSyntheticDefaultImports":true} 1`] = `
+exports[`Module es2015 run with options: {"module":"es2015","allowSyntheticDefaultImports":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -78,7 +78,7 @@ exports[`run with options: {"module":"es2015","allowSyntheticDefaultImports":tru
   ================================================================================
 `;
 
-exports[`run with options: {"module":"es2015","esModuleInterop":false} 1`] = `
+exports[`Module es2015 run with options: {"module":"es2015","esModuleInterop":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -113,7 +113,7 @@ exports[`run with options: {"module":"es2015","esModuleInterop":false} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"es2015","esModuleInterop":true} 1`] = `
+exports[`Module es2015 run with options: {"module":"es2015","esModuleInterop":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -158,7 +158,7 @@ exports[`run with options: {"module":"es2015","esModuleInterop":true} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"es2015"} 1`] = `
+exports[`Module es2015 run with options: {"module":"es2015"} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================

--- a/e2e/__tests__/module-kinds/__snapshots__/esnext-esm.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/esnext-esm.test.ts.snap
@@ -1,0 +1,1021 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Module esnext with preset default-esm run with options: {"module":"esnext","allowSyntheticDefaultImports":false} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'esModuleInterop' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset default-esm run with options: {"module":"esnext","allowSyntheticDefaultImports":true} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset default-esm run with options: {"module":"esnext","esModuleInterop":false} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset default-esm run with options: {"module":"esnext","esModuleInterop":true} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  PASS ./import-legacy.spec.ts
+  ts-jest[ts-compiler] (WARN) import-star.spec.ts:5:10 - error TS2349: This expression is not callable.
+    Type 'typeof lib' has no call signatures.
+  
+  5   expect(lib()).toBe('foo')
+             ~~~
+  
+    import-star.spec.ts:1:1
+      1 import * as lib from './lib'
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset default-esm run with options: {"module":"esnext"} with template default 1`] = `
+  × jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext","allowSyntheticDefaultImports":false} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext","allowSyntheticDefaultImports":false} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext","allowSyntheticDefaultImports":true} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext","allowSyntheticDefaultImports":true} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext","esModuleInterop":false} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext","esModuleInterop":false} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext","esModuleInterop":true} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-star.spec.ts:5:10 - error TS2349: This expression is not callable.
+    Type 'typeof lib' has no call signatures.
+  
+  5   expect(lib()).toBe('foo')
+             ~~~
+  
+    import-star.spec.ts:1:1
+      1 import * as lib from './lib'
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext","esModuleInterop":true} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-star.spec.ts:5:10 - error TS2349: This expression is not callable.
+    Type 'typeof lib' has no call signatures.
+  
+  5   expect(lib()).toBe('foo')
+             ~~~
+  
+    import-star.spec.ts:1:1
+      1 import * as lib from './lib'
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext"} with template with-babel-7 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-babel-esm run with options: {"module":"esnext"} with template with-babel-7-string-config 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[ts-compiler] (WARN) import-legacy.spec.ts:1:1 - error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+  
+  1 import lib = require('./lib')
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  FAIL ./import-legacy.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-legacy.spec.ts:4:22)
+  
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 2 failed, 1 passed, 3 total
+  Tests:       2 failed, 1 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-ts-esm run with options: {"module":"esnext","allowSyntheticDefaultImports":false} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  ts-jest[ts-compiler] (WARN) import-default.spec.ts:1:8 - error TS1259: Module '"<cwd>/lib"' can only be default-imported using the 'esModuleInterop' flag
+  
+  1 import lib from './lib'
+           ~~~
+  
+    lib.d.ts:5:1
+      5 export = lib
+        ~~~~~~~~~~~~
+      This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-ts-esm run with options: {"module":"esnext","allowSyntheticDefaultImports":true} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-ts-esm run with options: {"module":"esnext","esModuleInterop":false} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-ts-esm run with options: {"module":"esnext","esModuleInterop":true} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  PASS ./import-legacy.spec.ts
+  ts-jest[ts-compiler] (WARN) import-star.spec.ts:5:10 - error TS2349: This expression is not callable.
+    Type 'typeof lib' has no call signatures.
+  
+  5   expect(lib()).toBe('foo')
+             ~~~
+  
+    import-star.spec.ts:1:1
+      1 import * as lib from './lib'
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
+  FAIL ./import-star.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "object"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-star.spec.ts:4:22)
+  
+  PASS ./import-default.spec.ts
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;
+
+exports[`Module esnext with preset js-with-ts-esm run with options: {"module":"esnext"} with template default 1`] = `
+  × node --experimental-vm-modules node_modules/.bin/jest --no-cache
+  ↳ exit code: 1
+  ===[ STDOUT ]===================================================================
+  
+  ===[ STDERR ]===================================================================
+  ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting \`esModuleInterop\` to \`true\` in your TypeScript configuration file (usually \`tsconfig.json\`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
+  PASS ./import-legacy.spec.ts
+  PASS ./import-star.spec.ts
+  FAIL ./import-default.spec.ts
+    ● import default
+  
+      expect(received).toBe(expected) // Object.is equality
+  
+      Expected: "function"
+      Received: "undefined"
+  
+        2 | 
+        3 | test('import default', () => {
+      > 4 |   expect(typeof lib).toBe('function')
+          |                      ^
+        5 |   expect(lib()).toBe('foo')
+        6 |   expect(lib.bar).toBe('bar')
+        7 | })
+  
+        at Object.<anonymous> (import-default.spec.ts:4:22)
+  
+  Test Suites: 1 failed, 2 passed, 3 total
+  Tests:       1 failed, 2 passed, 3 total
+  Snapshots:   0 total
+  Time:        XXs
+  Ran all test suites.
+  ================================================================================
+`;

--- a/e2e/__tests__/module-kinds/__snapshots__/esnext.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/esnext.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`run with options: {"module":"esnext","allowSyntheticDefaultImports":false} 1`] = `
+exports[`Module esnext run with options: {"module":"esnext","allowSyntheticDefaultImports":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -44,7 +44,7 @@ exports[`run with options: {"module":"esnext","allowSyntheticDefaultImports":fal
   ================================================================================
 `;
 
-exports[`run with options: {"module":"esnext","allowSyntheticDefaultImports":true} 1`] = `
+exports[`Module esnext run with options: {"module":"esnext","allowSyntheticDefaultImports":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -78,7 +78,7 @@ exports[`run with options: {"module":"esnext","allowSyntheticDefaultImports":tru
   ================================================================================
 `;
 
-exports[`run with options: {"module":"esnext","esModuleInterop":false} 1`] = `
+exports[`Module esnext run with options: {"module":"esnext","esModuleInterop":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -113,7 +113,7 @@ exports[`run with options: {"module":"esnext","esModuleInterop":false} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"esnext","esModuleInterop":true} 1`] = `
+exports[`Module esnext run with options: {"module":"esnext","esModuleInterop":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -158,7 +158,7 @@ exports[`run with options: {"module":"esnext","esModuleInterop":true} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"esnext"} 1`] = `
+exports[`Module esnext run with options: {"module":"esnext"} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================

--- a/e2e/__tests__/module-kinds/__snapshots__/none.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/none.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`run with options: {"module":"none","allowSyntheticDefaultImports":false} 1`] = `
+exports[`Module none run with options: {"module":"none","allowSyntheticDefaultImports":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -44,7 +44,7 @@ exports[`run with options: {"module":"none","allowSyntheticDefaultImports":false
   ================================================================================
 `;
 
-exports[`run with options: {"module":"none","allowSyntheticDefaultImports":true} 1`] = `
+exports[`Module none run with options: {"module":"none","allowSyntheticDefaultImports":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -78,7 +78,7 @@ exports[`run with options: {"module":"none","allowSyntheticDefaultImports":true}
   ================================================================================
 `;
 
-exports[`run with options: {"module":"none","esModuleInterop":false} 1`] = `
+exports[`Module none run with options: {"module":"none","esModuleInterop":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -113,7 +113,7 @@ exports[`run with options: {"module":"none","esModuleInterop":false} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"none","esModuleInterop":true} 1`] = `
+exports[`Module none run with options: {"module":"none","esModuleInterop":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -158,7 +158,7 @@ exports[`run with options: {"module":"none","esModuleInterop":true} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"none"} 1`] = `
+exports[`Module none run with options: {"module":"none"} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================

--- a/e2e/__tests__/module-kinds/__snapshots__/system.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/system.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`run with options: {"module":"system","allowSyntheticDefaultImports":false} 1`] = `
+exports[`Module system run with options: {"module":"system","allowSyntheticDefaultImports":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -44,7 +44,7 @@ exports[`run with options: {"module":"system","allowSyntheticDefaultImports":fal
   ================================================================================
 `;
 
-exports[`run with options: {"module":"system","allowSyntheticDefaultImports":true} 1`] = `
+exports[`Module system run with options: {"module":"system","allowSyntheticDefaultImports":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -78,7 +78,7 @@ exports[`run with options: {"module":"system","allowSyntheticDefaultImports":tru
   ================================================================================
 `;
 
-exports[`run with options: {"module":"system","esModuleInterop":false} 1`] = `
+exports[`Module system run with options: {"module":"system","esModuleInterop":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -113,7 +113,7 @@ exports[`run with options: {"module":"system","esModuleInterop":false} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"system","esModuleInterop":true} 1`] = `
+exports[`Module system run with options: {"module":"system","esModuleInterop":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -158,7 +158,7 @@ exports[`run with options: {"module":"system","esModuleInterop":true} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"system"} 1`] = `
+exports[`Module system run with options: {"module":"system"} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================

--- a/e2e/__tests__/module-kinds/__snapshots__/umd.test.ts.snap
+++ b/e2e/__tests__/module-kinds/__snapshots__/umd.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`run with options: {"module":"umd","allowSyntheticDefaultImports":false} 1`] = `
+exports[`Module umd run with options: {"module":"umd","allowSyntheticDefaultImports":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -44,7 +44,7 @@ exports[`run with options: {"module":"umd","allowSyntheticDefaultImports":false}
   ================================================================================
 `;
 
-exports[`run with options: {"module":"umd","allowSyntheticDefaultImports":true} 1`] = `
+exports[`Module umd run with options: {"module":"umd","allowSyntheticDefaultImports":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -78,7 +78,7 @@ exports[`run with options: {"module":"umd","allowSyntheticDefaultImports":true} 
   ================================================================================
 `;
 
-exports[`run with options: {"module":"umd","esModuleInterop":false} 1`] = `
+exports[`Module umd run with options: {"module":"umd","esModuleInterop":false} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -113,7 +113,7 @@ exports[`run with options: {"module":"umd","esModuleInterop":false} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"umd","esModuleInterop":true} 1`] = `
+exports[`Module umd run with options: {"module":"umd","esModuleInterop":true} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================
@@ -158,7 +158,7 @@ exports[`run with options: {"module":"umd","esModuleInterop":true} 1`] = `
   ================================================================================
 `;
 
-exports[`run with options: {"module":"umd"} 1`] = `
+exports[`Module umd run with options: {"module":"umd"} with template default 1`] = `
   × jest --no-cache
   ↳ exit code: 1
   ===[ STDOUT ]===================================================================

--- a/e2e/__tests__/module-kinds/amd.test.ts
+++ b/e2e/__tests__/module-kinds/amd.test.ts
@@ -1,9 +1,5 @@
-import { runTestForOptions } from './helpers'
+import { runTestCases } from './helpers'
 
-const MODULE_KIND = 'amd'
-
-runTestForOptions({ module: MODULE_KIND })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: false })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: false })
+describe('Module amd', () => {
+  runTestCases('amd')
+})

--- a/e2e/__tests__/module-kinds/commonjs.test.ts
+++ b/e2e/__tests__/module-kinds/commonjs.test.ts
@@ -1,9 +1,5 @@
-import { runTestForOptions } from './helpers'
+import { runTestCases } from './helpers'
 
-const MODULE_KIND = 'commonjs'
-
-runTestForOptions({ module: MODULE_KIND })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: false })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: false })
+describe('Module commonjs', () => {
+  runTestCases('commonjs')
+})

--- a/e2e/__tests__/module-kinds/es2015-esm.test.ts
+++ b/e2e/__tests__/module-kinds/es2015-esm.test.ts
@@ -1,0 +1,9 @@
+import { AllPreset, esmOnly, runTestCases } from './helpers'
+
+esmOnly.each([
+  AllPreset.DEFAULT_ESM,
+  AllPreset.JS_WITH_TS_ESM,
+  AllPreset.JS_WITH_BABEL_ESM
+])('Module es2015 with preset %s', (preset) => {
+  runTestCases('es2015', preset)
+})

--- a/e2e/__tests__/module-kinds/es2015.test.ts
+++ b/e2e/__tests__/module-kinds/es2015.test.ts
@@ -1,9 +1,5 @@
-import { runTestForOptions } from './helpers'
+import { runTestCases } from './helpers'
 
-const MODULE_KIND = 'es2015'
-
-runTestForOptions({ module: MODULE_KIND })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: false })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: false })
+describe('Module es2015', () => {
+  runTestCases('es2015')
+})

--- a/e2e/__tests__/module-kinds/esnext-esm.test.ts
+++ b/e2e/__tests__/module-kinds/esnext-esm.test.ts
@@ -1,0 +1,9 @@
+import { AllPreset, esmOnly, runTestCases } from './helpers'
+
+esmOnly.each([
+  AllPreset.DEFAULT_ESM,
+  AllPreset.JS_WITH_TS_ESM,
+  AllPreset.JS_WITH_BABEL_ESM
+])('Module esnext with preset %s', (preset) => {
+  runTestCases('esnext', preset)
+})

--- a/e2e/__tests__/module-kinds/esnext.test.ts
+++ b/e2e/__tests__/module-kinds/esnext.test.ts
@@ -1,9 +1,6 @@
-import { runTestForOptions } from './helpers'
+import { runTestCases } from './helpers'
 
-const MODULE_KIND = 'esnext'
+describe('Module esnext', () => {
+  runTestCases('esnext')
+})
 
-runTestForOptions({ module: MODULE_KIND })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: false })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: false })

--- a/e2e/__tests__/module-kinds/helpers.ts
+++ b/e2e/__tests__/module-kinds/helpers.ts
@@ -1,4 +1,11 @@
+import { PackageSets } from '../../__helpers__/templates'
 import { configureTestCase } from '../../__helpers__/test-case'
+import { nodeWithESMSupport } from '../../__helpers__/test-case/utils'
+// @ts-expect-error testing purpose
+import tsJestPresets from '../../../presets'
+
+// eslint-disable-next-line no-console
+console.log = jest.fn()
 
 // None = 0,
 // CommonJS = 1,
@@ -7,19 +14,61 @@ import { configureTestCase } from '../../__helpers__/test-case'
 // System = 4,
 // ES2015 = 5,
 // ESNext = 6
-
-const testCaseForCompilerOpt = (config: any) => configureTestCase('module-kinds', {
-    tsJestConfig: { tsconfig: config, diagnostics: { warnOnly: true } },
-    noCache: true,
-  })
-
-// eslint-disable-next-line jest/no-export
-export const runTestForOptions = (options: {
+interface TestOptions {
   module: string
   allowSyntheticDefaultImports?: boolean
   esModuleInterop?: boolean
-}): void => {
-  test(`run with options: ${JSON.stringify(options)}`, () => {
-    expect(testCaseForCompilerOpt(options).run()).toMatchSnapshot()
+}
+// eslint-disable-next-line jest/no-export
+export const enum AllPreset {
+  DEFAULT = 'default',
+  DEFAULT_ESM = 'default-esm',
+  JS_WITH_TS_ESM = 'js-with-ts-esm',
+  JS_WITH_BABEL_ESM = 'js-with-babel-esm',
+}
+type AllPresetType = AllPreset.DEFAULT | AllPreset.DEFAULT_ESM | AllPreset.JS_WITH_TS_ESM | AllPreset.JS_WITH_BABEL_ESM
+
+const runTestForOptions = (options: TestOptions, preset: AllPresetType = AllPreset.DEFAULT): void => {
+  const packageSets = preset === AllPreset.JS_WITH_BABEL_ESM ? [PackageSets.babel7, PackageSets.babel7StringConfig] : [PackageSets.default]
+  let tsJestPresetToUse
+  switch (preset) {
+    case AllPreset.DEFAULT_ESM:
+      tsJestPresetToUse = tsJestPresets.defaultEsm
+      break
+    case AllPreset.JS_WITH_TS_ESM:
+      tsJestPresetToUse = tsJestPresets.jsWithTsESM
+      break
+    case AllPreset.JS_WITH_BABEL_ESM:
+      tsJestPresetToUse = tsJestPresets.jsWithBabelESM
+      break
+    default:
+      tsJestPresetToUse = tsJestPresets.default
+  }
+  const testCase = configureTestCase('module-kinds',
+    {
+      jestConfig: tsJestPresetToUse,
+      tsJestConfig: { tsconfig: options as any, diagnostics: { warnOnly: true } },
+      noCache: true,
+    },
+  )
+
+  testCase.runWithTemplates(packageSets, 0, (runTest, { templateName }) => {
+    it(`run with options: ${JSON.stringify(options)} with template ${templateName}`, () => {
+      const result = runTest()
+
+      expect(result).toMatchSnapshot()
+    })
   })
 }
+
+// eslint-disable-next-line jest/no-export
+export const runTestCases = (moduleKind: string, preset: AllPresetType = AllPreset.DEFAULT): void => {
+  runTestForOptions({ module: moduleKind }, preset)
+  runTestForOptions({ module: moduleKind, allowSyntheticDefaultImports: false }, preset)
+  runTestForOptions({ module: moduleKind, allowSyntheticDefaultImports: true }, preset)
+  runTestForOptions({ module: moduleKind, esModuleInterop: true }, preset)
+  runTestForOptions({ module: moduleKind, esModuleInterop: false }, preset)
+}
+
+// eslint-disable-next-line jest/no-export
+export const esmOnly = nodeWithESMSupport ? describe : describe.skip;

--- a/e2e/__tests__/module-kinds/none.test.ts
+++ b/e2e/__tests__/module-kinds/none.test.ts
@@ -1,9 +1,5 @@
-import { runTestForOptions } from './helpers'
+import { runTestCases } from './helpers'
 
-const MODULE_KIND = 'none'
-
-runTestForOptions({ module: MODULE_KIND })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: false })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: false })
+describe('Module none', () => {
+  runTestCases('none')
+})

--- a/e2e/__tests__/module-kinds/system.test.ts
+++ b/e2e/__tests__/module-kinds/system.test.ts
@@ -1,9 +1,5 @@
-import { runTestForOptions } from './helpers'
+import { runTestCases } from './helpers'
 
-const MODULE_KIND = 'system'
-
-runTestForOptions({ module: MODULE_KIND })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: false })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: false })
+describe('Module system', () => {
+  runTestCases('system')
+})

--- a/e2e/__tests__/module-kinds/umd.test.ts
+++ b/e2e/__tests__/module-kinds/umd.test.ts
@@ -1,9 +1,5 @@
-import { runTestForOptions } from './helpers'
+import { runTestCases } from './helpers'
 
-const MODULE_KIND = 'umd'
-
-runTestForOptions({ module: MODULE_KIND })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: false })
-runTestForOptions({ module: MODULE_KIND, allowSyntheticDefaultImports: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: true })
-runTestForOptions({ module: MODULE_KIND, esModuleInterop: false })
+describe('Module umd', () => {
+  runTestCases('umd')
+})

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -692,6 +692,7 @@ describe('_resolveTsConfig', () => {
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
         expect(conf.options.allowSyntheticDefaultImports).toEqual(true)
         expect(conf.errors).toMatchSnapshot()
+        expect(cs.parsedTsConfig.options.module).toEqual(ts.ModuleKind.CommonJS)
       })
 
       it('should use given tsconfig path', () => {
@@ -703,6 +704,7 @@ describe('_resolveTsConfig', () => {
             rootDir: '/root',
             cwd: '/cwd',
             globals: { 'ts-jest': { tsconfig: 'tsconfig.bar.json' } },
+            extensionsToTreatAsEsm: ['.ts'],
           } as any,
         })
 
@@ -713,6 +715,7 @@ describe('_resolveTsConfig', () => {
         expect(parseConfig.mock.calls[0][2]).toBe('/foo')
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
         expect(conf.errors).toMatchSnapshot()
+        expect(cs.parsedTsConfig.options.module).not.toEqual(ts.ModuleKind.CommonJS)
       })
     })
 
@@ -753,6 +756,7 @@ describe('_resolveTsConfig', () => {
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
         expect(conf.options.allowSyntheticDefaultImports).toEqual(true)
         expect(conf.errors).toMatchSnapshot()
+        expect(cs.parsedTsConfig.options.module).toEqual(ts.ModuleKind.CommonJS)
       })
 
       it('should use given tsconfig path', () => {
@@ -764,6 +768,7 @@ describe('_resolveTsConfig', () => {
             rootDir: '/root',
             cwd: '/cwd',
             globals: { 'ts-jest': { tsconfig: 'tsconfig.bar.json' } },
+            extensionsToTreatAsEsm: ['.ts'],
           } as any,
         })
 
@@ -774,6 +779,7 @@ describe('_resolveTsConfig', () => {
         expect(parseConfig.mock.calls[0][2]).toBe('/foo')
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
         expect(conf.errors).toMatchSnapshot()
+        expect(cs.parsedTsConfig.options.module).not.toEqual(ts.ModuleKind.CommonJS)
       })
     })
 
@@ -814,6 +820,7 @@ describe('_resolveTsConfig', () => {
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
         expect(conf.options.allowSyntheticDefaultImports).toBeUndefined()
         expect(conf.errors).toEqual([])
+        expect(cs.parsedTsConfig.options.module).toEqual(ts.ModuleKind.CommonJS)
       })
 
       it('should use given tsconfig path', () => {
@@ -825,6 +832,7 @@ describe('_resolveTsConfig', () => {
             rootDir: '/root',
             cwd: '/cwd',
             globals: { 'ts-jest': { tsconfig: 'tsconfig.bar.json' } },
+            extensionsToTreatAsEsm: ['.ts'],
           } as any,
         })
 
@@ -835,6 +843,7 @@ describe('_resolveTsConfig', () => {
         expect(parseConfig.mock.calls[0][2]).toBe('/foo')
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
         expect(conf.errors).toEqual([])
+        expect(cs.parsedTsConfig.options.module).not.toEqual(ts.ModuleKind.CommonJS)
       })
     })
 
@@ -875,6 +884,7 @@ describe('_resolveTsConfig', () => {
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
         expect(conf.errors).toEqual([])
         expect(conf.options.allowSyntheticDefaultImports).toEqual(true)
+        expect(cs.parsedTsConfig.options.module).toEqual(ts.ModuleKind.CommonJS)
       })
 
       it('should use given tsconfig path', () => {
@@ -886,6 +896,7 @@ describe('_resolveTsConfig', () => {
             rootDir: '/root',
             cwd: '/cwd',
             globals: { 'ts-jest': { tsconfig: 'tsconfig.bar.json' } },
+            extensionsToTreatAsEsm: ['.ts'],
           } as any,
         })
 
@@ -897,6 +908,7 @@ describe('_resolveTsConfig', () => {
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
         expect(conf.errors).toEqual([])
         expect(conf.options.allowSyntheticDefaultImports).toEqual(true)
+        expect(cs.parsedTsConfig.options.module).not.toEqual(ts.ModuleKind.CommonJS)
       })
     })
   })

--- a/src/ts-jest-transformer.ts
+++ b/src/ts-jest-transformer.ts
@@ -8,14 +8,14 @@ import { join, resolve } from 'path'
 import { TsJestCompiler } from './compiler/ts-jest-compiler'
 import { ConfigSet } from './config/config-set'
 import { DECLARATION_TYPE_EXT, JS_JSX_REGEX, TS_TSX_REGEX } from './constants'
+import type { TsJestProjectConfig, TransformOptionsTsJest } from './types'
 import { parse, stringify } from './utils/json'
 import { JsonableValue } from './utils/jsonable-value'
 import { rootLogger } from './utils/logger'
 import { Errors, interpolate } from './utils/messages'
-import type { TsJestProjectConfig, TransformOptionsTsJest } from './types'
+import { importer } from './utils/importer'
 import { sha1 } from './utils/sha1'
 import { VersionCheckers } from './utils/version-checkers'
-import { importer } from './utils/importer'
 
 interface CachedConfigSet {
   configSet: ConfigSet


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When `extensionsToTreatAsEsm` option is not an empty array, `CommonJS` enforcement will be no longer applicable.

Closes #1709 
Closes #2057 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Adjusted unit tests and e2e tests, green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->
To run tests with ESM support, one needs to make sure that:
 - `module` in tsconfig should be either `es2015` or `es2020` or `esnext` 
 - Use `ts-jest` ESM presets or define value for `extensionsToTreatAsEsm` option properly

## Other information
**N.A**
