### PR TITLE
fix(legacy): include existing globals config in cached config

### DIFF
--- a/src/legacy/ts-jest-transformer.ts
+++ b/src/legacy/ts-jest-transformer.ts
@@ -109,17 +109,17 @@ export class TsJestTransformer implements SyncTransformer {
         if (config.globals?.['ts-jest']) {
           this._logger.warn(Deprecations.GlobalsTsJestConfigOption)
         }
-        configSet = this._createConfigSet(
-          this.tsJestConfig
-            ? {
-                ...config,
-                globals: {
-                  'ts-jest': this.tsJestConfig,
-                },
-              }
-            : config,
-        )
-        const jest = { ...config }
+        const migratedConfig = this.tsJestConfig
+          ? {
+              ...config,
+              globals: {
+                ...(config.globals ?? Object.create(null)),
+                'ts-jest': this.tsJestConfig,
+              },
+            }
+          : config
+        configSet = this._createConfigSet(migratedConfig)
+        const jest = { ...migratedConfig }
         // we need to remove some stuff from jest config
         // this which does not depend on config
         jest.cacheDirectory = undefined as any // eslint-disable-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When creating `ConfigSet` with migrated Jest config (to migrate from `globals` to transformer config), it is a must to also copy other globals config.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**