### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,14 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   cleanup-runs:
+    permissions:
+      actions: write # for rokroskar/workflow-run-cleanup-action to obtain workflow name & cancel it
+      contents: read # for rokroskar/workflow-run-cleanup-action to obtain branch
     runs-on: ubuntu-latest
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
@@ -52,6 +58,9 @@ jobs:
         run: npm run lint-prettier-ci
 
   test:
+    permissions:
+      checks: write # for coverallsapp/github-action to create new checks
+      contents: read # for actions/checkout to fetch code
     name: Node v${{ matrix.node-version }} on ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -93,6 +102,8 @@ jobs:
         run: npm run test-examples
 
   finish:
+    permissions:
+      checks: write # for coverallsapp/github-action to create new checks
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/doc-generator.yml
+++ b/.github/workflows/doc-generator.yml
@@ -12,6 +12,9 @@ concurrency:
   group: doc-generator-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     if: github.event_name != 'push'
@@ -29,6 +32,8 @@ jobs:
           npm run build
 
   build-and-deploy:
+    permissions:
+      contents: write # for JamesIves/github-pages-deploy-action to push changes in repo
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -14,10 +14,15 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in
 # parallel
+permissions:
+  contents: read
+
 jobs:
   # For more information on setting outputs and reading them have a look at
   # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs
   setup_variables:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     outputs:
       isLatest: ${{ steps.release_type.outputs.latest }}
@@ -30,6 +35,8 @@ jobs:
         env:
           LATEST: ${{ contains(github.ref, '-next') != true && contains(github.ref, '-rc') != true }}
   create_release:
+    permissions:
+      contents: write # for actions/create-release to create a release
     needs: [setup_variables]
     # The type of runner that the job will run on
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
