### PR TITLE
fix: fix config:init types

### DIFF
--- a/src/cli/cli.spec.ts
+++ b/src/cli/cli.spec.ts
@@ -135,7 +135,7 @@ Jest configuration written to "${normalize('/foo/bar/jest.config.js')}".
       expect(fs.writeFileSync.mock.calls).toEqual([
         [
           normalize('/foo/bar/jest.config.js'),
-          `/** @type {import('@ts-jest/dist/types').InitialOptionsTsJest} */
+          `/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
@@ -159,7 +159,7 @@ Jest configuration written to "${normalize('/foo/bar/jest.config.foo.js')}".
           normalize('/foo/bar/jest.config.foo.js'),
           `const { jsWithTs: tsjPreset } = require('ts-jest/presets');
 
-/** @type {import('@ts-jest/dist/types').InitialOptionsTsJest} */
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   ...tsjPreset,
   globals: {

--- a/src/cli/config/init.ts
+++ b/src/cli/config/init.ts
@@ -90,7 +90,7 @@ export const run: CliCommand = async (args: Arguments /* , logger: Logger */) =>
     if (!jestPreset) {
       content.push(`${preset.jsImport('tsjPreset')};`, '')
     }
-    content.push(`/** @type {import('@ts-jest/dist/types').InitialOptionsTsJest} */`)
+    content.push(`/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */`)
     content.push('module.exports = {')
     if (jestPreset) {
       content.push(`  preset: '${preset.name}',`)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes `ts-jest config:init` generated file's type error.

When I ran `npx ts-jest config:init` then I have a following error in generated `jest.config.js`.

> Cannot find module '@ts-jest/dist/types' or its corresponding type declarations.

Because ts-jest is installed in node_modules/ts-jest not node_modules/@ts-jest.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Run `npx ts-jest config:init` then you don't have any errors in generated `jest.config.js` .

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information

Fixes #2772