### PR TITLE
fix: add `@types/jest` as optional `peerDependencies` to solve yarn 2 problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,13 +71,17 @@
     "jest": "^27.0.0",
     "typescript": ">=3.8 <5.0",
     "babel-jest": ">=27.0.0 <28",
-    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@babel/core": ">=7.0.0-beta.0 <8",
+    "@types/jest": "^26.0.0"
   },
   "peerDependenciesMeta": {
     "babel-jest": {
       "optional": true
     },
     "@babel/core": {
+      "optional": true
+    },
+    "@types/jest": {
       "optional": true
     }
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The `mocked` function [helper](https://kulshekhar.github.io/ts-jest/docs/guides/test-helpers) requires a project to have `@types/jest` installed. However, we can't force users to install a type package so the way to go is declare it in the list of optional `peerDependencies`

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Create a `tgz` file of `ts-jest` and install on any projects, there shouldn't have any warnings about missing peer dependency for `@types/jest`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A**
