### PR TITLE
Set @jest/types as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "peerDependencies": {
     "@babel/core": ">=7.0.0-beta.0 <8",
+    "@jest/types": "^28.0.0",
     "babel-jest": "^28.0.0",
     "jest": "^28.0.0",
     "typescript": ">=4.3"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

As `@jest/types` is imported in `src/types.ts` and it is present in documentation saying it is required to be installed. It should be listed in the package.json as peerDependencies
## Test plan

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
