### PR TITLE
Docs: Troubleshoot import statement

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -10,7 +10,7 @@ Cannot find module "" from ""
 
 - Check if `rootDir` is referenced correctly. If not add this on your existing jest configuration.
 
-```javascipt
+```javascript
 module.exports = {
   ...
    roots: ["<rootDir>"]
@@ -19,7 +19,7 @@ module.exports = {
 
 - Check if module directories are included on your jest configuration. If not add this on your existing jest configuration.
 
-```javascipt
+```javascript
 module.exports = {
   ...
   moduleDirectories: ["node_modules","<module-directory>"],
@@ -29,7 +29,7 @@ module.exports = {
 
 - Check if module name is properly mapped and can be referenced by jest. If not, you can define moduleNameMapper for your jest configuration.
 
-```javascipt
+```javascript
 module.exports = {
   ...
   moduleNameMapper: {
@@ -39,3 +39,35 @@ module.exports = {
 ```
 
 - Check github folder names if its identical to you local folder names. Sometimes github never updates your folder names even if you rename it locally. If this happens rename your folders via github or use this command `git mv <source> <destination>` and commit changes.
+
+### PROBLEM
+
+SyntaxError: Cannot use import statement outside a module
+
+### SOLUTION
+One of the node modules that is used doesn't need to be transpiled.
+
+There is a good chance that the error message shows which one:
+
+```shell
+    SyntaxError: Cannot use import statement outside a module
+      20 | <script lang="ts">
+      21 | import Vue from "vue";
+    > 22 | import Component from "../../node_modules/some-module/lib";
+         | ^
+```
+In this case **some-module** is the problem.
+
+This module needs to be ignored in the transformation process. Add the following to the
+configuration file:
+
+```javascript
+module.exports = {
+  ...
+  transformIgnorePatterns: ["node_modules/(?!(some-module|another-module))"]
+};
+```
+
+**some-module** and **another-module** will be ignored in the transformation process.
+
+For more information see [here](https://stackoverflow.com/questions/63389757/jest-unit-test-syntaxerror-cannot-use-import-statement-outside-a-module) and [here](https://stackoverflow.com/questions/52035066/how-to-write-jest-transformignorepatterns).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -40,26 +40,27 @@ module.exports = {
 
 - Check github folder names if its identical to you local folder names. Sometimes github never updates your folder names even if you rename it locally. If this happens rename your folders via github or use this command `git mv <source> <destination>` and commit changes.
 
+## Transform (node)-module explicitly
+
 ### PROBLEM
 
 SyntaxError: Cannot use import statement outside a module
 
 ### SOLUTION
-One of the node modules that is used doesn't need to be transpiled.
 
-There is a good chance that the error message shows which one:
+One of the node modules hasn't the correct syntax for Jests execution step. It needs to
+be transformed first.
+
+There is a good chance that the error message shows which module is affected:
 
 ```shell
     SyntaxError: Cannot use import statement outside a module
-      20 | <script lang="ts">
-      21 | import Vue from "vue";
     > 22 | import Component from "../../node_modules/some-module/lib";
          | ^
 ```
-In this case **some-module** is the problem.
-
-This module needs to be ignored in the transformation process. Add the following to the
-configuration file:
+In this case **some-module** is the problem and needs to be transformed.
+By adding the following line to the configuration file it will tell Jest which modules
+shouldnt be ignored during the transformation step:
 
 ```javascript
 module.exports = {
@@ -68,6 +69,6 @@ module.exports = {
 };
 ```
 
-**some-module** and **another-module** will be ignored in the transformation process.
+**some-module** and **another-module** will be transformed.
 
 For more information see [here](https://stackoverflow.com/questions/63389757/jest-unit-test-syntaxerror-cannot-use-import-statement-outside-a-module) and [here](https://stackoverflow.com/questions/52035066/how-to-write-jest-transformignorepatterns).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -58,6 +58,7 @@ There is a good chance that the error message shows which module is affected:
     > 22 | import Component from "../../node_modules/some-module/lib";
          | ^
 ```
+
 In this case **some-module** is the problem and needs to be transformed.
 By adding the following line to the configuration file it will tell Jest which modules
 shouldnt be ignored during the transformation step:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

When setting up a project with @vue/cli (https://github.com/vuejs/vue-cli) with version 4.5.13 with ts-jest I faced the problem that the test could not be executed for my component because one of the modules doesn't need to be transpiled.
I found this answer after searching for a long time on the web and therefore thought it should be added to the documentation of the project. 


## Test plan

There are no changes in the code. In can be tested as follows:

1. Setup a vue project with vue-cli: `vue create project`
2. Select Vue2.x, typescript, jest and babel
3. Add the vue-class-component package via `npm install --save vue vue-class-component`
4. Adapt the `HelloWorld.vue` component:
5. 
```
<script lang="ts">
import Vue from "vue";
import Component from "../../node_modules/vue-class-component/lib";

@Component
export default class HelloWorld extends Vue {
  name = "HelloWorld"
};
</script>
```

5. Run the test via `npm run test:unit` and verify the error message.
6. To fix this issue adapt the `jest.config.js` as following:
```
module.exports = {
  preset: "@vue/cli-plugin-unit-jest/presets/typescript-and-babel",
  transformIgnorePatterns: ["node_modules/(?!(vue-class-component))"]
};
```
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information

