### PR TITLE
Adds instructions for how to resolve "Cannot find module `./<module name>.js` from `./<module_name>.spec.ts`"

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,5 +1,19 @@
 # Troubleshooting
 
+## Cannot find module `./<module name>.js` from `./<module_name>.spec.ts`
+
+In order to support resolving import paths with a `.js` extension, which source file comes from a TypeScript module, one can add a custom resolver:
+
+```sh
+npm install --save-dev jest-ts-webcompat-resolver
+```
+
+And add to the `jest.config.js`:
+
+```
+resolver: 'jest-ts-webcompat-resolver'
+```
+
 ## Running ts-jest on CI tools
 
 ### PROBLEM


### PR DESCRIPTION
Adds instructions for how to resolve "Cannot find module `./<module name>.js` from `./<module_name>.spec.ts`".
