### PR TITLE
Fix: transform using received file content

### DIFF
--- a/src/compiler/ts-compiler.ts
+++ b/src/compiler/ts-compiler.ts
@@ -386,6 +386,8 @@ export class TsCompiler implements TsCompilerInstance {
     if (!hit) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this._fileVersionCache!.set(fileName, 1)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this._fileContentCache!.set(fileName, contents)
       shouldIncrementProjectVersion = true
     } else {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

The ts-jest transform is currently ignoring the file content it receives until there is already a hit in the memory cache. That prevents us from doing things like chaining transforms (see https://github.com/anc95/jest-chain-transform), as ts-jest will just read the original file from disk and ignore the transformation. It should also be affecting people trying to do this: https://github.com/kulshekhar/ts-jest/discussions/2721

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

I'm saying no, as this feature was previously non-functional so no one should be relying on the current behavior, but I guess it could be yes if we're very strict and want to support someone misusing the transform.

## Other information

The changes I'm proposing were enough to resolve the issue for my use case. I haven't done extensive research into it, but it seems pretty straightforward (it's just 2 lines of addition).