### PR TITLE
build(deps): Update dependency ejs to ^3.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "homepage": "https://kulshekhar.github.io/ts-jest",
   "dependencies": {
     "bs-logger": "0.x",
-    "ejs": "^3.0.0",
+    "ejs": "^3.1.10",
     "fast-json-stable-stringify": "2.x",
     "jest-util": "^29.0.0",
     "json5": "^2.2.3",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Dependency ejs was installing as dependency of ts-jest as vulnerable version 3.1.9 ([CVE-2024-33883](https://nvd.nist.gov/vuln/detail/CVE-2024-33883)). Patched version is 3.1.10

Fixes #4450 

## Test plan

Ran build and tests, which run successfully.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
