### PR TITLE
fix(config): define matchTestFilePath before setupTsJestCfg

### DIFF
--- a/src/__mocks__/dummy-transformer.js
+++ b/src/__mocks__/dummy-transformer.js
@@ -3,6 +3,8 @@ const { LogContexts, LogLevels } = require('bs-logger')
 function factory(cs) {
   const logger = cs.logger.child({ namespace: 'dummy-transformer' })
   const ts = cs.compilerModule
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const program = cs.tsCompiler.program
 
   function createVisitor(_ctx, _) {
     return (node) => node

--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -190,8 +190,6 @@ export class ConfigSet {
     this.logger.debug({ compilerModule: this.compilerModule }, 'normalized compiler module config via ts-jest option')
 
     this._backportJestCfg()
-    this._setupTsJestCfg(options)
-    this._resolveTsCacheDir()
     this._matchablePatterns = [...this._jestCfg.testMatch, ...this._jestCfg.testRegex].filter(
       (pattern) =>
         /**
@@ -206,6 +204,8 @@ export class ConfigSet {
     this._matchTestFilePath = globsToMatcher(
       this._matchablePatterns.filter((pattern: any) => typeof pattern === 'string') as string[],
     )
+    this._setupTsJestCfg(options)
+    this._resolveTsCacheDir()
   }
 
   /**


### PR DESCRIPTION
## Summary

Related https://github.com/kulshekhar/ts-jest/issues/2371

![some](https://user-images.githubusercontent.com/1300172/108312459-1d2a3480-71fa-11eb-9ff3-3170c1af2b6a.png)

This error occurs when accessing a `tsCompiler` object from a `factory` method inside `custom transformers`.

## Test plan

`npm test` passed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
