### PR TITLE
refactor(config): `_resolveTsConfig` only finds and gets tsconfig

### DIFF
--- a/src/compiler/ts-compiler.spec.ts
+++ b/src/compiler/ts-compiler.spec.ts
@@ -23,7 +23,7 @@ describe('TsCompiler', () => {
       })
       const source = 'export default 42'
 
-      const compiled = compiler.getCompiledOutput(source, fileName)
+      const compiled = compiler.getCompiledOutput(source, fileName, false)
 
       expect(new ProcessedSource(compiled, fileName)).toMatchSnapshot()
     })
@@ -45,7 +45,7 @@ describe('TsCompiler', () => {
             },
           },
         })
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName)).toMatchSnapshot()
       })
@@ -59,7 +59,7 @@ describe('TsCompiler', () => {
             },
           },
         })
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName)).toMatchSnapshot()
       })
@@ -71,7 +71,7 @@ describe('TsCompiler', () => {
 
       it('should have correct source maps without mapRoot', () => {
         const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsconfig: false } })
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName).outputSourceMaps).toMatchObject({
           file: fileName,
@@ -89,7 +89,7 @@ describe('TsCompiler', () => {
             },
           },
         })
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName).outputSourceMaps).toMatchObject({
           file: fileName,
@@ -111,6 +111,7 @@ const t: string = f(5)
 const v: boolean = t
 `,
             'foo.ts',
+            false,
           ),
         ).not.toThrowError()
       })
@@ -125,6 +126,7 @@ const f = (v: number) = v
 const t: string = f(5)
 `,
             'foo.ts',
+            false,
           ),
         ).toThrowErrorMatchingSnapshot()
       })
@@ -141,6 +143,7 @@ const f = (v: number) = v
 const t: string = f(5)
 `,
             'foo.ts',
+            false,
           ),
         ).toThrowErrorMatchingSnapshot()
       })
@@ -157,6 +160,7 @@ const f = (v: number) = v
 const t: string = f(5)
 `,
             'foo.ts',
+            false,
           ),
         ).not.toThrowError()
       })
@@ -235,7 +239,7 @@ const t: string = f(5)
           jestCacheFS,
         )
 
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName)).toMatchSnapshot()
       })
@@ -247,7 +251,7 @@ const t: string = f(5)
           },
           jestCacheFS,
         )
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName)).toMatchSnapshot()
       })
@@ -274,7 +278,7 @@ const t: string = f(5)
           jestCacheFS,
         )
 
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName)).toMatchSnapshot()
       })
@@ -290,7 +294,7 @@ const t: string = f(5)
           },
           jestCacheFS,
         )
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName)).toMatchSnapshot()
       })
@@ -306,7 +310,7 @@ const t: string = f(5)
           { tsJestConfig: { tsconfig: require.resolve('../../tsconfig.spec.json') } },
           jestCacheFS,
         )
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName).outputSourceMaps).toMatchObject({
           file: fileName,
@@ -326,7 +330,7 @@ const t: string = f(5)
           },
           jestCacheFS,
         )
-        const compiled = compiler.getCompiledOutput(source, fileName)
+        const compiled = compiler.getCompiledOutput(source, fileName, false)
 
         expect(new ProcessedSource(compiled, fileName).outputSourceMaps).toMatchObject({
           file: fileName,
@@ -420,7 +424,7 @@ const t: string = f(5)
           jestCacheFS,
         )
 
-        expect(() => compiler.getCompiledOutput(importedFileContent, importedFileName)).not.toThrowError()
+        expect(() => compiler.getCompiledOutput(importedFileContent, importedFileName, false)).not.toThrowError()
       })
 
       it(`shouldn't report diagnostic when processing file isn't used by any test files`, () => {
@@ -433,7 +437,7 @@ const t: string = f(5)
         )
         logTarget.clear()
 
-        compiler.getCompiledOutput(importedFileContent, 'foo.ts')
+        compiler.getCompiledOutput(importedFileContent, 'foo.ts', false)
 
         expect(logTarget.filteredLines(LogLevels.debug, Infinity)).toMatchSnapshot()
       })
@@ -453,7 +457,7 @@ const t: string = f(5)
           jestCacheFS,
         )
 
-        expect(() => compiler.getCompiledOutput(source, fileName)).toThrowErrorMatchingSnapshot()
+        expect(() => compiler.getCompiledOutput(source, fileName, false)).toThrowErrorMatchingSnapshot()
       })
     })
   })

--- a/src/compiler/ts-jest-compiler.ts
+++ b/src/compiler/ts-jest-compiler.ts
@@ -17,7 +17,7 @@ export class TsJestCompiler implements CompilerInstance {
     return this._compilerInstance.getResolvedModulesMap(fileContent, fileName)
   }
 
-  getCompiledOutput(fileContent: string, fileName: string, supportsStaticESM = false): string {
+  getCompiledOutput(fileContent: string, fileName: string, supportsStaticESM: boolean): string {
     return this._compilerInstance.getCompiledOutput(fileContent, fileName, supportsStaticESM)
   }
 }

--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -751,7 +751,6 @@ describe('_resolveTsConfig', () => {
         expect(readConfig.mock.calls[0][0]).toBe(tscfgPathStub)
         expect(parseConfig.mock.calls[0][2]).toBe('/root')
         expect(parseConfig.mock.calls[0][4]).toBe(tscfgPathStub)
-        expect(conf.options.allowSyntheticDefaultImports).toEqual(true)
         expect(conf.errors).toMatchSnapshot()
       })
 

--- a/src/ts-jest-transformer.ts
+++ b/src/ts-jest-transformer.ts
@@ -1,4 +1,4 @@
-import type { TransformedSource, Transformer, TransformOptions } from '@jest/transform'
+import type { TransformedSource, Transformer } from '@jest/transform'
 import type { Config } from '@jest/types'
 import type { Logger } from 'bs-logger'
 import { existsSync, readFileSync, statSync, writeFileSync } from 'fs'
@@ -8,7 +8,7 @@ import { join, resolve } from 'path'
 import { TsJestCompiler } from './compiler/ts-jest-compiler'
 import { ConfigSet } from './config/config-set'
 import { DECLARATION_TYPE_EXT, JS_JSX_REGEX, TS_TSX_REGEX } from './constants'
-import type { TsJestProjectConfig, TransformOptionsTsJest } from './types'
+import type { ProjectConfigTsJest, TransformOptionsTsJest } from './types'
 import { parse, stringify } from './utils/json'
 import { JsonableValue } from './utils/jsonable-value'
 import { rootLogger } from './utils/logger'
@@ -19,7 +19,7 @@ import { VersionCheckers } from './utils/version-checkers'
 
 interface CachedConfigSet {
   configSet: ConfigSet
-  jestConfig: JsonableValue<TsJestProjectConfig>
+  jestConfig: JsonableValue<ProjectConfigTsJest>
   transformerCfgStr: string
   compiler: TsJestCompiler
 }
@@ -58,7 +58,7 @@ export class TsJestTransformer implements Transformer {
     this._logger.debug('created new transformer')
   }
 
-  protected _configsFor(transformOptions: TransformOptions): ConfigSet {
+  protected _configsFor(transformOptions: TransformOptionsTsJest): ConfigSet {
     const { config, cacheFS } = transformOptions
     const ccs: CachedConfigSet | undefined = TsJestTransformer._cachedConfigSets.find(
       (cs) => cs.jestConfig.value === config,

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,14 +179,14 @@ export interface TsJestConfig {
   stringifyContentPathRegex: string | undefined
 }
 
-export interface TsJestProjectConfig extends Config.ProjectConfig {
+export interface ProjectConfigTsJest extends Config.ProjectConfig {
   globals: {
     'ts-jest': TsJestGlobalOptions
   }
 }
 
 export interface TransformOptionsTsJest extends TransformOptions {
-  config: TsJestProjectConfig
+  config: ProjectConfigTsJest
 }
 
 export type ResolvedModulesMap = Map<string, _ts.ResolvedModuleFull | undefined> | undefined


### PR DESCRIPTION
- Make supportsStaticESM a mandatory arg for `getCompiledOutput`
- `_resolveTsConfig` only does finding and getting tsconfig. Override options will be done by a private method `_getAndResolveTsConfig`
- Rename `TsJestProjectConfig` to `ProjectConfigTsJest`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information

