### PR TITLE
Remove deprecated @types/rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "@types/micromatch": "4.0.7",
         "@types/node": "20.13.0",
         "@types/react": "18.x",
-        "@types/rimraf": "^4.0.5",
         "@types/semver": "latest",
         "@types/yargs": "latest",
         "@types/yargs-parser": "21.0.3",
@@ -2905,16 +2904,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/rimraf": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-4.0.5.tgz",
-      "integrity": "sha512-DTCZoIQotB2SUJnYgrEx43cQIUYOlNZz0AZPbKU4PSLYTUdML5Gox0++z4F9kQocxStrCmRNhi4x5x/UlwtKUA==",
-      "deprecated": "This is a stub types definition. rimraf provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "rimraf": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -12145,15 +12134,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "@types/rimraf": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-4.0.5.tgz",
-      "integrity": "sha512-DTCZoIQotB2SUJnYgrEx43cQIUYOlNZz0AZPbKU4PSLYTUdML5Gox0++z4F9kQocxStrCmRNhi4x5x/UlwtKUA==",
-      "dev": true,
-      "requires": {
-        "rimraf": "*"
       }
     },
     "@types/scheduler": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@types/micromatch": "4.0.7",
     "@types/node": "20.13.0",
     "@types/react": "18.x",
-    "@types/rimraf": "^4.0.5",
     "@types/semver": "latest",
     "@types/yargs": "latest",
     "@types/yargs-parser": "21.0.3",


### PR DESCRIPTION
Per the npm install message:

> npm warn deprecated @types/rimraf@4.0.5: This is a stub types definition. rimraf provides its own type definitions, so you do not need this installed.