### PR TITLE
build: Remove `restore-keys` from `.github/actions/setup-workspace/action.yml`

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -20,8 +20,6 @@ runs:
       with:
         path: '**/node_modules'
         key: ${{ inputs.os }}-${{ inputs.node }}-build-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ inputs.os }}-${{ inputs.node }}-build
 
     - name: Setup Node version ⚙️
       uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

All caches restored from `restore-keys` in [`.github/actions/setup-workspace/action.yml`](https://github.com/kulshekhar/ts-jest/blob/12949188017939aa83e9a5dbd4a091211e1816f4/.github/actions/setup-workspace/action.yml#L23-L24) are discarded, so this option is not needed.

`cache-hit` has three possible values: [[1]](https://github.com/actions/cache?tab=readme-ov-file#outputs) [[2]](https://github.com/actions/cache/pull/1514/files) [[3]](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#output-parameters-for-the-cache-action) 
* `'true'` if there's an exact match for `key`.
* `'false'` if some prefix of the key matches an entry in `restore-keys`.
* `''` otherwise.

In the `cache-hit = false` case, `node_modules` is restored from a cache [but then immediately deleted by `npm ci`](https://github.com/kulshekhar/ts-jest/blob/12949188017939aa83e9a5dbd4a091211e1816f4/.github/actions/setup-workspace/action.yml#L32-L35).

> ### npm-ci
> ... 
> * ***If a `node_modules` is already present, it will be automatically removed before `npm ci` begins its install.***
>
> https://docs.npmjs.com/cli/commands/npm-ci

This means any cache restored from `restore-keys` will be discarded, so this option is effectively not used.

Examples: (observe `Cache hit for: ` followed by `Run npm ci` under `Setup workspace ⚙️`)
* https://github.com/kulshekhar/ts-jest/actions/runs/14045192275/job/39324317369
* https://github.com/kulshekhar/ts-jest/actions/runs/14045180075/job/39324281457

## Test plan

* [x] This change does not cause [CI](https://github.com/kulshekhar/ts-jest/blob/main/.github/workflows/ci.yml) to fail ([ci/prepare-npm-cache-ubuntu](https://github.com/kulshekhar/ts-jest/blob/12949188017939aa83e9a5dbd4a091211e1816f4/.github/workflows/ci.yml#L19-L27), [ci/prepare-npm-cache-windows](https://github.com/kulshekhar/ts-jest/blob/12949188017939aa83e9a5dbd4a091211e1816f4/.github/workflows/ci.yml#L29-L37), [ci/test-ubuntu](https://github.com/kulshekhar/ts-jest/blob/12949188017939aa83e9a5dbd4a091211e1816f4/.github/workflows/ci.yml#L39-L51), [ci/test-windows](https://github.com/kulshekhar/ts-jest/blob/12949188017939aa83e9a5dbd4a091211e1816f4/.github/workflows/ci.yml#L53-L65), [ci/lint](https://github.com/kulshekhar/ts-jest/blob/12949188017939aa83e9a5dbd4a091211e1816f4/.github/workflows/ci.yml#L67-L88)).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information

On a new `package-lock.json` we *should* rebuild rather than restore a cache from a previous build. Changing [this line](https://github.com/kulshekhar/ts-jest/blob/12949188017939aa83e9a5dbd4a091211e1816f4/.github/actions/setup-workspace/action.yml#L33) to additionally skip `npm ci` on a `restore-keys` hit would not be appropriate.

----

If the intent was to cache packages *across installs*, we should open a new issue to discuss caching the [npm cache](https://docs.npmjs.com/cli/v11/commands/npm-cache) rather than `node_modules` or switching from `npm ci` to `npm install`.

Examples:
* `npm ci --cache ./.npm --prefer-offline`
* ```npmrc
    # .npmrc
    cache=/tmp/.npm
    prefer-offline=true
    ```
    `npm ci`