### PR TITLE
fix(compiler): initialize compiler with `.ts`/`.tsx`/`.d.ts` files only

### DIFF
--- a/src/__mocks__/thing.ts
+++ b/src/__mocks__/thing.ts
@@ -1,3 +1,5 @@
+// @ts-expect-error testing purpose
+import babelFooCfg from './babel-foo.config'
 import { getFoo } from './thing1'
 import { getFooBar } from './thing1'
 import { getBar } from './thing2'
@@ -5,3 +7,4 @@ import { getBar } from './thing2'
 getFoo('foo')
 getBar('bar')
 getFooBar('foobar')
+getFoo(JSON.stringify(babelFooCfg.presets))

--- a/src/compiler/__snapshots__/ts-compiler.spec.ts.snap
+++ b/src/compiler/__snapshots__/ts-compiler.spec.ts.snap
@@ -36,12 +36,33 @@ const App = () => {
 `;
 
 exports[`TsCompiler isolatedModule false should compile codes with useESM true 1`] = `
-"import { getFoo } from './thing1';
+"// @ts-expect-error testing purpose
+import babelFooCfg from './babel-foo.config';
+import { getFoo } from './thing1';
 import { getFooBar } from './thing1';
 import { getBar } from './thing2';
 getFoo('foo');
 getBar('bar');
 getFooBar('foobar');
+getFoo(JSON.stringify(babelFooCfg.presets));
+//# "
+`;
+
+exports[`TsCompiler isolatedModule false should compile ts file which has an existing js file 1`] = `
+"\\"use strict\\";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { \\"default\\": mod };
+};
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+// @ts-expect-error testing purpose
+const babel_foo_config_1 = __importDefault(require(\\"./babel-foo.config\\"));
+const thing1_1 = require(\\"./thing1\\");
+const thing1_2 = require(\\"./thing1\\");
+const thing2_1 = require(\\"./thing2\\");
+thing1_1.getFoo('foo');
+thing2_1.getBar('bar');
+thing1_2.getFooBar('foobar');
+thing1_1.getFoo(JSON.stringify(babel_foo_config_1.default.presets));
 //# "
 `;
 
@@ -73,11 +94,14 @@ exports.default = 42;
 `;
 
 exports[`TsCompiler isolatedModule true should transpile code with useESM true 1`] = `
-"import { getFoo } from './thing1';
+"// @ts-expect-error testing purpose
+import babelFooCfg from './babel-foo.config';
+import { getFoo } from './thing1';
 import { getFooBar } from './thing1';
 import { getBar } from './thing2';
 getFoo('foo');
 getBar('bar');
 getFooBar('foobar');
+getFoo(JSON.stringify(babelFooCfg.presets));
 //# "
 `;

--- a/src/compiler/ts-compiler.ts
+++ b/src/compiler/ts-compiler.ts
@@ -21,8 +21,8 @@ import type {
   ResolvedModuleWithFailedLookupLocations,
 } from 'typescript'
 
-import { ConfigSet, TS_JEST_OUT_DIR } from '../config/config-set'
-import { LINE_FEED } from '../constants'
+import type { ConfigSet } from '../config/config-set'
+import { LINE_FEED, TS_TSX_REGEX } from '../constants'
 import type { StringMap, TsCompilerInstance, TsJestAstTransformer, TTypeScript } from '../types'
 import { rootLogger } from '../utils/logger'
 import { Errors, interpolate } from '../utils/messages'
@@ -116,12 +116,7 @@ export class TsCompiler implements TsCompilerInstance {
   private _createLanguageService(): void {
     // Initialize memory cache for typescript compiler
     this._parsedTsConfig.fileNames
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      .filter(
-        (fileName) =>
-          !this.configSet.isTestFile(fileName) &&
-          !fileName.includes(this._parsedTsConfig.options.outDir ?? TS_JEST_OUT_DIR),
-      )
+      .filter((fileName) => TS_TSX_REGEX.test(fileName) && !this.configSet.isTestFile(fileName))
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       .forEach((fileName) => this._fileVersionCache!.set(fileName, 0))
     /* istanbul ignore next */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Limit the initial list of file names for `LanguageService` to only include `.ts`/`.tsx`/`.d.ts` files

Closes #2445

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
