### PR TITLE
docs(installation): fix broken options.md internal link

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -43,4 +43,4 @@ However, answer `no` to the Jest question about whether or not to enable TypeScr
 
 For customizing jest, please follow their [official guide online](https://jestjs.io/docs/en/configuration.html).
 
-`ts-jest` specific options can be found [here](options).
+`ts-jest` specific options can be found [here](./options.md).

--- a/website/versioned_docs/version-26.5/getting-started/installation.md
+++ b/website/versioned_docs/version-26.5/getting-started/installation.md
@@ -55,4 +55,4 @@ However, answer `no` to the Jest question about whether or not to enable TypeScr
 
 For customizing jest, please follow their [official guide online](https://jestjs.io/docs/en/configuration.html).
 
-`ts-jest` specific options can be found [here](options).
+`ts-jest` specific options can be found [here](./options.md).

--- a/website/versioned_docs/version-27.0/getting-started/installation.md
+++ b/website/versioned_docs/version-27.0/getting-started/installation.md
@@ -55,4 +55,4 @@ However, answer `no` to the Jest question about whether or not to enable TypeScr
 
 For customizing jest, please follow their [official guide online](https://jestjs.io/docs/en/configuration.html).
 
-`ts-jest` specific options can be found [here](options).
+`ts-jest` specific options can be found [here](./options.md).

--- a/website/versioned_docs/version-27.1/getting-started/installation.md
+++ b/website/versioned_docs/version-27.1/getting-started/installation.md
@@ -55,4 +55,4 @@ However, answer `no` to the Jest question about whether or not to enable TypeScr
 
 For customizing jest, please follow their [official guide online](https://jestjs.io/docs/en/configuration.html).
 
-`ts-jest` specific options can be found [here](options).
+`ts-jest` specific options can be found [here](./options.md).

--- a/website/versioned_docs/version-28.0/getting-started/installation.md
+++ b/website/versioned_docs/version-28.0/getting-started/installation.md
@@ -55,4 +55,4 @@ However, answer `no` to the Jest question about whether or not to enable TypeScr
 
 For customizing jest, please follow their [official guide online](https://jestjs.io/docs/en/configuration.html).
 
-`ts-jest` specific options can be found [here](options).
+`ts-jest` specific options can be found [here](./options.md).

--- a/website/versioned_docs/version-29.0/getting-started/installation.md
+++ b/website/versioned_docs/version-29.0/getting-started/installation.md
@@ -43,4 +43,4 @@ However, answer `no` to the Jest question about whether or not to enable TypeScr
 
 For customizing jest, please follow their [official guide online](https://jestjs.io/docs/en/configuration.html).
 
-`ts-jest` specific options can be found [here](options).
+`ts-jest` specific options can be found [here](./options.md).

--- a/website/versioned_docs/version-29.2/getting-started/installation.md
+++ b/website/versioned_docs/version-29.2/getting-started/installation.md
@@ -43,4 +43,4 @@ However, answer `no` to the Jest question about whether or not to enable TypeScr
 
 For customizing jest, please follow their [official guide online](https://jestjs.io/docs/en/configuration.html).
 
-`ts-jest` specific options can be found [here](options).
+`ts-jest` specific options can be found [here](./options.md).


### PR DESCRIPTION
## Summary

closes #4496

In the installation doc page, the link that goes to ts-jest options is broken and redirects to the "options" folder instead of redirecting to the options.md file.

## Test plan

- Manually checked if the broken link was fixed
- Manually checked if links that goes to options/*.md works in the page options.md
- Ran lint

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
