### PR TITLE
Use Array.sort in hoist-jest

### DIFF
--- a/src/transformers/hoist-jest.ts
+++ b/src/transformers/hoist-jest.ts
@@ -87,21 +87,12 @@ export function factory({ configSet }: TsCompilerInstance) {
       return statements
     }
 
-    const pivot = statements[0]
-    const leftPart: _ts.Statement[] = []
-    const rightPart: _ts.Statement[] = []
-    for (let i = 1; i < statements.length; i++) {
-      const currentStatement = statements[i]
-      if (isJestGlobalImport(currentStatement)) {
-        leftPart.push(currentStatement)
-      } else {
-        isHoistableStatement(currentStatement) && !isHoistableStatement(pivot) && !isJestGlobalImport(pivot)
-          ? leftPart.push(currentStatement)
-          : rightPart.push(currentStatement)
-      }
-    }
-
-    return sortStatements(leftPart).concat(pivot, sortStatements(rightPart))
+    return statements.sort((stmtA, stmtB) =>
+      isJestGlobalImport(stmtA) ||
+      (isHoistableStatement(stmtA) && !isHoistableStatement(stmtB) && !isJestGlobalImport(stmtB))
+        ? -1
+        : 1,
+    )
   }
 
   const createVisitor = (ctx: _ts.TransformationContext, _: _ts.SourceFile) => {


### PR DESCRIPTION
## Summary

When hoist-jest encounters a file with a large enough number of statements to sort, it can error with `Maximum call stack size exceeded`

## Test plan

Use existing hoist-jest tests + tested change against our project.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information

Closes: #3476