### PR TITLE
fix(compiler): return file content on emitSkipped for non ts/tsx files

### DIFF
--- a/src/compiler/ts-compiler.ts
+++ b/src/compiler/ts-compiler.ts
@@ -176,9 +176,13 @@ export class TsCompiler implements TsCompilerInstance {
       const output: EmitOutput = this._languageService.getEmitOutput(fileName)
       this._doTypeChecking(fileName, options.depGraphs, options.watchMode)
       if (output.emitSkipped) {
-        this._logger.warn(interpolate(Errors.CannotProcessFile, { file: fileName }))
+        if (TS_TSX_REGEX.test(fileName)) {
+          throw new Error(interpolate(Errors.CannotProcessFile, { file: fileName }))
+        } else {
+          this._logger.warn(interpolate(Errors.CannotProcessFileReturnOriginal, { file: fileName }))
 
-        return updateOutput(fileContent, fileName, '{}')
+          return updateOutput(fileContent, fileName, '{}')
+        }
       }
       // Throw an error when requiring `.d.ts` files.
       if (!output.outputFiles.length) {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -17,7 +17,8 @@ export const enum Errors {
   GotUnknownFileTypeWithBabel = 'Got a unknown file type to compile (file: {{path}}). To fix this, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match this kind of files anymore. If you still want Babel to process it, add another entry to the `transform` option with value `babel-jest` which key matches this type of files.',
   ConfigNoModuleInterop = 'If you have issues related to imports, you should consider setting `esModuleInterop` to `true` in your TypeScript configuration file (usually `tsconfig.json`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.',
   MismatchNodeTargetMapping = 'There is a mismatch between your NodeJs version {{nodeJsVer}} and your TypeScript target {{compilationTarget}}. This might lead to some unexpected errors when running tests with `ts-jest`. To fix this, you can check https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping',
-  CannotProcessFile = "Unable to process '{{file}}', falling back to original file content. Please make sure that `outDir` in your tsconfig is neither `''` or `'.'`. You can also configure Jest config option `transformIgnorePatterns` to ignore {{file}} from transformation",
+  CannotProcessFileReturnOriginal = "Unable to process '{{file}}', falling back to original file content. You can also configure Jest config option `transformIgnorePatterns` to ignore {{file}} from transformation or make sure that `outDir` in your tsconfig is neither `''` or `'.'`",
+  CannotProcessFile = "Unable to process '{{file}}', please make sure that `outDir` in your tsconfig is neither `''` or `'.'`. You can also configure Jest config option `transformIgnorePatterns` to inform `ts-jest` to transform {{file}}",
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When encountering `emitSkipped`:
- Return file content and show a warning message for non `ts`/`tsx` files.
- Throw error for `ts`/`tsx` files

Closes #2513 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
