### PR TITLE
fix: revert `exports` field to support all node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,6 @@
   "version": "27.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": {
-    ".": "./dist/index.js",
-    "./dist/*": "./dist/*.js",
-    "./jest-preset": "./jest-preset.js",
-    "./presets": "./presets/index.js",
-    "./utils": "./utils/index.js",
-    "./package.json": "./package.json"
-  },
   "bin": {
     "ts-jest": "cli.js"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Subpath exports don't work with Node 10 and Node < 12.20.0 so we have to revert the `exports` declaration in `package.json` so that consumers of `ts-jest` can still use `ts-jest` public apis.

Related issue https://github.com/thymikee/jest-preset-angular/issues/941

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
See https://github.com/ahnpnl/jest-preset-angular/actions/runs/902838031

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
