### PR TITLE
fix: `default-esm` preset

### DIFF
--- a/presets/index.js
+++ b/presets/index.js
@@ -9,7 +9,7 @@ module.exports = {
     return createJestPreset(true, false)
   },
   get defaultsESM() {
-    return createJestPreset(false, false, { extensionsToTreatAsEsm: TS_EXT_TO_TREAT_AS_ESM })
+    return createJestPreset(false, false, { extensionsToTreatAsEsm: TS_EXT_TO_TREAT_AS_ESM, moduleNameMapper: {'^(\\.{1,2}/.*)\\.js$': '$1'} })
   },
   get defaultsESMLegacy() {
     return createJestPreset(true, false, { extensionsToTreatAsEsm: TS_EXT_TO_TREAT_AS_ESM })

--- a/src/presets/create-jest-preset.ts
+++ b/src/presets/create-jest-preset.ts
@@ -12,12 +12,13 @@ export function createJestPreset(
 ): TsJestPresets {
   logger.debug({ allowJs }, 'creating jest presets', allowJs ? 'handling' : 'not handling', 'JavaScript files')
 
-  const { extensionsToTreatAsEsm, moduleFileExtensions, testMatch } = extraOptions
+  const { extensionsToTreatAsEsm, moduleFileExtensions, testMatch, moduleNameMapper } = extraOptions
   const supportESM = extensionsToTreatAsEsm?.length
   const tsJestTransformOptions: TsJestTransformerOptions = supportESM ? { useESM: true } : {}
 
   return {
     ...(extensionsToTreatAsEsm ? { extensionsToTreatAsEsm } : undefined),
+    ...(moduleNameMapper ? { moduleNameMapper } : undefined),
     ...(moduleFileExtensions ? { moduleFileExtensions } : undefined),
     ...(testMatch ? { testMatch } : undefined),
     transform: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary
Updates the `default-esm` preset to include `moduleNameMapper` as shown in [manual configuration](https://kulshekhar.github.io/ts-jest/docs/guides/esm-support/#manual-configuration).

Without the `moduleNameMapper` config, `import` may fail depending on the location of the referenced file. The provided preset should work OOTB and not require additional configuration.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

No testing at this point. I'd want to make sure this is something that is wanted before I spent time testing.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [] Yes
- [x] No -- It shouldn't from what I can tell, but it's hard to say with certainty since I'm not fully up on the underlying code base.

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
