### PR TITLE
build(deps): bump @types/jest to v27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,42 +26,42 @@
         "@jest/transform": "^27.0.0",
         "@jest/types": "^27.0.0",
         "@types/babel__core": "7.x",
-        "@types/cross-spawn": "*",
-        "@types/fs-extra": "*",
-        "@types/jest": "*",
-        "@types/js-yaml": "*",
+        "@types/cross-spawn": "latest",
+        "@types/fs-extra": "latest",
+        "@types/jest": "latest",
+        "@types/js-yaml": "latest",
         "@types/lodash": "4.x",
         "@types/micromatch": "4.x",
         "@types/node": "16.4.13",
         "@types/node-fetch": "^2.5.8",
         "@types/react": "17.x",
-        "@types/semver": "*",
-        "@types/yargs": "*",
+        "@types/semver": "latest",
+        "@types/yargs": "latest",
         "@types/yargs-parser": "20.x",
         "@typescript-eslint/eslint-plugin": "4.x",
         "@typescript-eslint/parser": "4.x",
         "conventional-changelog-cli": "2.x",
-        "cross-spawn": "*",
+        "cross-spawn": "latest",
         "eslint": "7.x",
-        "eslint-config-prettier": "*",
+        "eslint-config-prettier": "latest",
         "eslint-plugin-import": "latest",
-        "eslint-plugin-jest": "*",
-        "eslint-plugin-jsdoc": "*",
-        "eslint-plugin-prefer-arrow": "*",
-        "eslint-plugin-prettier": "*",
-        "execa": "*",
+        "eslint-plugin-jest": "latest",
+        "eslint-plugin-jsdoc": "latest",
+        "eslint-plugin-prefer-arrow": "latest",
+        "eslint-plugin-prettier": "latest",
+        "execa": "latest",
         "fs-extra": "10.x",
         "glob": "^7.1.7",
-        "glob-gitignore": "*",
+        "glob-gitignore": "latest",
         "husky": "4.x",
         "jest": "^27.0.0",
-        "js-yaml": "*",
+        "js-yaml": "latest",
         "json-schema-to-typescript": "^10.1.4",
-        "lint-staged": "*",
+        "lint-staged": "latest",
         "node-fetch": "^2.6.1",
-        "npm-run-all": "*",
+        "npm-run-all": "latest",
         "prettier": "2.3.2",
-        "source-map": "*",
+        "source-map": "latest",
         "typescript": "~4.2.4"
       },
       "engines": {
@@ -69,7 +69,7 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@types/jest": "^26.0.0",
+        "@types/jest": "^27.0.0",
         "babel-jest": ">=27.0.0 <28",
         "jest": "^27.0.0",
         "typescript": ">=3.8 <5.0"
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.0.tgz",
+      "integrity": "sha512-IlpQZVpxufe+3qPaAqEoSPHVSxnJh1cf0BqqWHJeKiAUbwnHdmNzjP3ZCWSZSTbmAGXQPNk9QmM3Bif0pR54rg==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^26.0.0",
@@ -2782,14 +2782,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.0.tgz",
-      "integrity": "sha512-+92YRNHFdXgq+GhWQPT2bmjX09X7EH36JfgN2/4wmhtwV/HPxozpCNst8jrWcngLtEVd/4zAwA6BKojAlf+YqA==",
+      "version": "4.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
+      "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.29.0",
-        "@typescript-eslint/types": "4.29.0",
-        "@typescript-eslint/typescript-estree": "4.29.0",
+        "@typescript-eslint/scope-manager": "4.29.1",
+        "@typescript-eslint/types": "4.29.1",
+        "@typescript-eslint/typescript-estree": "4.29.1",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2880,51 +2880,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-      "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -14470,9 +14425,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.0.tgz",
+      "integrity": "sha512-IlpQZVpxufe+3qPaAqEoSPHVSxnJh1cf0BqqWHJeKiAUbwnHdmNzjP3ZCWSZSTbmAGXQPNk9QmM3Bif0pR54rg==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
@@ -14765,47 +14720,47 @@
         "@typescript-eslint/types": "4.29.1",
         "@typescript-eslint/typescript-estree": "4.29.1",
         "debug": "^4.3.1"
-      }
-    },
-    "@typescript-eslint/scope-manager": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-      "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-      "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-      "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-      "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz",
+          "integrity": "sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.0",
+            "@typescript-eslint/visitor-keys": "4.29.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.29.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.0.tgz",
+          "integrity": "sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.0.tgz",
+          "integrity": "sha512-8ZpNHDIOyqzzgZrQW9+xQ4k5hM62Xy2R4RPO3DQxMc5Rq5QkCdSpk/drka+DL9w6sXNzV5nrdlBmf8+x495QXQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.0",
+            "@typescript-eslint/visitor-keys": "4.29.0",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.29.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.0.tgz",
+          "integrity": "sha512-LoaofO1C/jAJYs0uEpYMXfHboGXzOJeV118X4OsZu9f7rG7Pr9B3+4HTU8+err81rADa4xfQmAxnRnPAI2jp+Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {

--- a/package.json
+++ b/package.json
@@ -66,11 +66,11 @@
     "yargs-parser": "20.x"
   },
   "peerDependencies": {
-    "jest": "^27.0.0",
-    "typescript": ">=3.8 <5.0",
-    "babel-jest": ">=27.0.0 <28",
     "@babel/core": ">=7.0.0-beta.0 <8",
-    "@types/jest": "^26.0.0"
+    "@types/jest": "^27.0.0",
+    "babel-jest": ">=27.0.0 <28",
+    "jest": "^27.0.0",
+    "typescript": ">=3.8 <5.0"
   },
   "peerDependenciesMeta": {
     "babel-jest": {


### PR DESCRIPTION
## Summary

This library is built to work with Jest 27. However, it uses the types for Jest 26, as types for Jest 27 were not available until recently. This PR updates the peer dependencies for version 27.

## Test plan

Everything still builds happily

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

However, users with old versions of `@types/jest` will see a warning (which has no effect apart from displaying this warning) that they're using a different optional peer dependency version.

## Other information

All I did was change the version of `@types/jest` to 27 and then did an `npm install` - not sure why it wanted to move around the ordering in the package.json :shrug: