### PR TITLE
fix(compiler): make sure language service use updated compiler options

### DIFF
--- a/src/compiler/ts-compiler.spec.ts
+++ b/src/compiler/ts-compiler.spec.ts
@@ -329,6 +329,14 @@ describe('TsCompiler', () => {
     beforeEach(() => {
       // @ts-expect-error testing purpose
       compiler._projectVersion = 1
+      /**
+       * This is to ensure that `compilerOptions` value and `_parsedTsConfig.fileNames` are always like
+       * when compiler instance is created since here we only create compiler instance once for all the tests below.
+       */
+      // @ts-expect-error testing purpose.
+      compiler._compilerOptions = { ...compiler._initialCompilerOptions }
+      // @ts-expect-error testing purpose.
+      compiler._parsedTsConfig.fileNames = []
       fileContentCache.clear()
       fileVersionCache.clear()
     })
@@ -352,6 +360,29 @@ describe('TsCompiler', () => {
       compiler._fileContentCache = fileContentCache
       // @ts-expect-error testing purpose
       compiler._fileVersionCache = fileVersionCache
+
+      // @ts-expect-error testing purpose
+      compiler._updateMemoryCache(fileContent, fileName)
+
+      // @ts-expect-error testing purpose
+      expect(compiler._projectVersion).toEqual(2)
+    })
+
+    test('should increase project version if processing file is in compiler file list', () => {
+      // @ts-expect-error testing purpose
+      compiler._parsedTsConfig.fileNames.push(fileName)
+      fileContentCache.set(fileName, fileContent)
+      fileVersionCache.set(fileName, 1)
+      // @ts-expect-error testing purpose
+      compiler._fileContentCache = fileContentCache
+      // @ts-expect-error testing purpose
+      compiler._fileVersionCache = fileVersionCache
+      // @ts-expect-error testing purpose
+      compiler._compilerOptions = {
+        // @ts-expect-error testing purpose
+        ...compiler._compilerOptions,
+        module: ModuleKind.AMD,
+      }
 
       // @ts-expect-error testing purpose
       compiler._updateMemoryCache(fileContent, fileName)

--- a/src/compiler/ts-compiler.ts
+++ b/src/compiler/ts-compiler.ts
@@ -32,6 +32,7 @@ import type {
   TsJestCompileOptions,
   TTypeScript,
 } from '../types'
+import { stringify } from '../utils/json'
 import { rootLogger } from '../utils/logger'
 import { Errors, interpolate } from '../utils/messages'
 
@@ -404,6 +405,9 @@ export class TsCompiler implements TsCompilerInstance {
       if (!this._parsedTsConfig.fileNames.includes(fileName)) {
         shouldIncrementProjectVersion = true
       }
+    }
+    if (stringify(this._compilerOptions) !== stringify(this._initialCompilerOptions)) {
+      shouldIncrementProjectVersion = true
     }
 
     if (shouldIncrementProjectVersion) this._projectVersion++


### PR DESCRIPTION
## Summary

When a file initially exists in compiler file set when `TsCompiler` is created, later in `getCompiledOutput` the value of `compilerOptions` which makes `LanguageService` is not aware of because `_updateMemoryCache` checks and sees that the file is the same so `projectVersion` value is not increased which makes `LanguageService` uses the outdated `_compilerOptions`.

This commit adds a comparison via JSON stringify between `_compilerOptions` and `_initialCompilerOptions`. If there is a difference, increase `projectVersion` for `LanguageService`.

This regression came to light when bumping vue-jest to ts-jest v27.
The tsconfig used has : `"module": "es2015"`, and `ts-jest` used to compile the files to commonjs anyway.
This is no longer the case when using ts-jest v27.0.0

Closes #2629 

## Test plan

Added unit test
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
