### PR TITLE
fix(compiler): compile and type check correctly in watch mode when file content itself changes

### DIFF
--- a/src/compiler/ts-jest-compiler.ts
+++ b/src/compiler/ts-jest-compiler.ts
@@ -1,5 +1,5 @@
 import type { ConfigSet } from '../config/config-set'
-import type { CompilerInstance, ResolvedModulesMap, StringMap } from '../types'
+import type { CompilerInstance, StringMap } from '../types'
 
 import { TsCompiler } from './ts-compiler'
 
@@ -9,13 +9,13 @@ import { TsCompiler } from './ts-compiler'
 export class TsJestCompiler implements CompilerInstance {
   private readonly _compilerInstance: CompilerInstance
 
-  constructor(readonly configSet: ConfigSet, readonly jestCacheFS: StringMap) {
+  constructor(configSet: ConfigSet, runtimeCacheFS: StringMap) {
     // Later we can add swc/esbuild or other typescript compiler instance here
-    this._compilerInstance = new TsCompiler(configSet, jestCacheFS)
+    this._compilerInstance = new TsCompiler(configSet, runtimeCacheFS)
   }
 
-  getResolvedModulesMap(fileContent: string, fileName: string): ResolvedModulesMap {
-    return this._compilerInstance.getResolvedModulesMap(fileContent, fileName)
+  getResolvedModules(fileContent: string, fileName: string, runtimeCacheFS: StringMap): string[] {
+    return this._compilerInstance.getResolvedModules(fileContent, fileName, runtimeCacheFS)
   }
 
   getCompiledOutput(fileContent: string, fileName: string, supportsStaticESM: boolean): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,15 +204,18 @@ export interface InitialOptionsTsJest extends Config.InitialOptions {
   globals?: GlobalConfigTsJest
 }
 
-export type ResolvedModulesMap = Map<string, _ts.ResolvedModuleFull | undefined> | undefined
-
 /**
  * @internal
  */
 export type StringMap = Map<string, string>
 
+export interface DepGraphInfo {
+  fileContent: string
+  resolvedModuleNames: string[]
+}
+
 export interface CompilerInstance {
-  getResolvedModulesMap(fileContent: string, fileName: string): ResolvedModulesMap
+  getResolvedModules(fileContent: string, fileName: string, runtimeCacheFS: StringMap): string[]
   getCompiledOutput(fileContent: string, fileName: string, supportsStaticESM: boolean): string
 }
 export interface TsCompilerInstance extends CompilerInstance {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Separate compiler file content cache and jest file content cache. When compiling and type checking, comparing a file content from compiler file content cache against jest file content cache so that `LanguageService` is updated correctly.

Closes #2118 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test, Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
