### PR TITLE
fix(cli): keep `testMatch` if old jest config contains it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ module.exports = {
 ```
 * Remove possibilities to import `mocked`, `createJestPreset`, `pathsToModuleNameMapper` from package entry. One should change to
 ```
-import { mocked, createJestPreset, pathsToModuleNameMapper` } from 'ts-jest/utils'
+import { mocked, createJestPreset, pathsToModuleNameMapper } from 'ts-jest/utils'
 ```
 * **config:** One currently uses `tsConfig` should change to `tsconfig` in your `jest.config.js` or `package.json`.
 

--- a/src/cli/__snapshots__/cli.spec.ts.snap
+++ b/src/cli/__snapshots__/cli.spec.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`config migrate should migrate preset if valid preset value is used 1`] = `
+"
+No migration needed for given Jest configuration
+    "
+`;
+
+exports[`config migrate should migrate preset if valid preset value is used 2`] = `
+"\\"jest\\": {
+  \\"preset\\": \\"ts-jest\\"
+}
+"
+`;
+
+exports[`config migrate should migrate preset if valid preset value is used 3`] = `
+"
+No migration needed for given Jest configuration
+    "
+`;
+
+exports[`config migrate should reset testMatch if testRegex is used 1`] = `
+"\\"jest\\": {
+  \\"testRegex\\": \\"foo-pattern\\",
+  \\"preset\\": \\"ts-jest\\"
+}
+"
+`;
+
+exports[`config migrate should reset testMatch if testRegex is used 2`] = `
+"\\"jest\\": {
+  \\"testRegex\\": [
+    \\"foo-pattern\\"
+  ],
+  \\"preset\\": \\"ts-jest\\"
+}
+"
+`;
+
+exports[`config migrate should reset testMatch if testRegex is used 3`] = `
+"\\"jest\\": {
+  \\"testRegex\\": [],
+  \\"testMatch\\": [
+    \\"**/__tests__/**/*.(spec|test).[tj]s?(x)\\"
+  ],
+  \\"preset\\": \\"ts-jest\\"
+}
+"
+`;
+
+exports[`config migrate should reset testMatch if testRegex is used 4`] = `
+"\\"jest\\": {
+  \\"testMatch\\": [
+    \\"**/__tests__/**/*.(spec|test).[tj]s?(x)\\"
+  ],
+  \\"preset\\": \\"ts-jest\\"
+}
+"
+`;
+
+exports[`config migrate should reset testMatch if testRegex is used 5`] = `
+"\\"jest\\": {
+  \\"testRegex\\": \\"foo-pattern\\",
+  \\"preset\\": \\"ts-jest\\"
+}
+"
+`;

--- a/src/cli/cli.spec.ts
+++ b/src/cli/cli.spec.ts
@@ -413,27 +413,69 @@ Migrated Jest configuration:
 `)
     })
 
-    it('should reset testMatch if testRegex is used', async () => {
+    test.each([
+      {
+        jest: {
+          preset: 'ts-jest',
+        },
+      },
+      {
+        jest: {
+          preset: 'ts-jest/foo',
+        },
+      },
+      {
+        jest: {
+          preset: 'foo-preset',
+        },
+      },
+    ])('should migrate preset if valid preset value is used', async (jestCfg) => {
       expect.assertions(1)
       fs.existsSync.mockImplementation(() => true)
-      jest.mock(
-        pkgPaths.next,
-        () => ({
-          jest: {
-            testRegex: 'foo-pattern',
-          },
-        }),
-        { virtual: true },
-      )
+      jest.mock(pkgPaths.next, () => jestCfg, { virtual: true })
+
       const res = await runCli(...noOption, pkgPaths.current)
-      expect(res.stdout).toMatchInlineSnapshot(`
-"\\"jest\\": {
-  \\"testRegex\\": \\"foo-pattern\\",
-  \\"preset\\": \\"ts-jest\\",
-  \\"testMatch\\": null
-}
-"
-`)
+
+      expect(res.stdout ? res.stdout : res.stderr).toMatchSnapshot()
+    })
+
+    test.each([
+      {
+        jest: {
+          testRegex: 'foo-pattern',
+          testMatch: ['**/__tests__/**/*.(spec|test).[tj]s?(x)'],
+        },
+      },
+      {
+        jest: {
+          testRegex: ['foo-pattern'],
+          testMatch: ['**/__tests__/**/*.(spec|test).[tj]s?(x)'],
+        },
+      },
+      {
+        jest: {
+          testRegex: [],
+          testMatch: ['**/__tests__/**/*.(spec|test).[tj]s?(x)'],
+        },
+      },
+      {
+        jest: {
+          testMatch: ['**/__tests__/**/*.(spec|test).[tj]s?(x)'],
+        },
+      },
+      {
+        jest: {
+          testRegex: 'foo-pattern',
+        },
+      },
+    ])('should reset testMatch if testRegex is used', async (jestCfg) => {
+      expect.assertions(1)
+      fs.existsSync.mockImplementation(() => true)
+      jest.mock(pkgPaths.next, () => jestCfg, { virtual: true })
+
+      const res = await runCli(...noOption, pkgPaths.current)
+
+      expect(res.stdout).toMatchSnapshot()
     })
 
     it('should detect best preset', async () => {

--- a/src/cli/config/migrate.ts
+++ b/src/cli/config/migrate.ts
@@ -71,19 +71,19 @@ export const run: CliCommand = async (args: Arguments /* , logger: Logger*/) => 
       }
     }
     // ensure we are using a preset
-    presetName = presetName || JestPresetNames.default
+    presetName = presetName ?? JestPresetNames.default
     preset = allPresets[presetName]
     footNotes.push(
       `Detected preset '${preset.label}' as the best matching preset for your configuration.
 Visit https://kulshekhar.github.io/ts-jest/user/config/#jest-preset for more information about presets.
 `,
     )
-  } else if (migratedConfig.preset && migratedConfig.preset.startsWith('ts-jest')) {
+  } else if (migratedConfig.preset?.startsWith('ts-jest')) {
     if (args.jestPreset === false) {
       delete migratedConfig.preset
     } else {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      preset = (allPresets as any)[migratedConfig.preset] || defaults
+      preset = (allPresets as any)[migratedConfig.preset] ?? defaults
     }
   }
 
@@ -91,21 +91,20 @@ Visit https://kulshekhar.github.io/ts-jest/user/config/#jest-preset for more inf
   if (preset) migratedConfig.preset = preset.name
 
   // check the extensions
-  if (migratedConfig.moduleFileExtensions && migratedConfig.moduleFileExtensions.length && preset) {
-    const presetValue = dedupSort(preset.value.moduleFileExtensions || []).join('::')
+  if (migratedConfig.moduleFileExtensions?.length && preset) {
+    const presetValue = dedupSort(preset.value.moduleFileExtensions ?? []).join('::')
     const migratedValue = dedupSort(migratedConfig.moduleFileExtensions).join('::')
     if (presetValue === migratedValue) {
       delete migratedConfig.moduleFileExtensions
     }
   }
   // there is a testRegex, remove our testMatch
-  if (migratedConfig.testRegex && preset) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    migratedConfig.testMatch = null as any
+  if ((typeof migratedConfig.testRegex === 'string' || migratedConfig.testRegex?.length) && preset) {
+    delete migratedConfig.testMatch
   }
   // check the testMatch
-  else if (migratedConfig.testMatch && migratedConfig.testMatch.length && preset) {
-    const presetValue = dedupSort(preset.value.testMatch || []).join('::')
+  else if (migratedConfig.testMatch?.length && preset) {
+    const presetValue = dedupSort(preset.value.testMatch ?? []).join('::')
     const migratedValue = dedupSort(migratedConfig.testMatch).join('::')
     if (presetValue === migratedValue) {
       delete migratedConfig.testMatch
@@ -190,20 +189,20 @@ function cleanupConfig(config: Config.InitialOptions): void {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (config as any).globals['ts-jest']
     }
-    if (Object.keys(config.globals).length === 0) {
+    if (!Object.keys(config.globals).length) {
       delete config.globals
     }
   }
-  if (config.transform && Object.keys(config.transform).length === 0) {
+  if (config.transform && !Object.keys(config.transform).length) {
     delete config.transform
   }
   if (config.moduleFileExtensions) {
     config.moduleFileExtensions = dedupSort(config.moduleFileExtensions)
-    if (config.moduleFileExtensions.length === 0) delete config.moduleFileExtensions
+    if (!config.moduleFileExtensions.length) delete config.moduleFileExtensions
   }
   if (config.testMatch) {
     config.testMatch = dedupSort(config.testMatch)
-    if (config.testMatch.length === 0) delete config.testMatch
+    if (!config.testMatch.length) delete config.testMatch
   }
   if (config.preset === JestPresetNames.default) config.preset = defaults.name
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The issue happens when `testRegex` is an empty array. This PR adds a few changes:
- Instead of set `testMatch` to `null`, delete `testMatch` from migrated config.
- Only delete `testMatch` from migrated config when `testRegex` is a string or a non-empty array.
- Improved codes to use optional chaining and nullish coalescing.

Closes #2616

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit tests
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
