### PR TITLE
build: do not remove comments

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,6 @@
     "module": "CommonJS",
     "target": "ES5",
     "declaration": true,
-    "removeComments": true,
     "stripInternal": true,
     "outDir": "dist"
   },


### PR DESCRIPTION
## Summary

Currently the library is build with `"removeComments": true` set and most probably there is a reason for that.

Just wanted to draw your attention that that together with other comments `@deprecated` tags are getting removed as well. The JSDoc comments are also missing in the build file. Aren’t these supposed to reach the users?

## Test plan

Checked output files in the `dist` directory locally.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
