### PR TITLE
fix: calculated cache key based on supportsStaticESM

### DIFF
--- a/src/legacy/ts-jest-transformer.spec.ts
+++ b/src/legacy/ts-jest-transformer.spec.ts
@@ -191,6 +191,10 @@ describe('TsJestTransformer', () => {
         }),
         tr.getCacheKey(input.fileContent, input.fileName, {
           ...input.transformOptions,
+          supportsStaticESM: true,
+        }),
+        tr.getCacheKey(input.fileContent, input.fileName, {
+          ...input.transformOptions,
           config: { ...input.transformOptions.config, rootDir: '/bar' },
         }),
       ]
@@ -227,6 +231,27 @@ describe('TsJestTransformer', () => {
           ...input.transformOptions.config,
           globals: { 'ts-jest': { isolatedModules: true } },
         },
+      })
+
+      jest.spyOn(TsJestCompiler.prototype, 'getResolvedModules').mockReturnValueOnce([])
+      const tr1 = new TsJestTransformer()
+      const cacheKey2 = tr1.getCacheKey(input.fileContent, input.fileName, transformOptionsWithCache)
+
+      expect(TsJestCompiler.prototype.getResolvedModules).toHaveBeenCalledTimes(1)
+      expect(TsJestCompiler.prototype.getResolvedModules).toHaveBeenCalledWith(
+        input.fileContent,
+        input.fileName,
+        new Map(),
+      )
+      expect(cacheKey1).not.toEqual(cacheKey2)
+    })
+
+    test('should be different between supportsStaticESM true and supportsStaticESM false', () => {
+      jest.spyOn(TsJestCompiler.prototype, 'getResolvedModules').mockReturnValueOnce([])
+
+      const cacheKey1 = tr.getCacheKey(input.fileContent, input.fileName, {
+        ...transformOptionsWithCache,
+        supportsStaticESM: true,
       })
 
       jest.spyOn(TsJestCompiler.prototype, 'getResolvedModules').mockReturnValueOnce([])

--- a/src/legacy/ts-jest-transformer.ts
+++ b/src/legacy/ts-jest-transformer.ts
@@ -308,13 +308,15 @@ export class TsJestTransformer implements SyncTransformer {
     this._logger.debug({ fileName: filePath, transformOptions }, 'computing cache key for', filePath)
 
     // we do not instrument, ensure it is false all the time
-    const { instrument = false } = transformOptions
+    const { supportsStaticESM, instrument = false } = transformOptions
     const constructingCacheKeyElements = [
       this._transformCfgStr,
       CACHE_KEY_EL_SEPARATOR,
       configs.rootDir,
       CACHE_KEY_EL_SEPARATOR,
       `instrument:${instrument ? 'on' : 'off'}`,
+      CACHE_KEY_EL_SEPARATOR,
+      `supportsStaticESM:${supportsStaticESM ? 'on' : 'off'}`,
       CACHE_KEY_EL_SEPARATOR,
       fileContent,
       CACHE_KEY_EL_SEPARATOR,


### PR DESCRIPTION
## Summary

`ts-jest` will generate different transformations if `supportsStaticESM` is true or false. I've noticed the issue when using jest with an esm globalSetup file in my application AND my tests were re-using imported files from the globalSetup.

`globalSetup` file seems is transpiled with `supportsStaticESM` unset here https://github.com/jestjs/jest/blob/4e56991693da7cd4c3730dc3579a1dd1403ee630/packages/jest-transform/src/ScriptTransformer.ts#L781

While tests had `supportsStaticESM` true in my case, and therefore, generating two different outputs.

## Test plan


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
