### PR TITLE
Update compiler name

### DIFF
--- a/website/versioned_docs/version-27.0/getting-started/options/compiler.md
+++ b/website/versioned_docs/version-27.0/getting-started/options/compiler.md
@@ -17,7 +17,7 @@ module.exports = {
   // [...]
   globals: {
     'ts-jest': {
-      compiler: 'ttypescript',
+      compiler: 'typescript',
     },
   },
 }
@@ -30,7 +30,7 @@ module.exports = {
   "jest": {
     "globals": {
       "ts-jest": {
-        "compiler": "ttypescript"
+        "compiler": "typescript"
       }
     }
   }

--- a/website/versioned_docs/version-27.0/getting-started/options/compiler.md
+++ b/website/versioned_docs/version-27.0/getting-started/options/compiler.md
@@ -7,7 +7,7 @@ The `compiler` option allows you to define the compiler to be used. It'll be use
 The default value is `typescript`, which will load the original [TypeScript compiler module](https://www.npmjs.com/package/typescript).
 The loaded version will depend on the one installed in your project.
 
-If you use a custom compiler, such as `ttypescript`, make sure its API is the same as the original TypeScript, at least for what `ts-jest` is using.
+If you use a custom compiler, such as `typescript`, make sure its API is the same as the original TypeScript, at least for what `ts-jest` is using.
 
 ### Example
 


### PR DESCRIPTION
## Summary

### Update documentation
Use `typescript` instead of `ttypescript`.
- It will allow the end-user to copy and paste the options easily.
- It will avoid confusion for people who has not too much experience with the JS/TS ecosystem.



## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information

