### PR TITLE
fix: remove `esbuild` from peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@babel/core": ">=7.0.0-beta.0 <8",
     "@types/jest": "^27.0.0",
     "babel-jest": ">=27.0.0 <28",
-    "esbuild": "~0.14.0",
     "jest": "^27.0.0",
     "typescript": ">=3.8 <5.0"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Closes #3346 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
- Pack `ts-jest` with `npm pack`
- Install the `tgz` file together with `esbuild@0.12.28` to a project using Yarn 2+
- Check if the warning no longer appears like reported in #3346 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**