### PR TITLE
Update ts-jest import

### DIFF
--- a/website/versioned_docs/version-27.1/getting-started/paths-mapping.md
+++ b/website/versioned_docs/version-27.1/getting-started/paths-mapping.md
@@ -56,7 +56,7 @@ module.exports = {
 
 ```js
 // jest.config.js
-const { pathsToModuleNameMapper } = require('ts-jest')
+const { pathsToModuleNameMapper } = require('ts-jest/utils')
 // In the following statement, replace `./tsconfig` with the path to your `tsconfig` file
 // which contains the path mapping (ie the `compilerOptions.paths` option):
 const { compilerOptions } = require('./tsconfig')


### PR DESCRIPTION
## Summary

Docs update only. Updates the `ts-jest` import to `ts-jest/utils` as per the following warning produced by `ts-jest`:

> ts-jest[root] (WARN) The `pathsToModuleNameMapper` helper has been moved to `ts-jest/utils`. Use `import { pathsToModuleNameMapper } from 'ts-jest/utils'` instead.

## Test plan

n/a

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

n/a