### PR TITLE
fix: 'ts-jest' should be optional in ConfigGlobals

### DIFF
--- a/e2e/config-typing/jest.config.ts
+++ b/e2e/config-typing/jest.config.ts
@@ -9,6 +9,9 @@ const jestCfg: JestConfigWithTsJest = {
       },
     ],
   },
+  globals: {
+    aaa: true,
+  },
 }
 
 export default jestCfg

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ declare module '@jest/types' {
        */
       // eslint-disable-next-line
       // @ts-ignore
-      'ts-jest': TsJestGlobalOptions
+      'ts-jest'?: TsJestGlobalOptions
     }
   }
 }
@@ -184,7 +184,7 @@ export interface TransformOptionsTsJest extends TransformOptions {
  * @deprecated use `JestConfigWithTsJest` instead
  */
 export interface GlobalConfigTsJest extends Config.ConfigGlobals {
-  'ts-jest': TsJestGlobalOptions
+  'ts-jest'?: TsJestGlobalOptions
 }
 /**
  * @deprecated use `JestConfigWithTsJest` instead
@@ -193,16 +193,13 @@ export interface InitialOptionsTsJest extends Config.InitialOptions {
   globals?: GlobalConfigTsJest
 }
 type TsJestTransformerOptions = TsJestGlobalOptions
-export interface JestConfigWithTsJest extends Partial<Omit<Config.ProjectConfig, 'transform'>> {
-  transform: {
+export interface JestConfigWithTsJest extends Omit<Config.InitialOptions, 'transform'> {
+  transform?: {
     [regex: string]: 'ts-jest' | ['ts-jest', TsJestTransformerOptions] | string | [string, Record<string, unknown>]
   }
 }
 
 export type StringMap = Map<string, string>
-/**
- * @internal
- */
 export interface DepGraphInfo {
   fileContent: string
   resolvedModuleNames: string[]


### PR DESCRIPTION
## Summary

This PR attempts to solve the globals type issue mentioned [here](https://github.com/kulshekhar/ts-jest/issues/3815), that 'ts-jest' should be optional in globals.

## Test plan

I've run `test` and it was passed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
