### PR TITLE
Add `renovate.json` to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -57,6 +57,7 @@ node_modules
 icon.png
 .idea
 .husky
+renovate.json
 
 # ensure we do not omit the digest
 !.ts-jest-digest


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Add `renovate.json` to the `.npmignore` file with the goal of excluding it from releases of ts-jest to npm.

## Test plan

No code changes were made.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information

I was comparing [the diff between 28.0.3 and 28.0.5](https://app.renovatebot.com/package-diff?name=ts-jest&from=28.0.3&to=28.0.5) and noticed this file was added. As it's not needed I figured I can add it to the `.npmignore` file so it's not included in future releases.