### PR TITLE
feat(config): replace `pathRegex` with `exclude`

### DIFF
--- a/src/compiler/__snapshots__/ts-compiler.spec.ts.snap
+++ b/src/compiler/__snapshots__/ts-compiler.spec.ts.snap
@@ -53,9 +53,9 @@ exports[`TsCompiler isolatedModule false should compile codes with useESM true 1
 //# "
 `;
 
-exports[`TsCompiler isolatedModule true diagnostics should report diagnostics related to codes with pathRegex config is undefined 1`] = `"foo.ts(2,23): error TS1005: '=>' expected."`;
+exports[`TsCompiler isolatedModule true diagnostics should report diagnostics related to codes with exclude config is undefined 1`] = `"foo.ts(2,23): error TS1005: '=>' expected."`;
 
-exports[`TsCompiler isolatedModule true diagnostics should report diagnostics related to codes with pathRegex config matches file name 1`] = `"foo.ts(2,23): error TS1005: '=>' expected."`;
+exports[`TsCompiler isolatedModule true diagnostics should report diagnostics related to codes with exclude config matches file name 1`] = `"foo.ts(2,23): error TS1005: '=>' expected."`;
 
 exports[`TsCompiler isolatedModule true jsx option should compile tsx file for jsx preserve 1`] = `
 "\\"use strict\\";

--- a/src/compiler/ts-compiler.spec.ts
+++ b/src/compiler/ts-compiler.spec.ts
@@ -130,7 +130,7 @@ const v: boolean = t
         ).not.toThrowError()
       })
 
-      it('should report diagnostics related to codes with pathRegex config is undefined', () => {
+      it('should report diagnostics related to codes with exclude config is undefined', () => {
         const compiler = makeCompiler({ tsJestConfig: { ...baseTsJestConfig, tsconfig: false } })
 
         expect(() =>
@@ -145,9 +145,9 @@ const t: string = f(5)
         ).toThrowErrorMatchingSnapshot()
       })
 
-      it('should report diagnostics related to codes with pathRegex config matches file name', () => {
+      it('should report diagnostics related to codes with exclude config matches file name', () => {
         const compiler = makeCompiler({
-          tsJestConfig: { ...baseTsJestConfig, tsconfig: false, diagnostics: { pathRegex: 'foo.ts' } },
+          tsJestConfig: { ...baseTsJestConfig, tsconfig: false, diagnostics: { exclude: ['foo.ts'] } },
         })
 
         expect(() =>
@@ -162,9 +162,9 @@ const t: string = f(5)
         ).toThrowErrorMatchingSnapshot()
       })
 
-      it('should not report diagnostics related to codes with pathRegex config does not match file name', () => {
+      it('should not report diagnostics related to codes with exclude config does not match file name', () => {
         const compiler = makeCompiler({
-          tsJestConfig: { ...baseTsJestConfig, tsconfig: false, diagnostics: { pathRegex: 'bar.ts' } },
+          tsJestConfig: { ...baseTsJestConfig, tsconfig: false, diagnostics: { exclude: ['bar.ts'] } },
         })
 
         expect(() =>
@@ -410,7 +410,7 @@ const t: string = f(5)
           {
             tsJestConfig: {
               ...baseTsJestConfig,
-              diagnostics: { pathRegex: 'foo.spec.ts' },
+              diagnostics: { exclude: ['foo.spec.ts'] },
             },
           },
           jestCacheFS,

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,10 +102,9 @@ export interface TsJestGlobalOptions {
          */
         ignoreCodes?: number | string | (number | string)[]
         /**
-         * If specified, diagnostics of source files which path does **not** match
-         * will be ignored
+         * If specified, diagnostics of source files which path **matches** will be ignored
          */
-        pathRegex?: RegExp | string
+        exclude?: Config.Glob[]
         /**
          * Logs TypeScript errors to stderr instead of throwing exceptions
          *
@@ -152,7 +151,7 @@ type TsJestConfig$tsConfig = TsJestConfig$tsConfig$file | TsJestConfig$tsConfig$
 export interface TsJestDiagnosticsCfg {
   pretty: boolean
   ignoreCodes: number[]
-  pathRegex?: string | undefined
+  exclude: Config.Glob[]
   throws: boolean
   warnOnly?: boolean
 }

--- a/src/utils/__snapshots__/backports.spec.ts.snap
+++ b/src/utils/__snapshots__/backports.spec.ts.snap
@@ -98,7 +98,9 @@ Object {
   "globals": Object {
     "ts-jest": Object {
       "diagnostics": Object {
-        "pathRegex": "\\\\.spec\\\\.ts$",
+        "exclude": Array [
+          "\\\\.spec\\\\.ts$",
+        ],
         "warnOnly": true,
       },
     },

--- a/src/utils/backports.ts
+++ b/src/utils/backports.ts
@@ -64,7 +64,7 @@ export const backportJestConfig = <T extends Config.InitialOptions | Config.Proj
     warnConfig('globals.ts-jest.enableTsDiagnostics', 'globals.ts-jest.diagnostics')
     if (tsJest.enableTsDiagnostics) {
       mergeTsJest.diagnostics = { warnOnly: true }
-      if (typeof tsJest.enableTsDiagnostics === 'string') mergeTsJest.diagnostics.pathRegex = tsJest.enableTsDiagnostics
+      if (typeof tsJest.enableTsDiagnostics === 'string') mergeTsJest.diagnostics.exclude = [tsJest.enableTsDiagnostics]
     } else {
       mergeTsJest.diagnostics = false
     }

--- a/website/docs/options/diagnostics.md
+++ b/website/docs/options/diagnostics.md
@@ -20,9 +20,11 @@ The `diagnostics` option's value can also accept an object for more advanced con
 - **`warnOnly`**: If specified and `true`, diagnostics will be reported but won't stop compilation (default: _disabled_).
 - **`ignoreCodes`**: List of TypeScript error codes to ignore. Complete list can be found [there](https://github.com/Microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json). By default here are the ones ignored:
   - `6059`: _'rootDir' is expected to contain all source files._
-  - `18002`: _The 'files' list in config file is empty._ (it is strongly recommended to include this one)
+  - `18002`: _The 'files' list in config file is empty._ (it is strongly recommended including this one)
   - `18003`: _No inputs were found in config file._
-- **`pathRegex`**: If specified, diagnostics of source files which path does **not** match will be ignored.
+- **`exclude`**: If specified, diagnostics of source files which path **matches** will be ignored. This works a bit
+  similar to `tsconfig` option [exclude](https://www.typescriptlang.org/tsconfig#exclude) with the only difference is that
+  in TypeScript, `exclude` will also exclude files from compilation process.
 - **`pretty`**: Enables/disables colorful and pretty output of errors (default: _enabled_).
 
 ### Examples
@@ -68,7 +70,7 @@ module.exports = {
   globals: {
     'ts-jest': {
       diagnostics: {
-        pathRegex: /\.(spec|test)\.ts$/,
+        exclude: ['**/*.spec.ts'],
       },
     },
   },
@@ -83,7 +85,7 @@ module.exports = {
     "globals": {
       "ts-jest": {
         "diagnostics": {
-          "pathRegex": "\\.(spec|test)\\.ts$"
+          "exclude": ["**/*.spec.ts"]
         }
       }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Replace `pathRegex` by `exclude` which uses Glob patterns, similar to tsconfig `exclude` option. This will make it easier to configure files to exclude from type checking.
- Adjust documentation

Partially related to #2258 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Adjusted unit tests, green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->
One is currently using `pathRegex` should use `exclude` with Glob patterns

## Other information
**N.A.**
