### PR TITLE
typo(package.json): preset -> presets

### DIFF
--- a/website/docs/getting-started/presets.md
+++ b/website/docs/getting-started/presets.md
@@ -74,12 +74,12 @@ Or through TypeScript (if `ts-node` is installed):
 ```ts
 // jest.config.ts
 import type { InitialOptionsTsJest } from 'ts-jest/dist/types'
-import { defaults as tsjPreset } from 'ts-jest/preset'
-// import { defaultsESM as tsjPreset } from 'ts-jest/preset'
-// import { jsWithTs as tsjPreset } from 'ts-jest/preset'
-// import { jsWithTsESM as tsjPreset } from 'ts-jest/preset'
-// import { jsWithBabel as tsjPreset } from 'ts-jest/preset'
-// import { jsWithBabelESM as tsjPreset } from 'ts-jest/preset'
+import { defaults as tsjPreset } from 'ts-jest/presets'
+// import { defaultsESM as tsjPreset } from 'ts-jest/presets'
+// import { jsWithTs as tsjPreset } from 'ts-jest/presets'
+// import { jsWithTsESM as tsjPreset } from 'ts-jest/presets'
+// import { jsWithBabel as tsjPreset } from 'ts-jest/presets'
+// import { jsWithBabelESM as tsjPreset } from 'ts-jest/presets'
 
 const config: InitialOptionsTsJest = {
   // [...]

--- a/website/versioned_docs/version-26.5/getting-started/presets.md
+++ b/website/versioned_docs/version-26.5/getting-started/presets.md
@@ -67,9 +67,9 @@ Or through TypeScript (if `ts-node` is installed):
 ```ts
 // jest.config.ts
 import type { InitialOptionsTsJest } from 'ts-jest/dist/types'
-import { defaults as tsjPreset } from 'ts-jest/preset'
-// import { jsWithTs as tsjPreset } from 'ts-jest/preset'
-// import { jsWithBabel as tsjPreset } from 'ts-jest/preset'
+import { defaults as tsjPreset } from 'ts-jest/presets'
+// import { jsWithTs as tsjPreset } from 'ts-jest/presets'
+// import { jsWithBabel as tsjPreset } from 'ts-jest/presets'
 const config: InitialOptionsTsJest = {
   // [...]
   transform: {


### PR DESCRIPTION
If I'm this is a typo, I had to make the change locally for node to resolve the presets correctly.

Eitherway there is some incoherence in the doc or their.

> https://kulshekhar.github.io/ts-jest/docs/next/getting-started/presets
```js
// jest.config.js
const { defaults: tsjPreset } = require('ts-jest/presets')
// const { defaultsESM: tsjPreset } = require('ts-jest/presets')
// const { jsWithTs: tsjPreset } = require('ts-jest/presets')
// const { jsWithTsESM: tsjPreset } = require('ts-jest/presets')
// const { jsWithBabel: tsjPreset } = require('ts-jest/presets')
// const { jsWithBabelESM: tsjPreset } = require('ts-jest/presets')

module.exports = {
  // [...]
  transform: {
    ...tsjPreset.transform,
    // [...]
  },
}
```
```
// jest.config.ts
import type { InitialOptionsTsJest } from 'ts-jest/dist/types'
import { defaults as tsjPreset } from 'ts-jest/preset'
// import { defaultsESM as tsjPreset } from 'ts-jest/preset'
// import { jsWithTs as tsjPreset } from 'ts-jest/preset'
// import { jsWithTsESM as tsjPreset } from 'ts-jest/preset'
// import { jsWithBabel as tsjPreset } from 'ts-jest/preset'
// import { jsWithBabelESM as tsjPreset } from 'ts-jest/preset'

const config: InitialOptionsTsJest = {
  // [...]
  transform: {
    ...tsjPreset.transform,
    // [...]
  },
}

export default config
```

