### PR TITLE
fix(config): `exclude` should only exclude files which match glob values

### DIFF
--- a/src/config/config-set.ts
+++ b/src/config/config-set.ts
@@ -141,7 +141,7 @@ export class ConfigSet {
   /**
    * @internal
    */
-  private _shouldGetDiagnosticsForFile!: (filePath: string) => boolean
+  private _shouldIgnoreDiagnosticsForFile!: (filePath: string) => boolean
   /**
    * @internal
    */
@@ -277,9 +277,9 @@ export class ConfigSet {
         throws: diagnosticsOpt,
       }
     }
-    this._shouldGetDiagnosticsForFile = this._diagnostics.exclude.length
+    this._shouldIgnoreDiagnosticsForFile = this._diagnostics.exclude.length
       ? globsToMatcher(this._diagnostics.exclude)
-      : () => true
+      : () => false
 
     this.logger.debug({ diagnostics: this._diagnostics }, 'normalized diagnostics config via ts-jest option')
 
@@ -549,8 +549,8 @@ export class ConfigSet {
     const fileExtension = extname(filePath)
 
     return JS_JSX_EXTENSIONS.includes(fileExtension)
-      ? this.parsedTsConfig.options.checkJs && this._shouldGetDiagnosticsForFile(filePath)
-      : this._shouldGetDiagnosticsForFile(filePath)
+      ? this.parsedTsConfig.options.checkJs && !this._shouldIgnoreDiagnosticsForFile(filePath)
+      : !this._shouldIgnoreDiagnosticsForFile(filePath)
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Reverse logic to check whether a file should be type checked to suit the usage of `exclude`.

Closes #2634

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
