### PR TITLE
docs: add note for Babel config

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -61,7 +61,7 @@ There is a good chance that the error message shows which module is affected:
 
 In this case **some-module** is the problem and needs to be transformed.
 By adding the following line to the configuration file it will tell Jest which modules
-shouldnt be ignored during the transformation step:
+shouldn't be ignored during the transformation step:
 
 ```javascript
 module.exports = {
@@ -71,5 +71,7 @@ module.exports = {
 ```
 
 **some-module** and **another-module** will be transformed.
+
+Note that if you are using Babel with a `.babelrc` config file, you will need to rename it to `babel.config.json` in order to compile any part of `node_modules`, as described in the [Babel docs](https://babeljs.io/docs/configuration#whats-your-use-case).
 
 For more information see [here](https://stackoverflow.com/questions/63389757/jest-unit-test-syntaxerror-cannot-use-import-statement-outside-a-module) and [here](https://stackoverflow.com/questions/52035066/how-to-write-jest-transformignorepatterns).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Update the troubleshooting docs page to include a note that Babel configured with `.babelrc` will not work when trying to compile any part of `node_modules`, even when `transformIgnorePatterns` is updated. Instead, the Babel config must be renamed to `babel.config.js`. (See Babel docs: https://babeljs.io/docs/configuration#whats-your-use-case)

This is not well documented elsewhere, so this could be helpful for folks debugging the fairly common "Cannot use import statement outside a module" error.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

(n/a, docs update)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information

Since this is pretty minor, I just created the PR here, but am happy to open an issue/discussion if preferred! Thank you
