### PR TITLE
test: fix up types in importer.spec.

### DIFF
--- a/src/utils/importer.spec.ts
+++ b/src/utils/importer.spec.ts
@@ -9,13 +9,12 @@ const moduleNotFound = (mod: string) => {
   throw err
 }
 const fakeFullPath = (mod: string) => `/root/${mod}.js`
-const requireModule = jest.fn((mod) => (mod in modules ? modules[mod]() : moduleNotFound(mod)))
-const resolveModule = jest.fn((mod) => (mod in modules ? fakeFullPath(mod) : moduleNotFound(mod)))
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-__requireModule(requireModule as any, resolveModule)
+const requireModule = jest.fn((mod: string) => (mod in modules ? modules[mod]() : moduleNotFound(mod)))
+const resolveModule = jest.fn((mod: string) => (mod in modules ? fakeFullPath(mod) : moduleNotFound(mod)))
+__requireModule(requireModule, resolveModule)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let modules!: { [key: string]: () => any }
+let modules: { [key: string]: () => any }
 beforeEach(() => {
   modules = {}
   requireModule.mockClear()
@@ -90,8 +89,8 @@ describe('tryTheseOr', () => {
 })
 
 describe('patcher', () => {
-  const patch1 = jest.fn((mod) => ({ ...mod, p1: true }))
-  const patch2 = jest.fn((mod) => ({ ...mod, p2: true }))
+  const patch1 = jest.fn((mod: object) => ({ ...mod, p1: true }))
+  const patch2 = jest.fn((mod: object) => ({ ...mod, p2: true }))
 
   it('should apply patches correctly', () => {
     const imp = new Importer({ foo: [patch1, patch2] })


### PR DESCRIPTION
## Summary
The importer test used untyped parameters in the mocks for `requireModule` and `resolveModule`. TypeScript 4.9 complains about this since those parameters are used to test for key membership in an object (`mod in modules`), and type `unknown` can't be used as an index.

It does a similar thing for patchers. Since the argument there is used with a spread operator, TypeScript 4.9 complains if it isn't an object.

Also removed a `!` non-null assertion for the `modules` variable and a cast to `any` for `requireModule`, since they aren't necessary.

This should fix the test failures in #4011 (update typescript to 4.9.5).

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
