### PR TITLE
revert: allow `babelConfig` in default/js-with-ts presets

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -196,14 +196,6 @@ export interface JestConfigWithTsJest extends Omit<Config.InitialOptions, 'trans
   }
 }
 
-/**
- * @deprecated use `DefaultPreset`/`JsWithTsPreset`/`JsWithBabelPreset` instead
- */
-export type TsJestPresets = Pick<
-  JestConfigWithTsJest,
-  'extensionsToTreatAsEsm' | 'moduleFileExtensions' | 'transform' | 'testMatch'
->
-
 export type StringMap = Map<string, string>
 export interface DepGraphInfo {
   fileContent: string
@@ -245,7 +237,15 @@ export interface TsJestAstTransformer {
   afterDeclarations: AstTransformerDesc[]
 }
 
-export type DefaultTransformOptions = Omit<TsJestTransformerOptions, 'useESM' | 'babelConfig'>
+/**
+ * @deprecated use other preset types below instead
+ */
+export type TsJestPresets = Pick<
+  JestConfigWithTsJest,
+  'extensionsToTreatAsEsm' | 'moduleFileExtensions' | 'transform' | 'testMatch'
+>
+
+export type DefaultTransformOptions = Omit<TsJestTransformerOptions, 'useESM'>
 export type DefaultPreset = {
   transform: {
     [TS_TRANSFORM_PATTERN]: ['ts-jest', DefaultTransformOptions]
@@ -271,7 +271,7 @@ export type DefaultEsmLegacyPreset = {
   }
 }
 
-export type JsWithTsTransformOptions = Omit<TsJestTransformerOptions, 'useESM' | 'babelConfig'>
+export type JsWithTsTransformOptions = Omit<TsJestTransformerOptions, 'useESM'>
 export type JsWithTsPreset = {
   transform: {
     [TS_JS_TRANSFORM_PATTERN]: ['ts-jest', JsWithTsTransformOptions]


### PR DESCRIPTION
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**