### PR TITLE
docs: fix links for options subpages

### DIFF
--- a/website/versioned_docs/version-29.0/getting-started/options.md
+++ b/website/versioned_docs/version-29.0/getting-started/options.md
@@ -89,11 +89,11 @@ All options have default values which should fit most of the projects. Click on 
 | [**`stringifyContentPathRegex`**][stringifycontentpathregex] | [Files which will become modules returning self content.][stringifycontentpathregex] | `string`\|`RegExp`            | _disabled_     |
 | [**`useESM`**][useesm]                                       | [Enable ESM support][useesm]                                                         | `boolean`                     | _auto_         |
 
-[compiler]: options/compiler
-[tsconfig]: options/tsconfig
-[isolatedmodules]: options/isolatedModules
-[asttransformers]: options/astTransformers
-[diagnostics]: options/diagnostics
-[babelconfig]: options/babelConfig
-[stringifycontentpathregex]: options/stringifyContentPathRegex
-[useesm]: options/useESM
+[compiler]: compiler
+[tsconfig]: tsconfig
+[isolatedmodules]: isolatedModules
+[asttransformers]: astTransformers
+[diagnostics]: diagnostics
+[babelconfig]: babelConfig
+[stringifycontentpathregex]: stringifyContentPathRegex
+[useesm]: useESM


### PR DESCRIPTION
Current: `https://kulshekhar.github.io/ts-jest/docs/getting-started/options/options/compiler` 

New: `https://kulshekhar.github.io/ts-jest/docs/getting-started/options/compiler`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Hyperlinks for options subpages in the table have an extra `options/` in the path.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
