### PR TITLE
fix(transformer): allow transforming of .cts/.mts extensions. (#3996)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,8 @@
 export const LINE_FEED = '\n'
 export const DECLARATION_TYPE_EXT = '.d.ts'
 export const JS_JSX_EXTENSIONS = ['.js', '.jsx']
-export const TS_TSX_REGEX = /\.m?tsx?$/
-export const JS_JSX_REGEX = /\.m?jsx?$/
+export const TS_TSX_REGEX = /\.[cm]?tsx?$/
+export const JS_JSX_REGEX = /\.[cm]?jsx?$/
 // `extensionsToTreatAsEsm` will throw error with `.mjs`
 export const TS_EXT_TO_TREAT_AS_ESM = ['.ts', '.tsx', '.mts']
 export const JS_EXT_TO_TREAT_AS_ESM = ['.jsx']

--- a/src/legacy/ts-jest-transformer.spec.ts
+++ b/src/legacy/ts-jest-transformer.spec.ts
@@ -330,7 +330,7 @@ describe('TsJestTransformer', () => {
       expect(process.env.TS_JEST).toBe('1')
     })
 
-    test.each(['foo.ts', 'foo.tsx', 'foo.mts', 'foo.mtsx'])('should process ts/tsx file', (filePath) => {
+    test.each(['foo.ts', 'foo.tsx', 'foo.cts', 'foo.mts', 'foo.mtsx'])('should process ts/tsx file', (filePath) => {
       const fileContent = 'const foo = 1'
       const output = 'var foo = 1'
       tr.getCacheKey(fileContent, filePath, baseTransformOptions)
@@ -345,7 +345,7 @@ describe('TsJestTransformer', () => {
       })
     })
 
-    test.each(['foo.js', 'foo.jsx', 'foo.mjs', 'foo.mjsx'])(
+    test.each(['foo.js', 'foo.jsx', 'foo.cjs', 'foo.mjs', 'foo.mjsx'])(
       'should process js/jsx file with allowJs true',
       (filePath) => {
         const fileContent = 'const foo = 1'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

This is a pull request to implement the feature request:
[Support loading of ".cjs" and ".cts" files. #3996](https://github.com/kulshekhar/ts-jest/issues/3996)
Closes #3996 

## Test plan

I added 2 test cases to `src/legacy/ts-jest-transformer.spec.ts` to test loading of '.cts' and '.cjs' files.

`npm run test` reports:
```
Test Suites: 35 passed, 35 total
Tests:       329 passed, 329 total
Snapshots:   135 passed, 135 total
```

`npm run test-examples` also exited successfully.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This fix will allow us to remove our hack we've been using in order to transform `.cts` files and load `.cjs` files.
