### PR TITLE
docs(paths-mapping): Fixed broken guide for paths mapping helper

### DIFF
--- a/website/docs/getting-started/paths-mapping.md
+++ b/website/docs/getting-started/paths-mapping.md
@@ -76,6 +76,8 @@ const { compilerOptions } = require('./tsconfig')
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   // [...]
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
 }
 ```
@@ -89,6 +91,8 @@ import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
 }
 

--- a/website/versioned_docs/version-26.5/getting-started/paths-mapping.md
+++ b/website/versioned_docs/version-26.5/getting-started/paths-mapping.md
@@ -63,6 +63,8 @@ const { compilerOptions } = require('./tsconfig')
 
 module.exports = {
   // [...]
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
 }
 ```

--- a/website/versioned_docs/version-27.0/getting-started/paths-mapping.md
+++ b/website/versioned_docs/version-27.0/getting-started/paths-mapping.md
@@ -63,6 +63,8 @@ const { compilerOptions } = require('./tsconfig')
 
 module.exports = {
   // [...]
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
 }
 ```

--- a/website/versioned_docs/version-27.1/getting-started/paths-mapping.md
+++ b/website/versioned_docs/version-27.1/getting-started/paths-mapping.md
@@ -63,6 +63,8 @@ const { compilerOptions } = require('./tsconfig')
 
 module.exports = {
   // [...]
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
 }
 ```

--- a/website/versioned_docs/version-28.0/getting-started/paths-mapping.md
+++ b/website/versioned_docs/version-28.0/getting-started/paths-mapping.md
@@ -63,6 +63,8 @@ const { compilerOptions } = require('./tsconfig')
 
 module.exports = {
   // [...]
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
 }
 ```

--- a/website/versioned_docs/version-29.0/getting-started/paths-mapping.md
+++ b/website/versioned_docs/version-29.0/getting-started/paths-mapping.md
@@ -76,6 +76,8 @@ const { compilerOptions } = require('./tsconfig')
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   // [...]
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
 }
 ```
@@ -89,6 +91,8 @@ import type { JestConfigWithTsJest } from 'ts-jest'
 
 const jestConfig: JestConfigWithTsJest = {
   // [...]
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
 }
 


### PR DESCRIPTION
## Summary

Hi! I'm a newcomer to ts-jest, had a problem setting up test environment for my project using this library.

TypeScript Alias using tsconfig.json didn't work in test files. 

I was wondering for around 30 minutes and found the answer from the [Issue's comment](https://github.com/kulshekhar/ts-jest/issues/364) - which was at the bottom of the page. It seemed really hard to find the information.

This PR provides "helper" part of "Paths Mapping" documentation page the missing code.

As this [Issue's comment](https://github.com/kulshekhar/ts-jest/issues/364#issuecomment-900349786) states, the documentation should state as follows to make jest config work with aliases from tsconfig:

```js
module.exports = {
  // [...]
  roots: ['<rootDir>'],
  modulePaths: [compilerOptions.baseUrl], // <-- This will be set to './src'
  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
}
```

FYI, the documentation was as follows(as you can see from commit):

```js
  // [...]
  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths /*, { prefix: '<rootDir>/' } */),
}
```

## Test plan

Not needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

None.