### PR TITLE
Update example ESM configs to support ESM-compatible imports that include .js extension

### DIFF
--- a/website/docs/guides/esm-support.md
+++ b/website/docs/guides/esm-support.md
@@ -23,6 +23,9 @@ module.exports = {
       useESM: true,
     },
   },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 }
 ```
 
@@ -36,6 +39,9 @@ module.exports = {
       "ts-jest": {
         "useESM": true
       }
+    },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
     }
   }
 }
@@ -53,6 +59,9 @@ module.exports = {
       useESM: true,
     },
   },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 }
 ```
 
@@ -66,6 +75,9 @@ module.exports = {
       "ts-jest": {
         "useESM": true
       }
+    },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
     }
   }
 }

--- a/website/versioned_docs/version-27.0/guides/esm-support.md
+++ b/website/versioned_docs/version-27.0/guides/esm-support.md
@@ -23,6 +23,9 @@ module.exports = {
       useESM: true,
     },
   },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 }
 ```
 
@@ -36,6 +39,9 @@ module.exports = {
       "ts-jest": {
         "useESM": true
       }
+    },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
     }
   }
 }
@@ -53,6 +59,9 @@ module.exports = {
       useESM: true,
     },
   },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 }
 ```
 
@@ -66,6 +75,9 @@ module.exports = {
       "ts-jest": {
         "useESM": true
       }
+    },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
     }
   }
 }


### PR DESCRIPTION
## Summary

this PR adds the necessary code to the ESM docs config examples to enable `"type": "module"` typescript packages to use `ts-jest` for testing. reference: https://github.com/kulshekhar/ts-jest/issues/1709#issuecomment-869567343

## Test plan

it’s a docs change, no test plan i can think of

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
