### PR TITLE
refactor(config): convert getters to methods/properties in `ConfigSet`

### DIFF
--- a/src/__helpers__/fakers.ts
+++ b/src/__helpers__/fakers.ts
@@ -13,6 +13,9 @@ export function filePath(relPath: string): string {
 
 export const rootDir = filePath('')
 
+const defaultTestRegex = ['(/__tests__/.*|(\\\\.|/)(test|spec))\\\\.[jt]sx?$']
+const defaultTestMatch = ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)']
+
 function getJestConfig<T extends Config.ProjectConfig>(
   options?: Partial<Config.InitialOptions | Config.ProjectConfig>,
   tsJestOptions?: TsJestGlobalOptions,
@@ -47,7 +50,16 @@ export function createConfigSet({
   resolve?: ((path: string) => string) | null
   [key: string]: any
 } = {}): ConfigSet {
-  const cs = new ConfigSet(getJestConfig(jestConfig, tsJestConfig), logger)
+  const jestCfg = getJestConfig(jestConfig, tsJestConfig)
+  const cs = new ConfigSet(
+    {
+      ...jestCfg,
+      testMatch: jestConfig?.testMatch ? [...jestConfig.testMatch, ...defaultTestMatch] : defaultTestMatch,
+      testRegex: jestConfig?.testRegex ? [...jestConfig.testRegex, ...defaultTestRegex] : defaultTestRegex,
+      extensionsToTreatAsEsm: jestCfg.extensionsToTreatAsEsm ?? [],
+    },
+    logger,
+  )
   if (resolve) {
     cs.resolvePath = resolve
   }
@@ -76,12 +88,11 @@ export function makeCompiler(
     ...(tsJestConfig.diagnostics as any),
     pretty: false,
   }
-  const defaultTestRegex = ['(/__tests__/.*|(\\\\.|/)(test|spec))\\\\.[jt]sx?$']
-  const defaultTestMatch = ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)']
   jestConfig = {
     ...jestConfig,
+    extensionsToTreatAsEsm: jestConfig?.extensionsToTreatAsEsm ?? [],
     testMatch: jestConfig?.testMatch ? [...jestConfig.testMatch, ...defaultTestMatch] : defaultTestMatch,
-    testRegex: jestConfig?.testRegex ? [...defaultTestRegex, ...jestConfig.testRegex] : defaultTestRegex,
+    testRegex: jestConfig?.testRegex ? [...jestConfig.testRegex, ...defaultTestRegex] : defaultTestRegex,
   }
   const cs = createConfigSet({ jestConfig, tsJestConfig, parentConfig, resolve: null })
 

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -396,17 +396,6 @@ describe('tsJestDigest', () => {
   })
 }) // tsJestDigest
 
-describe('hooks', () => {
-  it('should return empty object when environment variable TS_JEST_HOOKS is undefined', () => {
-    expect(createConfigSet().hooks).toEqual({})
-  })
-
-  it('should return value when environment variable TS_JEST_HOOKS is defined', () => {
-    process.env.TS_JEST_HOOKS = './foo'
-    expect(createConfigSet().hooks).toBeDefined()
-  })
-}) // hooks
-
 describe('isTestFile', () => {
   it.each([
     {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Convert several getters to public methods/public properties for `ConfigSet` because IDE complains  about
```
Accessors are only available when targeting ECMAScript 5 and higher.
```
Since we are building with target `es5`, therefore complaining is there

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
