### PR TITLE
fix: remove `@types/jest` from peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,16 +62,12 @@
   },
   "peerDependencies": {
     "@babel/core": ">=7.0.0-beta.0 <8",
-    "@types/jest": "^27.0.0",
     "babel-jest": "^28.0.0",
     "jest": "^28.0.0",
     "typescript": ">=4.3"
   },
   "peerDependenciesMeta": {
     "@babel/core": {
-      "optional": true
-    },
-    "@types/jest": {
       "optional": true
     },
     "babel-jest": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,68 @@
 {
   "extends": [
-    "config:base"
+    ":dependencyDashboard",
+    "group:babelMonorepo",
+    "group:commitlintMonorepo",
+    "group:docusaurusMonorepo",
+    ":prHourlyLimit2",
+    "workarounds:all"
+  ],
+  "timezone": "UTC",
+  "rangeStrategy": "bump",
+  "separateMajorMinor": true,
+  "prConcurrentLimit": 2,
+  "semanticCommits": "enabled",
+  "commitMessagePrefix": "build(deps):",
+  "ignorePaths": ["examples/react-app"],
+  "ignoreDeps": [
+    "@mdx-js/react",
+    "@types/react",
+    "execa",
+    "chalk",
+    "husky"
+  ],
+  "packageRules": [
+    {
+      "matchPaths": ["examples/**"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchPaths": ["examples/react-app"],
+      "enabled": false
+    },
+    {
+      "matchPaths": ["package.json"],
+      "matchPackagePatterns": ["jest"],
+      "excludePackageNames": ["eslint-plugin-jest"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "Jest packages"
+    },
+    {
+      "extends": ["packages:eslint"],
+      "groupName": "ESLint packages"
+    },
+    {
+      "matchPackagePrefixes": ["esbuild"],
+      "groupName": "Esbuild packages"
+    },
+    {
+      "matchFiles": ["package.json"],
+      "matchDepTypes": ["dependencies", "optionalDependencies"],
+      "rangeStrategy": "in-range-only"
+    },
+    {
+      "matchPaths": ["e2e/**"],
+      "matchPackageNames": [
+        "react",
+        "react-intl"
+      ],
+      "groupName": "React e2e packages",
+      "enabled": true
+    },
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Since we already removed `mocked`, `@types/jest` is no longer required as peer dep

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**