### PR TITLE
fix: vars starting with 'mock' in hoisted context

### DIFF
--- a/e2e/ast-transformers/hoist-jest/__tests__/typescript.test.ts
+++ b/e2e/ast-transformers/hoist-jest/__tests__/typescript.test.ts
@@ -1,3 +1,4 @@
+import { Chocolate } from '../chocolate'
 import { color } from '../entry'
 
 jest.mock('some-module', () => ({} as Partial<Record<string, unknown>>), { virtual: true })
@@ -6,8 +7,17 @@ jest.mock('../entry', () => {
   return { color: 'blue' }
 })
 
+const mockEat = jest.fn().mockReturnValue('sweet')
+jest.mock('../chocolate', () => ({
+  eat: mockEat,
+}))
+
 describe('hoisting', () => {
   test('works even with type imports', () => {
     expect(color).toBe('blue')
+  })
+  test('permits access to variables starting with "mock"', () => {
+    const chocolate = new Chocolate()
+    expect(chocolate.eat()).toBe('sweet')
   })
 })

--- a/e2e/ast-transformers/hoist-jest/chocolate.ts
+++ b/e2e/ast-transformers/hoist-jest/chocolate.ts
@@ -1,0 +1,5 @@
+export class Chocolate {
+  public eat() {
+    return 'yummy'
+  }
+}


### PR DESCRIPTION
## Summary

This PR attempts to address #3292, where variable whose name starts with `mock` cannot be used in a hoisted mock context. 

In plain jest and jest+babel, one can reference a variable that is not yet initialised when creating a mock which jest will hoist by starting the name with `mock`, e.g. `mockMyFoo`. Presently this throws a `ReferenceError` when using ts-jest.

## Test plan

So far I've added an e2e test that demonstrates this bug. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
