### PR TITLE
fix: add `@jest/transform` as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "peerDependencies": {
     "@babel/core": ">=7.0.0-beta.0 <8",
+    "@jest/transform": "^29.0.0",
     "@jest/types": "^29.0.0",
     "babel-jest": "^29.0.0",
     "jest": "^29.0.0",
@@ -69,6 +70,9 @@
   },
   "peerDependenciesMeta": {
     "@babel/core": {
+      "optional": true
+    },
+    "@jest/transform": {
       "optional": true
     },
     "@jest/types": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

https://github.com/kulshekhar/ts-jest/blob/edef16ed78fb114fbeb93953660b397cffa9ba18/src/types.ts#L1

The above import means when using TypeScript there is a dependency on `@jest/transform` which is currently not expressed, making Yarn Berry unhappy when using the PnP linker.

From what I understand, specifying this dependency as an optional peer dependency should resolve this.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
