### PR TITLE
fix(transformer): don't use cache when tsJestConfig is different

### DIFF
--- a/src/legacy/ts-jest-transformer.spec.ts
+++ b/src/legacy/ts-jest-transformer.spec.ts
@@ -80,6 +80,16 @@ describe('TsJestTransformer', () => {
       expect(cs2).toBe(cs1)
     })
 
+    test('should return different config set for different tsJestConfig', () => {
+      const obj2 = { ...obj1, config: { ...obj1.config } }
+      // @ts-expect-error testing purpose
+      const cs1 = new TsJestTransformer({ isolatedModules: true })._configsFor(obj1)
+      // @ts-expect-error testing purpose
+      const cs2 = new TsJestTransformer({ isolatedModules: false })._configsFor(obj2)
+
+      expect(cs2).not.toBe(cs1)
+    })
+
     test(`should not read disk cache with isolatedModules true`, () => {
       const tr = new TsJestTransformer()
       const cs = createConfigSet({

--- a/src/legacy/ts-jest-transformer.ts
+++ b/src/legacy/ts-jest-transformer.ts
@@ -86,8 +86,25 @@ export class TsJestTransformer implements SyncTransformer {
       this._watchMode = ccs.watchMode
       configSet = ccs.configSet
     } else {
+      if (config.globals?.['ts-jest']) {
+        this._logger.warn(Deprecations.GlobalsTsJestConfigOption)
+      }
+      const jestGlobalsConfig = config.globals ?? {}
+      const tsJestGlobalsConfig = jestGlobalsConfig['ts-jest'] ?? {}
+      const migratedConfig = this.tsJestConfig
+        ? {
+            ...config,
+            globals: {
+              ...jestGlobalsConfig,
+              'ts-jest': {
+                ...tsJestGlobalsConfig,
+                ...this.tsJestConfig,
+              },
+            },
+          }
+        : config
       // try to look-it up by stringified version
-      const serializedJestCfg = stringify(config)
+      const serializedJestCfg = stringify(migratedConfig)
       const serializedCcs = TsJestTransformer._cachedConfigSets.find(
         (cs) => cs.jestConfig.serialized === serializedJestCfg,
       )
@@ -105,24 +122,6 @@ export class TsJestTransformer implements SyncTransformer {
       } else {
         // create the new record in the index
         this._logger.info('no matching config-set found, creating a new one')
-
-        if (config.globals?.['ts-jest']) {
-          this._logger.warn(Deprecations.GlobalsTsJestConfigOption)
-        }
-        const jestGlobalsConfig = config.globals ?? {}
-        const tsJestGlobalsConfig = jestGlobalsConfig['ts-jest'] ?? {}
-        const migratedConfig = this.tsJestConfig
-          ? {
-              ...config,
-              globals: {
-                ...jestGlobalsConfig,
-                'ts-jest': {
-                  ...tsJestGlobalsConfig,
-                  ...this.tsJestConfig,
-                },
-              },
-            }
-          : config
         configSet = this._createConfigSet(migratedConfig)
         const jest = { ...migratedConfig }
         // we need to remove some stuff from jest config


### PR DESCRIPTION
## Summary

When creating two instances of `TsJestTransformer` with different ts-jest configurations, they will generate the same config set if provided with the same options.

```js
const tr1 = new TsJestTransformer({ isolatedModules: true });
const tr2 = new TsJestTransformer({ isolatedModules: false });

// @ts-expect-error testing purpose
const cs1 = tr1._configsFor({ config: { cwd: process.cwd() }, cacheFS: new Map() } as TransformOptionsTsJest);
// @ts-expect-error testing purpose
const cs2 = tr2._configsFor({ config: { cwd: process.cwd() }, cacheFS: new Map() } as TransformOptionsTsJest);

console.log(cs1 === cs2); // true
```

This PR aims to fix this by taking into account the provided `tsJestConfig` when generating the cache key.

## Test plan

Tested on a project using `ts-jest`. Checked with `npm run test-examples`

## Does this PR introduce a breaking change?

- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information

This fix is needed to remove a workaround on my Jest 29 migration PR of `jest-preset-angular` https://github.com/thymikee/jest-preset-angular/pull/1901 
