### PR TITLE
test: unit test fixes for jest 29.5

### DIFF
--- a/e2e/__tests__/__snapshots__/enum.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/enum.test.ts.snap
@@ -19,7 +19,7 @@ exports[`partial successfully runs the tests inside enum with 'isolatedModules: 
       3 | const getTwo = (): string => FooEnum.two
       4 |
 
-      at Resolver._throwModNotFoundError (../../node_modules/jest-resolve/build/resolver.js:487:11)
+      at Resolver._throwModNotFoundError (../../node_modules/jest-resolve/build/resolver.js:427:11)
       at Object.<anonymous> (__tests__/import-from-d-ts-no-js.spec.ts:1:1)
 
 PASS __tests__/import-from-d-ts-has-js.spec.ts
@@ -45,7 +45,7 @@ exports[`partial successfully runs the tests inside enum with 'isolatedModules: 
       3 | const getTwo = (): string => FooEnum.two
       4 |
 
-      at Resolver._throwModNotFoundError (../../node_modules/jest-resolve/build/resolver.js:487:11)
+      at Resolver._throwModNotFoundError (../../node_modules/jest-resolve/build/resolver.js:427:11)
       at Object.<anonymous> (__tests__/import-from-d-ts-no-js.spec.ts:1:1)
 
 PASS __tests__/import-from-d-ts-has-js.spec.ts

--- a/examples/react-app/jest-esm-isolated.config.js
+++ b/examples/react-app/jest-esm-isolated.config.js
@@ -6,7 +6,7 @@ module.exports = {
   ...baseEsmCfg,
   transform: {
     ...baseCfg.transform,
-    '^.+\\.tsx?$': [
+    '^.+\\.(ts|tsx)$': [
       'ts-jest',
       {
         babelConfig: {

--- a/examples/react-app/jest-esm.config.js
+++ b/examples/react-app/jest-esm.config.js
@@ -6,7 +6,7 @@ module.exports = {
   preset: 'ts-jest/presets/js-with-babel-esm',
   transform: {
     ...baseCfg.transform,
-    '^.+\\.tsx?$': [
+    '^.+\\.(ts|tsx)$': [
       'ts-jest',
       {
         babelConfig: {

--- a/examples/react-app/jest-isolated.config.js
+++ b/examples/react-app/jest-isolated.config.js
@@ -5,7 +5,7 @@ module.exports = {
   ...baseCfg,
   transform: {
     ...baseCfg.transform,
-    '^.+\\.tsx?$': [
+    '^.+\\.(ts|tsx)$': [
       'ts-jest',
       {
         babelConfig: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2850,9 +2850,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001387",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001387.tgz",
-      "integrity": "sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA==",
+      "version": "1.0.30001466",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001466.tgz",
+      "integrity": "sha512-ewtFBSfWjEmxUgNBSZItFSmVtvk9zkwkl1OfRZlKA8slltRN+/C/tuGVrF9styXkN36Yu3+SeJ1qkXxDEyNZ5w==",
       "devOptional": true,
       "funding": [
         {
@@ -11310,9 +11310,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001387",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001387.tgz",
-      "integrity": "sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA==",
+      "version": "1.0.30001466",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001466.tgz",
+      "integrity": "sha512-ewtFBSfWjEmxUgNBSZItFSmVtvk9zkwkl1OfRZlKA8slltRN+/C/tuGVrF9styXkN36Yu3+SeJ1qkXxDEyNZ5w==",
       "devOptional": true
     },
     "chalk": {

--- a/src/legacy/compiler/ts-jest-compiler.spec.ts
+++ b/src/legacy/compiler/ts-jest-compiler.spec.ts
@@ -4,8 +4,10 @@ import { TsCompiler } from './ts-compiler'
 import { TsJestCompiler } from './ts-jest-compiler'
 
 describe('TsJestCompiler', () => {
-  jest.spyOn(TsCompiler.prototype, 'getResolvedModules').mockReset()
-  jest.spyOn(TsCompiler.prototype, 'getCompiledOutput').mockReset()
+  jest.spyOn(TsCompiler.prototype, 'getResolvedModules').mockImplementation(() => [])
+  jest.spyOn(TsCompiler.prototype, 'getCompiledOutput').mockImplementation(() => ({
+    code: '',
+  }))
   const runtimeCacheFS = new Map<string, string>()
   const fileContent = 'const foo = 1'
   const fileName = 'foo.ts'


### PR DESCRIPTION
This adds some minor changes that will allow the jest 29.5 updates in #3979 to pass unit tests:
  * Use mockImplementation instead of mockReset on Jest spy mock. The [jest implementation has changed](https://github.com/facebook/jest/pull/13692), and mockReset no longer sets an empty mock function on spy mocks.
  * Update the snapshots for the e2e enum tests. A line number in the stack traces has changed.
  * Update the caniuse-lite version. browserlist was writing a 'Browserslist: caniuse-lite is outdated...' message to stderr, which caused parsing of jest output to fail in the e2e transform-js test.
  * Fix the configuration of jest transforms in the examples tests. These configurations previously specified two regex configurations that matched .ts and .tsx files (`^.+\\.(ts|tsx)$` and `^.+\\.tsx?$`). Only the second one specified the necessary options to ts-jest for ESM and isolated configurations. This only worked because jest stored options per-transform-script and not per-regex. That changed [in a recent fix](https://github.com/facebook/jest/pull/13770), which broke these tests.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
