### PR TITLE
feat: enable type check when `isolatedModules` and `diagnostics` === true

### DIFF
--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -99,7 +99,7 @@ export class TsCompiler implements TsCompilerInstance {
     this._initialCompilerOptions = { ...this._parsedTsConfig.options }
     this._compilerOptions = { ...this._initialCompilerOptions }
     this._runtimeCacheFS = runtimeCacheFS
-    if (!this.configSet.isolatedModules) {
+    if (!this.configSet.isolatedModules || this.configSet.getDiagnostics().originalValue === true) {
       this._fileContentCache = new Map<string, string>()
       this._fileVersionCache = new Map<string, number>()
       this._cachedReadFile = this._logger.wrap(

--- a/src/legacy/config/config-set.ts
+++ b/src/legacy/config/config-set.ts
@@ -46,6 +46,7 @@ interface TsJestDiagnosticsCfg {
   exclude: string[]
   throws: boolean
   warnOnly?: boolean
+  originalValue: TsJestTransformerOptions['diagnostics']
 }
 
 /**
@@ -303,6 +304,7 @@ export class ConfigSet {
         exclude: diagnosticsOpt.exclude ?? [],
         ignoreCodes: toDiagnosticCodeList(ignoreList),
         throws: !diagnosticsOpt.warnOnly,
+        originalValue: options.diagnostics,
       }
     } else {
       this._diagnostics = {
@@ -310,6 +312,7 @@ export class ConfigSet {
         exclude: [],
         pretty: true,
         throws: diagnosticsOpt,
+        originalValue: options.diagnostics,
       }
     }
     if (diagnosticsOpt) {
@@ -692,5 +695,9 @@ export class ConfigSet {
     this.logger.debug({ fromPath: inputPath, toPath: path }, 'resolved path from', inputPath, 'to', path)
 
     return path
+  }
+
+  getDiagnostics() {
+    return this._diagnostics
   }
 }


### PR DESCRIPTION
### Motivation
TS config `isolatedModules` disables type check. https://github.com/kulshekhar/ts-jest/issues/4859

### Solution (just a RFC)

This solution is a basic RFC to temporarily enable provide the ability to execute type check when `isolatedModules` and `diagnostics` are true.

Currently `isolatedModules` === true disable type check no matter any other configuration

In the next major I believe `ts-jest` should handle  `isolatedModules` so that it never disables type check.

### Demo

I've temporarily tested the change in [this repro](https://github.com/toomuchdesign/ts-jest-type-check-repro) and it seems to work.

## Does this PR introduce a breaking change?

- [X] Yes :)
- [X] No :)

Technically yes (is case of `isolatedModules` and `diagnostics` === true). But it could be interpreted as a fix.

## Other information

Opening this PR as a draft just for sharing purposes.

I haven't found a way to test it, yet. My code addition didn't influence tests.
