### PR TITLE
test: add TypeScript module specs to examples

### DIFF
--- a/examples/js-with-babel/jest-esm-isolated.config.js
+++ b/examples/js-with-babel/jest-esm-isolated.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel-esm',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         babelConfig: true,

--- a/examples/js-with-babel/jest-esm.config.js
+++ b/examples/js-with-babel/jest-esm.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel-esm',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         babelConfig: true,

--- a/examples/js-with-babel/jest-isolated.config.js
+++ b/examples/js-with-babel/jest-isolated.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         babelConfig: true,

--- a/examples/js-with-babel/jest.config.js
+++ b/examples/js-with-babel/jest.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         babelConfig: true,

--- a/examples/js-with-babel/mjs-resolver.ts
+++ b/examples/js-with-babel/mjs-resolver.ts
@@ -1,0 +1,35 @@
+void `
+type ModuleResolverOptions = {
+  readonly conditions: unknown
+  defaultResolver(path: string, options: Readonly<ModuleResolverOptions>): ModuleResolver
+  rootDir: unknown
+
+  /** @see {@link https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/resolve/index.d.ts}, interface Opts */
+  readonly baseDir: string
+  extensions: string | readonly string[] | undefined
+  moduleDirectory: string | undefined
+  paths: string | readonly string[] | undefined
+}
+
+type ModuleResolver = (
+  path: string,
+  options: Readonly<ModuleResolverOptions>,
+) => ModuleResolverOptions['defaultResolver']
+`
+
+const mjsResolver /*: ModuleResolver */ = function (path, options) {
+  const mjsExtRegex = /\.mjs$/i
+
+  const resolver = options.defaultResolver
+  if (mjsExtRegex.test(path)) {
+    try {
+      return resolver(path.replace(mjsExtRegex, '.mts'), options)
+    } catch {
+      // use default resolver
+    }
+  }
+
+  return resolver(path, options)
+}
+
+module.exports = mjsResolver

--- a/examples/js-with-babel/src/welcome-message-module.spec.mts
+++ b/examples/js-with-babel/src/welcome-message-module.spec.mts
@@ -1,0 +1,11 @@
+import { getWelcomeMessage } from './welcome-message'
+import welcomePerson from './welcome-person'
+
+test('module: should show welcome message', () => {
+  expect(getWelcomeMessage()).toMatchInlineSnapshot(`"Welcome to ts-jest!!!"`)
+})
+
+test('module: should show welcome person message', () => {
+  // @ts-expect-error in ESM mode, `default` is kept after compilation
+  expect(welcomePerson.default ? welcomePerson.default : welcomePerson).toMatchInlineSnapshot(`"Welcome to ts-jest!!!"`)
+})

--- a/examples/js-with-ts/jest-esm-isolated.config.js
+++ b/examples/js-with-ts/jest-esm-isolated.config.js
@@ -1,7 +1,26 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts-esm',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
+    // m? for modules
     '^.+\\.m?[tj]sx?$': [
       'ts-jest',
       {

--- a/examples/js-with-ts/jest-esm.config.js
+++ b/examples/js-with-ts/jest-esm.config.js
@@ -1,7 +1,26 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts-esm',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
+    // m? for modules
     '^.+\\.m?[tj]sx?$': [
       'ts-jest',
       {

--- a/examples/js-with-ts/jest-isolated.config.js
+++ b/examples/js-with-ts/jest-isolated.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.[tj]sx?$': [
+    // m? for modules
+    '^.+\\.m?[tj]sx?$': [
       'ts-jest',
       {
         isolatedModules: true,

--- a/examples/js-with-ts/jest.config.js
+++ b/examples/js-with-ts/jest.config.js
@@ -1,4 +1,25 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+
+  transform: {
+    '^.+\\.mtsx?$': ['ts-jest'],
+  },
+  // #endregion support for .mts files as an extension
 }

--- a/examples/js-with-ts/mjs-resolver.ts
+++ b/examples/js-with-ts/mjs-resolver.ts
@@ -1,0 +1,35 @@
+void `
+type ModuleResolverOptions = {
+  readonly conditions: unknown
+  defaultResolver(path: string, options: Readonly<ModuleResolverOptions>): ModuleResolver
+  rootDir: unknown
+
+  /** @see {@link https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/resolve/index.d.ts}, interface Opts */
+  readonly baseDir: string
+  extensions: string | readonly string[] | undefined
+  moduleDirectory: string | undefined
+  paths: string | readonly string[] | undefined
+}
+
+type ModuleResolver = (
+  path: string,
+  options: Readonly<ModuleResolverOptions>,
+) => ModuleResolverOptions['defaultResolver']
+`
+
+const mjsResolver /*: ModuleResolver */ = function (path, options) {
+  const mjsExtRegex = /\.mjs$/i
+
+  const resolver = options.defaultResolver
+  if (mjsExtRegex.test(path)) {
+    try {
+      return resolver(path.replace(mjsExtRegex, '.mts'), options)
+    } catch {
+      // use default resolver
+    }
+  }
+
+  return resolver(path, options)
+}
+
+module.exports = mjsResolver

--- a/examples/js-with-ts/src/welcome-message-module.spec.mts
+++ b/examples/js-with-ts/src/welcome-message-module.spec.mts
@@ -1,0 +1,11 @@
+import { getWelcomeMessage } from './welcome-message'
+import welcomePerson from './welcome-person'
+
+test('module: should show welcome message', () => {
+  expect(getWelcomeMessage()).toMatchInlineSnapshot(`"Welcome to ts-jest!!!"`)
+})
+
+test('module: should show welcome person message', () => {
+  // @ts-expect-error in ESM mode, `default` is kept after compilation
+  expect(welcomePerson.default ? welcomePerson.default : welcomePerson).toMatchInlineSnapshot(`"Welcome to ts-jest!!!"`)
+})

--- a/examples/ts-only/jest-esm-isolated.config.js
+++ b/examples/ts-only/jest-esm-isolated.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/default-esm',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         isolatedModules: true,

--- a/examples/ts-only/jest-esm.config.js
+++ b/examples/ts-only/jest-esm.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/default-esm',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         tsconfig: 'tsconfig-esm.json',

--- a/examples/ts-only/jest-isolated.config.js
+++ b/examples/ts-only/jest-isolated.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         isolatedModules: true,

--- a/examples/ts-only/jest.config.js
+++ b/examples/ts-only/jest.config.js
@@ -1,4 +1,25 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+
+  transform: {
+    '^.+\\.mtsx?$': ['ts-jest'],
+  },
+  // #endregion support for .mts files as an extension
 }

--- a/examples/ts-only/mjs-resolver.ts
+++ b/examples/ts-only/mjs-resolver.ts
@@ -1,0 +1,35 @@
+void `
+type ModuleResolverOptions = {
+  readonly conditions: unknown
+  defaultResolver(path: string, options: Readonly<ModuleResolverOptions>): ModuleResolver
+  rootDir: unknown
+
+  /** @see {@link https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/resolve/index.d.ts}, interface Opts */
+  readonly baseDir: string
+  extensions: string | readonly string[] | undefined
+  moduleDirectory: string | undefined
+  paths: string | readonly string[] | undefined
+}
+
+type ModuleResolver = (
+  path: string,
+  options: Readonly<ModuleResolverOptions>,
+) => ModuleResolverOptions['defaultResolver']
+`
+
+const mjsResolver /*: ModuleResolver */ = function (path, options) {
+  const mjsExtRegex = /\.mjs$/i
+
+  const resolver = options.defaultResolver
+  if (mjsExtRegex.test(path)) {
+    try {
+      return resolver(path.replace(mjsExtRegex, '.mts'), options)
+    } catch {
+      // use default resolver
+    }
+  }
+
+  return resolver(path, options)
+}
+
+module.exports = mjsResolver

--- a/examples/ts-only/src/welcome-message-module.spec.mts
+++ b/examples/ts-only/src/welcome-message-module.spec.mts
@@ -1,0 +1,5 @@
+import { getWelcomeMessage } from './welcome-message'
+
+test('module: should show welcome message', () => {
+  expect(getWelcomeMessage()).toMatchInlineSnapshot(`"Welcome to ts-jest!!!"`)
+})

--- a/examples/type-module/jest-esm-isolated.config.js
+++ b/examples/type-module/jest-esm-isolated.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const jestConfig = {
   preset: 'ts-jest/presets/default-esm',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         isolatedModules: true,

--- a/examples/type-module/jest-esm.config.js
+++ b/examples/type-module/jest-esm.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const jestConfig = {
   preset: 'ts-jest/presets/default-esm',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         tsconfig: 'tsconfig.json',

--- a/examples/type-module/jest-isolated.config.js
+++ b/examples/type-module/jest-isolated.config.js
@@ -1,8 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const jestConfig = {
   preset: 'ts-jest',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+  // #endregion support for .mts files as an extension
+
   transform: {
-    '^.+\\.tsx?$': [
+    // m? for modules
+    '^.+\\.m?tsx?$': [
       'ts-jest',
       {
         isolatedModules: true,

--- a/examples/type-module/jest.config.js
+++ b/examples/type-module/jest.config.js
@@ -1,6 +1,27 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const jestConfig = {
   preset: 'ts-jest',
+
+  // #region support for .mts files as an extension
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+  moduleFileExtensions: ['js', 'ts', 'mts'],
+
+  resolver: '<rootDir>/mjs-resolver.ts',
+  testMatch: ['**/__tests__/**/*.(m)?[jt]s?(x)', '**/?(*.)+(spec|test).(m)?[tj]s?(x)'],
+
+  transform: {
+    '^.+\\.mtsx?$': ['ts-jest'],
+  },
+  // #endregion support for .mts files as an extension
 }
 
 export default jestConfig

--- a/examples/type-module/mjs-resolver.ts
+++ b/examples/type-module/mjs-resolver.ts
@@ -1,0 +1,35 @@
+void `
+type ModuleResolverOptions = {
+  readonly conditions: unknown
+  defaultResolver(path: string, options: Readonly<ModuleResolverOptions>): ModuleResolver
+  rootDir: unknown
+
+  /** @see {@link https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/resolve/index.d.ts}, interface Opts */
+  readonly baseDir: string
+  extensions: string | readonly string[] | undefined
+  moduleDirectory: string | undefined
+  paths: string | readonly string[] | undefined
+}
+
+type ModuleResolver = (
+  path: string,
+  options: Readonly<ModuleResolverOptions>,
+) => ModuleResolverOptions['defaultResolver']
+`
+
+const mjsResolver /*: ModuleResolver */ = function (path, options) {
+  const mjsExtRegex = /\.mjs$/i
+
+  const resolver = options.defaultResolver
+  if (mjsExtRegex.test(path)) {
+    try {
+      return resolver(path.replace(mjsExtRegex, '.mts'), options)
+    } catch {
+      // use default resolver
+    }
+  }
+
+  return resolver(path, options)
+}
+
+module.exports = mjsResolver

--- a/examples/type-module/src/welcome-message-module.spec.mts
+++ b/examples/type-module/src/welcome-message-module.spec.mts
@@ -1,0 +1,5 @@
+import { getWelcomeMessage } from './welcome-message'
+
+test('module: should show welcome message', () => {
+  expect(getWelcomeMessage()).toMatchInlineSnapshot(`"Welcome to ts-jest!!!"`)
+})


### PR DESCRIPTION
This is to show existing support for TypeScript modules.

## Summary

Per https://github.com/kulshekhar/ts-jest/discussions/3954, I'm adding example specs [with the `.mts` extension](https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions).

This is based on [ts-jest's documentation](https://kulshekhar.github.io/ts-jest/docs/guides/esm-support/#support-mts-extension) and [existing code](https://github.com/kulshekhar/ts-jest/blob/main/e2e/native-esm-ts/mjs-resolver.ts).

## Test plan

`npm run test-examples`

I manually inspected to confirm each of the configuration files this PR touches runs two different spec files: the existing one and the new TypeScript module file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Questions on this patch for reviewers, because I'm unfamiliar with this code base:

1. Should the transform value always be `['ts-jest', ...]`?  The type definition says it could be `TransformerConfig`, which is just `[string, ...]`.  I am specifically asking because it differs from the `preset` field in most of these changes.
1. There's a big Caution about [mixing `preset` and `transform`](https://kulshekhar.github.io/ts-jest/docs/getting-started/options) in the documentation.  I see some of these examples already do this, but I'm making it happen here across all of them.  What's the right way to handle this?
1. Help wanted with the react-app example.  I tried to update it, but I'm almost as new to React as I am to this project.  It was too complex for me to quickly figure out.  So I left it alone...
1. I figured out most of the `mjsResolver`'s type.  When I tried to include it in the TypeScript file, jest-resolve gave me many errors.  I tried adding a .d.ts file (which led to linting errors), and renaming it to .mts.  Finally, I just put it in as a void string expression, which is a Dirty Hack.  I'd like a better fix, so that we can do proper type checking on the resolver.  As code documentation, though, it's better than nothing.
