### PR TITLE
fix: declare missing export for `jest-preset`

### DIFF
--- a/e2e/__cases__/presets/ts-jest-presets.spec.ts
+++ b/e2e/__cases__/presets/ts-jest-presets.spec.ts
@@ -1,13 +1,15 @@
 // preset and utils should work all the time
 import * as presets from 'ts-jest/presets'
+import * as defaultPreset from 'ts-jest/jest-preset';
 import { JS_EXT_TO_TREAT_AS_ESM, TS_EXT_TO_TREAT_AS_ESM } from 'ts-jest/dist/constants'
 
 test('presets', () => {
-  expect(presets.defaults).toEqual({
+  expect(defaultPreset).toEqual({
     transform: {
       '^.+\\.tsx?$': 'ts-jest',
     },
   })
+
   expect(presets.defaultsESM).toEqual({
     extensionsToTreatAsEsm: [...TS_EXT_TO_TREAT_AS_ESM],
     transform: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./dist/*": "./dist/*.js",
-    "./presets": "./jest-preset.js",
+    "./jest-preset": "./jest-preset.js",
+    "./preset": "./presets/index.js",
     "./utils": "./utils/index.js",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Declare missing export for `jest-preset` which made `const defaultPreset = require('ts-jest/jest-preset')` failed

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Adjusted e2e test, green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
