### PR TITLE
feat: allow extending `processAsync` and `getCacheKeyAsync`

### DIFF
--- a/e2e/__tests__/enum.test.ts
+++ b/e2e/__tests__/enum.test.ts
@@ -3,13 +3,13 @@ import { extractSortedSummary } from '../utils'
 
 const DIR = 'enum'
 
-test('partial successfully runs the tests inside `enum/` with `isolatedModules: true`', () => {
+test('partial successfully runs the tests inside `enum/` with `isolatedModules: false`', () => {
   const result = runJest(DIR)
 
   expect(extractSortedSummary(result.stderr).rest).toMatchSnapshot()
 })
 
-test('partial successfully runs the tests inside `enum/` with `isolatedModules: false`', () => {
+test('partial successfully runs the tests inside `enum/` with `isolatedModules: true`', () => {
   const result = runJest(DIR, ['-c=jest-isolated.config.js'])
 
   expect(extractSortedSummary(result.stderr).rest).toMatchSnapshot()

--- a/e2e/__tests__/extend-ts-jest.test.ts
+++ b/e2e/__tests__/extend-ts-jest.test.ts
@@ -1,0 +1,15 @@
+import { json as runWithJson, onNodeVersions } from '../run-jest'
+
+const DIR = 'extend-ts-jest'
+
+// Only need to test in ESM because ESM makes `this` context become `undefined`
+onNodeVersions('>=12.16.0', () => {
+  test(`successfully runs the tests inside ${DIR}`, () => {
+    const { json } = runWithJson(DIR, undefined, {
+      nodeOptions: '--experimental-vm-modules --no-warnings',
+    })
+
+    expect(json.success).toBe(true)
+    expect(json.numTotalTestSuites).toBe(1)
+  })
+})

--- a/e2e/extend-ts-jest/__tests__/foo.spec.ts
+++ b/e2e/extend-ts-jest/__tests__/foo.spec.ts
@@ -1,0 +1,3 @@
+test('should pass', () => {
+  expect(true).toBe(true)
+})

--- a/e2e/extend-ts-jest/foo-transformer.js
+++ b/e2e/extend-ts-jest/foo-transformer.js
@@ -1,0 +1,10 @@
+const tsJestTransformer = require('../../dist/ts-jest-transformer')
+
+class FooTransformer extends tsJestTransformer.TsJestTransformer {
+  async processAsync(sourceText, sourcePath, transformOptions) {
+    return new Promise((resolve) => resolve(this.process(sourceText, sourcePath, transformOptions)))
+  }
+}
+module.exports = {
+  createTransformer: () => new FooTransformer(),
+}

--- a/e2e/extend-ts-jest/package.json
+++ b/e2e/extend-ts-jest/package.json
@@ -1,0 +1,12 @@
+{
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "isolatedModules": true
+      }
+    },
+    "transform": {
+      "^.+\\.tsx?$": "./foo-transformer.js"
+    }
+  }
+}

--- a/src/ts-jest-transformer.ts
+++ b/src/ts-jest-transformer.ts
@@ -53,7 +53,9 @@ export class TsJestTransformer implements SyncTransformer {
      * when running Jest in ESM mode
      */
     this.getCacheKey = this.getCacheKey.bind(this)
+    this.getCacheKeyAsync = this.getCacheKeyAsync.bind(this)
     this.process = this.process.bind(this)
+    this.processAsync = this.processAsync.bind(this)
 
     this._logger.debug('created new transformer')
     process.env.TS_JEST = '1'
@@ -183,6 +185,14 @@ export class TsJestTransformer implements SyncTransformer {
     return result
   }
 
+  async processAsync(
+    sourceText: string,
+    sourcePath: Config.Path,
+    transformOptions: TransformOptionsTsJest,
+  ): Promise<TransformedSource | string> {
+    return new Promise((resolve) => resolve(this.process(sourceText, sourcePath, transformOptions)))
+  }
+
   /**
    * Jest uses this to cache the compiled version of a file
    *
@@ -246,6 +256,14 @@ export class TsJestTransformer implements SyncTransformer {
     }
 
     return sha1(...constructingCacheKeyElements)
+  }
+
+  async getCacheKeyAsync(
+    sourceText: string,
+    sourcePath: string,
+    transformOptions: TransformOptionsTsJest,
+  ): Promise<string> {
+    return new Promise((resolve) => resolve(this.getCacheKey(sourceText, sourcePath, transformOptions)))
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Allow subclasses to extend `processAsync` and `getCacheKeyAsync` methods

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added e2e test, unit test can't test this

Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
