### PR TITLE
feat: set env var `TS_JEST` to allow detecting of ts-jest

### DIFF
--- a/src/ts-jest-transformer.spec.ts
+++ b/src/ts-jest-transformer.spec.ts
@@ -352,6 +352,10 @@ Array [
       `)
     })
 
+    test('should allow detection of ts-jest', () => {
+      expect(process.env.TS_JEST).toBe('1')
+    })
+
     test.each(['foo.ts', 'foo.tsx'])('should process ts/tsx file', (filePath) => {
       const fileContent = 'const foo = 1'
       const output = 'var foo = 1'

--- a/src/ts-jest-transformer.ts
+++ b/src/ts-jest-transformer.ts
@@ -63,6 +63,7 @@ export class TsJestTransformer implements SyncTransformer {
     this.process = this.process.bind(this)
 
     this._logger.debug('created new transformer')
+    process.env.TS_JEST = '1'
   }
 
   private _configsFor(transformOptions: TransformOptionsTsJest): ConfigSet {


### PR DESCRIPTION
This allows to detect on runtime that the code is executed via jest with TS support enabled via ts-jest. Works via setting environment variable `TS_JEST=1`.

Closes #2716

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

I am author of MikroORM. It allows to discover entities either via references (entities: [User]) or via paths (entities: ['./entities']). To use the folder based discovery, I need to operate on the TS files when running via ts-node or ts-jest, as I am attaching some properties to the entity prototype and therefore need to work with TS file if that is what will be later used on runtime (in other words, if ts-node/ts-jest is used, I need to discover TS files from src, otherwise JS files from dist).

To deal with this, I have two different config options for entity paths, one for JS files, one for TS files. If I am able to detect typescript support (e.g. ts-node) I am using the TS one.

While there are several ways to detect if we are under ts-node environment (e.g. using !!process[Symbol.for('ts-node.register.instance')]), I failed to find one to detect if we are running via jest with ts-jest preset.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

As this only sets env var, it should be safe. I failed to come up with a way to test it actually works from the runtime, happy to hear suggestions. I did verify the change does what it should in my project by adding the line to node_modules. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

