### PR TITLE
build: Add NPM cache

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -25,9 +25,11 @@ runs:
       uses: actions/setup-node@v4
       if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
       with:
+        cache: npm
+        cache-dependency-path: '**/package-lock.json'
         node-version: ${{ inputs.node }}
 
     - name: Install and build 🔧
       if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-      run: npm ci
+      run: npm ci --prefer-offline --no-audit
       shell: bash

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -31,5 +31,5 @@ runs:
 
     - name: Install and build 🔧
       if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-      run: npm ci --prefer-offline --no-audit
+      run: npm ci --prefer-offline
       shell: bash


### PR DESCRIPTION
## Summary

This change resolves #4749 by configuring `actions/setup-node` to cache packages.

Example config using these options [[1]](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data):
```yaml
steps:
- uses: actions/checkout@v4
- uses: actions/setup-node@v4
  with:
    node-version: '14'
    cache: 'npm'
    cache-dependency-path: '**/package-lock.json'
- run: npm ci
- run: npm test
```

* [`--prefer-offline`](https://docs.npmjs.com/cli/v11/using-npm/config#prefer-offline) documentation.

## Test plan

If CI succeeds, we should be good to go.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
