### PR TITLE
fix: include test files in language server

### DIFF
--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -283,7 +283,7 @@ export class TsCompiler implements TsCompilerInstance {
   private _createLanguageService(): void {
     // Initialize memory cache for typescript compiler
     this._parsedTsConfig.fileNames
-      .filter((fileName) => TS_TSX_REGEX.test(fileName) && !this.configSet.isTestFile(fileName))
+      .filter((fileName) => TS_TSX_REGEX.test(fileName))
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       .forEach((fileName) => this._fileVersionCache!.set(fileName, 0))
     /* istanbul ignore next */

--- a/src/legacy/config/__snapshots__/config-set.spec.ts.snap
+++ b/src/legacy/config/__snapshots__/config-set.spec.ts.snap
@@ -170,11 +170,3 @@ exports[`customTransformers should show warning log when missing version and nam
   "[level:40] The AST transformer {{file}} must have an \`export const name = <your_transformer_name>",
 ]
 `;
-
-exports[`isTestFile should return a boolean value whether the file matches test pattern 1`] = `true`;
-
-exports[`isTestFile should return a boolean value whether the file matches test pattern 2`] = `true`;
-
-exports[`isTestFile should return a boolean value whether the file matches test pattern 3`] = `true`;
-
-exports[`isTestFile should return a boolean value whether the file matches test pattern 4`] = `true`;

--- a/src/legacy/config/config-set.spec.ts
+++ b/src/legacy/config/config-set.spec.ts
@@ -493,37 +493,6 @@ describe('tsJestDigest', () => {
   })
 }) // tsJestDigest
 
-describe('isTestFile', () => {
-  it.each([
-    {
-      jestConfig: {
-        testRegex: [{}],
-        testMatch: [],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    },
-    {
-      jestConfig: {
-        testMatch: [],
-        testRegex: [/.*\.(spec|test)\.[jt]sx?$/],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    },
-    {
-      jestConfig: {
-        testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
-        testRegex: [],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    },
-    {
-      jestConfig: {
-        testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
-        testRegex: ['**/?(*.)+(foo|bar).[tj]s?(x)'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    },
-  ])('should return a boolean value whether the file matches test pattern', (config) => {
-    expect(createConfigSet(config).isTestFile('foo.spec.ts')).toMatchSnapshot()
-  })
-}) // isTestFile
-
 describe('shouldStringifyContent', () => {
   it('should return correct value is defined', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/legacy/config/config-set.ts
+++ b/src/legacy/config/config-set.ts
@@ -160,10 +160,6 @@ export class ConfigSet {
   /**
    * @internal
    */
-  private readonly _matchTestFilePath: (filePath: string) => boolean
-  /**
-   * @internal
-   */
   private _shouldIgnoreDiagnosticsForFile!: (filePath: string) => boolean
   /**
    * @internal
@@ -215,9 +211,6 @@ export class ConfigSet {
     if (!this._matchablePatterns.length) {
       this._matchablePatterns.push(...DEFAULT_JEST_TEST_MATCH)
     }
-    this._matchTestFilePath = globsToMatcher(
-      this._matchablePatterns.filter((pattern: string | RegExp) => typeof pattern === 'string') as string[],
-    )
   }
 
   /**
@@ -577,12 +570,6 @@ export class ConfigSet {
 
     // parse json, merge config extending others, ...
     return ts.parseJsonConfigFileContent(config, ts.sys, basePath, undefined, configFileName)
-  }
-
-  isTestFile(fileName: string): boolean {
-    return this._matchablePatterns.some((pattern) =>
-      typeof pattern === 'string' ? this._matchTestFilePath(fileName) : pattern.test(fileName),
-    )
   }
 
   shouldStringifyContent(filePath: string): boolean {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

- include test files in language server so that `languageService.getProgram().getTypeChecker().getTypeAtLocation(node)` for a node in `.test.ts` file would return correct type object instead of `error` TypeObject

```js
TypeObject {
  flags: 1,
  id: 5,
  intrinsicName: 'error',
  debugIntrinsicName: undefined,
  objectFlags: 52953088
}
```

- remove `isTestFile` function from `ConfigSet` which is no longer used


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
