### PR TITLE
fix(docs): update the link for the ts-jest options

### DIFF
--- a/website/versioned_docs/version-28.0/getting-started/options.md
+++ b/website/versioned_docs/version-28.0/getting-started/options.md
@@ -92,11 +92,11 @@ All options have default values which should fit most of the projects. Click on 
 | [**`stringifyContentPathRegex`**][stringifycontentpathregex] | [Files which will become modules returning self content.][stringifycontentpathregex] | `string`\|`RegExp`            | _disabled_     |
 | [**`useESM`**][useesm]                                       | [Enable ESM support][useesm]                                                         | `boolean`                     | _auto_         |
 
-[compiler]: options/compiler
-[tsconfig]: options/tsconfig
-[isolatedmodules]: options/isolatedModules
-[asttransformers]: options/astTransformers
-[diagnostics]: options/diagnostics
-[babelconfig]: options/babelConfig
-[stringifycontentpathregex]: options/stringifyContentPathRegex
-[useesm]: options/useESM
+[compiler]: compiler
+[tsconfig]: tsconfig
+[isolatedmodules]: isolatedModules
+[asttransformers]: astTransformers
+[diagnostics]: diagnostics
+[babelconfig]: babelConfig
+[stringifycontentpathregex]: stringifyContentPathRegex
+[useesm]: useESM


### PR DESCRIPTION
It looks like it has an extra `options/` in the URL.

## Summary

When checking for the configuration for ts-jest there is an extra `options/` in the URL.

## Test plan

Open browser to [https://kulshekhar.github.io/ts-jest/docs/getting-started/options/](https://kulshekhar.github.io/ts-jest/docs/getting-started/options/) and check the links works.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
