### PR TITLE
feat(config): type checking `js` files based on `checkJs`

### DIFF
--- a/src/config/config-set.spec.ts
+++ b/src/config/config-set.spec.ts
@@ -549,13 +549,48 @@ describe('raiseDiagnostics', () => {
 }) // raiseDiagnostics
 
 describe('shouldReportDiagnostics', () => {
-  it('should return correct value', () => {
-    let cs = createConfigSet({ tsJestConfig: { tsconfig: false, diagnostics: { pathRegex: '/foo/' } } as any })
+  it('should return correct value for ts/tsx files', () => {
+    let cs = createConfigSet({
+      tsJestConfig: {
+        tsconfig: false,
+        diagnostics: { pathRegex: '/foo/' },
+      } as any,
+    })
+
     expect(cs.shouldReportDiagnostics('/foo/index.ts')).toBe(true)
-    expect(cs.shouldReportDiagnostics('/bar/index.ts')).toBe(false)
+    expect(cs.shouldReportDiagnostics('/bar/index.tsx')).toBe(false)
+
     cs = createConfigSet({ tsJestConfig: { tsconfig: false } as any })
+
     expect(cs.shouldReportDiagnostics('/foo/index.ts')).toBe(true)
-    expect(cs.shouldReportDiagnostics('/bar/index.ts')).toBe(true)
+    expect(cs.shouldReportDiagnostics('/bar/index.tsx')).toBe(true)
+  })
+
+  test('should return correct value for js/jsx files with checkJs compiler option', () => {
+    let cs = createConfigSet({
+      tsJestConfig: {
+        tsconfig: { checkJs: false },
+        diagnostics: { pathRegex: '/foo/' },
+      },
+    })
+
+    expect(cs.shouldReportDiagnostics('/foo/index.js')).toBe(false)
+    expect(cs.shouldReportDiagnostics('/foo/index.jsx')).toBe(false)
+
+    cs = createConfigSet({
+      tsJestConfig: {
+        tsconfig: { checkJs: true },
+        diagnostics: { pathRegex: '/foo/' },
+      },
+    })
+
+    expect(cs.shouldReportDiagnostics('/foo/index.js')).toBe(true)
+    expect(cs.shouldReportDiagnostics('/foo/index.jsx')).toBe(true)
+
+    cs = createConfigSet({ tsJestConfig: { tsconfig: { checkJs: true } } })
+
+    expect(cs.shouldReportDiagnostics('/foo/index.js')).toBe(true)
+    expect(cs.shouldReportDiagnostics('/foo/index.jsx')).toBe(true)
   })
 }) // shouldReportDiagnostics
 

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -26,7 +26,7 @@ import {
   ScriptTarget,
 } from 'typescript'
 
-import { DEFAULT_JEST_TEST_MATCH } from '../constants'
+import { DEFAULT_JEST_TEST_MATCH, JS_JSX_EXTENSIONS } from '../constants'
 import { factory as hoisting } from '../transformers/hoist-jest'
 import type {
   AstTransformer,
@@ -528,12 +528,14 @@ export class ConfigSet {
 
   shouldReportDiagnostics(filePath: string): boolean {
     const { pathRegex } = this._diagnostics
+    const fileExtension = extname(filePath)
+    const { checkJs } = this.parsedTsConfig.options
     if (pathRegex) {
       const regex = new RegExp(pathRegex)
 
-      return regex.test(filePath)
+      return JS_JSX_EXTENSIONS.includes(fileExtension) ? checkJs && regex.test(filePath) : regex.test(filePath)
     } else {
-      return true
+      return JS_JSX_EXTENSIONS.includes(fileExtension) ? checkJs : true
     }
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,8 @@
 export const LINE_FEED = '\n'
+export const DECLARATION_TYPE_EXT = '.d.ts'
+export const JS_JSX_EXTENSIONS = ['.js', '.jsx']
 export const TS_TSX_REGEX = /\.tsx?$/
 export const JS_JSX_REGEX = /\.jsx?$/
-export const DECLARATION_TYPE_EXT = '.d.ts'
 // `extensionsToTreatAsEsm` only accepts `.ts`, `.tsx` and `.jsx`. `.js`, `.cjs`, `.mjs` will throw error
 export const TS_EXT_TO_TREAT_AS_ESM = ['.ts', '.tsx']
 export const JS_EXT_TO_TREAT_AS_ESM = ['.jsx']


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When `allowJs` is `true`, `ts-jest` will process `js` files and also perform type checking. However, since default behavior of TypeScript is not doing type checking on `js` files (`checkJs` default value is `false`), we should respect that behavior.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test, green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->
If one currently relies on type check for `js` files, please set `checkJs: true` in your tsconfig

## Other information
**N.A.**
