### PR TITLE
docs: fix `JestConfigWithTsJest` type import in examples

### DIFF
--- a/website/docs/getting-started/options.md
+++ b/website/docs/getting-started/options.md
@@ -24,7 +24,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/getting-started/options/astTransformers.md
+++ b/website/docs/getting-started/options/astTransformers.md
@@ -34,7 +34,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -96,7 +96,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/getting-started/options/babelConfig.md
+++ b/website/docs/getting-started/options/babelConfig.md
@@ -30,7 +30,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -84,7 +84,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -135,7 +135,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 import babelConfig from './babelrc.test.js'
 
 const jestConfig: JestConfigWithTsJest = {
@@ -176,7 +176,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/getting-started/options/compiler.md
+++ b/website/docs/getting-started/options/compiler.md
@@ -27,7 +27,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/getting-started/options/diagnostics.md
+++ b/website/docs/getting-started/options/diagnostics.md
@@ -47,7 +47,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -104,7 +104,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -164,7 +164,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -228,7 +228,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/getting-started/options/stringifyContentPathRegex.md
+++ b/website/docs/getting-started/options/stringifyContentPathRegex.md
@@ -34,7 +34,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 import tsJestPresets from 'ts-jest/presets'
 
 const jestConfig: JestConfigWithTsJest = {

--- a/website/docs/getting-started/options/tsconfig.md
+++ b/website/docs/getting-started/options/tsconfig.md
@@ -30,7 +30,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -86,7 +86,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -143,7 +143,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/getting-started/options/useESM.md
+++ b/website/docs/getting-started/options/useESM.md
@@ -24,7 +24,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/getting-started/paths-mapping.md
+++ b/website/docs/getting-started/paths-mapping.md
@@ -40,7 +40,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -85,7 +85,7 @@ import { pathsToModuleNameMapper } from 'ts-jest'
 // In the following statement, replace `./tsconfig` with the path to your `tsconfig` file
 // which contains the path mapping (ie the `compilerOptions.paths` option):
 import { compilerOptions } from './tsconfig'
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/getting-started/presets.md
+++ b/website/docs/getting-started/presets.md
@@ -44,7 +44,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -94,7 +94,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 import { defaults as tsjPreset } from 'ts-jest/presets'
 // import { defaultsESM as tsjPreset } from 'ts-jest/presets';

--- a/website/docs/guides/esm-support.md
+++ b/website/docs/guides/esm-support.md
@@ -38,7 +38,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -107,7 +107,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/docs/guides/react-native.md
+++ b/website/docs/guides/react-native.md
@@ -19,7 +19,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   presets: ['module:metro-react-native-babel-preset'],
@@ -67,7 +67,7 @@ module.exports = {
 
 ```ts tab
 import { defaults as tsjPreset } from 'ts-jest/presets'
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   preset: 'react-native',

--- a/website/versioned_docs/version-29.0/getting-started/options.md
+++ b/website/versioned_docs/version-29.0/getting-started/options.md
@@ -24,7 +24,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/getting-started/options/astTransformers.md
+++ b/website/versioned_docs/version-29.0/getting-started/options/astTransformers.md
@@ -34,7 +34,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -96,7 +96,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/getting-started/options/babelConfig.md
+++ b/website/versioned_docs/version-29.0/getting-started/options/babelConfig.md
@@ -30,7 +30,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -84,7 +84,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -135,7 +135,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 import babelConfig from './babelrc.test.js'
 
 const jestConfig: JestConfigWithTsJest = {
@@ -176,7 +176,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/getting-started/options/compiler.md
+++ b/website/versioned_docs/version-29.0/getting-started/options/compiler.md
@@ -27,7 +27,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/getting-started/options/diagnostics.md
+++ b/website/versioned_docs/version-29.0/getting-started/options/diagnostics.md
@@ -47,7 +47,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -104,7 +104,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -164,7 +164,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -228,7 +228,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/getting-started/options/stringifyContentPathRegex.md
+++ b/website/versioned_docs/version-29.0/getting-started/options/stringifyContentPathRegex.md
@@ -34,7 +34,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 import tsJestPresets from 'ts-jest/presets'
 
 const jestConfig: JestConfigWithTsJest = {

--- a/website/versioned_docs/version-29.0/getting-started/options/tsconfig.md
+++ b/website/versioned_docs/version-29.0/getting-started/options/tsconfig.md
@@ -30,7 +30,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -86,7 +86,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -143,7 +143,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/getting-started/options/useESM.md
+++ b/website/versioned_docs/version-29.0/getting-started/options/useESM.md
@@ -24,7 +24,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/getting-started/paths-mapping.md
+++ b/website/versioned_docs/version-29.0/getting-started/paths-mapping.md
@@ -40,7 +40,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -85,7 +85,7 @@ import { pathsToModuleNameMapper } from 'ts-jest'
 // In the following statement, replace `./tsconfig` with the path to your `tsconfig` file
 // which contains the path mapping (ie the `compilerOptions.paths` option):
 import { compilerOptions } from './tsconfig'
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/getting-started/presets.md
+++ b/website/versioned_docs/version-29.0/getting-started/presets.md
@@ -44,7 +44,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -94,7 +94,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 import { defaults as tsjPreset } from 'ts-jest/presets'
 // import { defaultsESM as tsjPreset } from 'ts-jest/presets';

--- a/website/versioned_docs/version-29.0/guides/esm-support.md
+++ b/website/versioned_docs/version-29.0/guides/esm-support.md
@@ -38,7 +38,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
@@ -107,7 +107,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]

--- a/website/versioned_docs/version-29.0/guides/react-native.md
+++ b/website/versioned_docs/version-29.0/guides/react-native.md
@@ -19,7 +19,7 @@ module.exports = {
 ```
 
 ```ts tab
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   presets: ['module:metro-react-native-babel-preset'],
@@ -67,7 +67,7 @@ module.exports = {
 
 ```ts tab
 import { defaults as tsjPreset } from 'ts-jest/presets'
-import type { JestConfigWithTsJest } from './types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   preset: 'react-native',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

`JestConfigWithTsJest` type imports do not look correct in current docs. At least they don’t work if copy-pasted.

## Test plan

Deploy preview.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

