### PR TITLE
Docs: fix deprecated option in installation.md

### DIFF
--- a/website/versioned_docs/version-29.3/getting-started/installation.md
+++ b/website/versioned_docs/version-29.3/getting-started/installation.md
@@ -42,7 +42,7 @@ yarn ts-jest config:init
 
 This will create a basic Jest configuration file which will inform Jest about how to handle `.ts` files correctly.
 
-You can also use the `jest --init` command (prefixed with either `npx` or `yarn` depending on what you're using) to have more options related to Jest.
+You can also use the `create-jest` command (prefixed with either `npx` or `yarn` depending on what you're using) to have more options related to Jest.
 However, answer `no` to the Jest question about whether or not to enable TypeScript. Instead, add the line: `preset: "ts-jest"` to the `jest.config.js` file afterwards.
 
 #### Customizing


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary
Option "jest --init" has been deprecated.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to recommend using the `create-jest` command instead of `jest --init`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->