### PR TITLE
revert 29.4.3 changes

### DIFF
--- a/e2e/const-enum/__tests__/const-enum.spec.ts
+++ b/e2e/const-enum/__tests__/const-enum.spec.ts
@@ -1,9 +1,12 @@
 import { BarConstEnum } from '../src/bar-constant'
 import { FooConstEnum } from '../src/foo-constant'
 
+const getOne = (): string => BarConstEnum.one
+const getTwo = (): string => FooConstEnum.two
+
 describe('const-enum', () => {
-  it('should pass with non transpilation mode', () => {
-    expect(BarConstEnum.one).toBe('ONE')
-    expect(FooConstEnum.two).toBe('TWO')
+  it('should pass', () => {
+    expect(getOne()).toBe('ONE')
+    expect(getTwo()).toBe('TWO')
   })
 })

--- a/e2e/const-enum/jest-transpiler-cjs.config.ts
+++ b/e2e/const-enum/jest-transpiler-cjs.config.ts
@@ -6,8 +6,7 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-cjs.spec.json',
-        transpilation: true,
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
       },
     ],
   },

--- a/e2e/const-enum/jest-transpiler-esm.config.ts
+++ b/e2e/const-enum/jest-transpiler-esm.config.ts
@@ -7,9 +7,8 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/const-enum/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/const-enum/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+  }
+}

--- a/e2e/const-enum/tsconfig-esm-transpiler.spec.json
+++ b/e2e/const-enum/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+  }
+}

--- a/e2e/enum/jest-transpiler-cjs.config.ts
+++ b/e2e/enum/jest-transpiler-cjs.config.ts
@@ -6,8 +6,7 @@ export default {
     [ESM_TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-cjs.spec.json',
-        transpilation: true,
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
       },
     ],
   },

--- a/e2e/enum/jest-transpiler-esm.config.ts
+++ b/e2e/enum/jest-transpiler-esm.config.ts
@@ -7,9 +7,8 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/enum/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/enum/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/enum/tsconfig-esm-transpiler.spec.json
+++ b/e2e/enum/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/esm-features/jest-compiler-esm.config.ts
+++ b/e2e/esm-features/jest-compiler-esm.config.ts
@@ -7,7 +7,7 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
       },
     ],

--- a/e2e/esm-features/jest-transpiler-esm.config.ts
+++ b/e2e/esm-features/jest-transpiler-esm.config.ts
@@ -7,9 +7,8 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/esm-features/tsconfig-esm-transpiler.spec.json
+++ b/e2e/esm-features/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/extend-ts-jest/jest-transpiler-cjs.config.ts
+++ b/e2e/extend-ts-jest/jest-transpiler-cjs.config.ts
@@ -6,8 +6,7 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-cjs.spec.json',
-        transpilation: true,
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
       },
     ],
   },

--- a/e2e/extend-ts-jest/jest-transpiler-esm.config.ts
+++ b/e2e/extend-ts-jest/jest-transpiler-esm.config.ts
@@ -7,9 +7,8 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/extend-ts-jest/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/extend-ts-jest/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/extend-ts-jest/tsconfig-esm-transpiler.spec.json
+++ b/e2e/extend-ts-jest/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/hoist-jest/jest-transpiler-cjs.config.ts
+++ b/e2e/hoist-jest/jest-transpiler-cjs.config.ts
@@ -6,8 +6,7 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-cjs.spec.json',
-        transpilation: true,
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
       },
     ],
   },

--- a/e2e/hoist-jest/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/hoist-jest/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/presets/jest-transpiler-cjs.config.ts
+++ b/e2e/presets/jest-transpiler-cjs.config.ts
@@ -6,8 +6,7 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-cjs.spec.json',
-        transpilation: true,
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
       },
     ],
   },

--- a/e2e/presets/jest-transpiler-esm.config.ts
+++ b/e2e/presets/jest-transpiler-esm.config.ts
@@ -7,9 +7,8 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/presets/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/presets/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/presets/tsconfig-esm-transpiler.spec.json
+++ b/e2e/presets/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/source-map/jest-transpiler-cjs.config.ts
+++ b/e2e/source-map/jest-transpiler-cjs.config.ts
@@ -6,8 +6,7 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/../tsconfig-cjs.spec.json',
-        transpilation: true,
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
       },
     ],
   },

--- a/e2e/source-map/jest-transpiler-esm.config.ts
+++ b/e2e/source-map/jest-transpiler-esm.config.ts
@@ -7,9 +7,8 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/../tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/source-map/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/source-map/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/source-map/tsconfig-esm-transpiler.spec.json
+++ b/e2e/source-map/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/test-utils/jest-transpiler-cjs.config.ts
+++ b/e2e/test-utils/jest-transpiler-cjs.config.ts
@@ -6,8 +6,7 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/../tsconfig-cjs.spec.json',
-        transpilation: true,
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
       },
     ],
   },

--- a/e2e/test-utils/jest-transpiler-esm.config.ts
+++ b/e2e/test-utils/jest-transpiler-esm.config.ts
@@ -7,9 +7,8 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/../tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/test-utils/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/test-utils/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/test-utils/tsconfig-esm-transpiler.spec.json
+++ b/e2e/test-utils/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/transform-js/jest-transpiler-cjs.config.ts
+++ b/e2e/transform-js/jest-transpiler-cjs.config.ts
@@ -6,8 +6,7 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-cjs.spec.json',
-        transpilation: true,
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
       },
     ],
   },

--- a/e2e/transform-js/jest-transpiler-esm.config.ts
+++ b/e2e/transform-js/jest-transpiler-esm.config.ts
@@ -7,9 +7,8 @@ export default {
     [TS_JS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/transform-js/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/transform-js/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/transform-js/tsconfig-esm-transpiler.spec.json
+++ b/e2e/transform-js/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/transformer-in-ts/jest-transpiler-cjs.config.ts
+++ b/e2e/transformer-in-ts/jest-transpiler-cjs.config.ts
@@ -6,7 +6,7 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/../tsconfig-cjs.spec.json',
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
         astTransformers: {
           before: [
             {
@@ -14,7 +14,6 @@ export default {
             },
           ],
         },
-        transpilation: true,
       },
     ],
   },

--- a/e2e/transformer-in-ts/jest-transpiler-esm.config.ts
+++ b/e2e/transformer-in-ts/jest-transpiler-esm.config.ts
@@ -7,7 +7,7 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/../tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         astTransformers: {
           before: [
             {
@@ -16,7 +16,6 @@ export default {
           ],
         },
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/transformer-in-ts/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/transformer-in-ts/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/transformer-in-ts/tsconfig-esm-transpiler.spec.json
+++ b/e2e/transformer-in-ts/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/transformer-options/jest-transpiler-cjs.config.ts
+++ b/e2e/transformer-options/jest-transpiler-cjs.config.ts
@@ -7,7 +7,7 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-cjs.spec.json',
+        tsconfig: '<rootDir>/tsconfig-cjs-transpiler.spec.json',
         astTransformers: {
           before: [
             {
@@ -18,7 +18,6 @@ export default {
             },
           ],
         },
-        transpilation: true,
       },
     ],
   },

--- a/e2e/transformer-options/jest-transpiler-esm.config.ts
+++ b/e2e/transformer-options/jest-transpiler-esm.config.ts
@@ -8,7 +8,7 @@ export default {
     [TS_TRANSFORM_PATTERN]: [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+        tsconfig: '<rootDir>/tsconfig-esm-transpiler.spec.json',
         astTransformers: {
           before: [
             {
@@ -20,7 +20,6 @@ export default {
           ],
         },
         useESM: true,
-        transpilation: true,
       },
     ],
   },

--- a/e2e/transformer-options/tsconfig-cjs-transpiler.spec.json
+++ b/e2e/transformer-options/tsconfig-cjs-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/transformer-options/tsconfig-esm-transpiler.spec.json
+++ b/e2e/transformer-options/tsconfig-esm-transpiler.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/js-with-babel/jest-esm-isolated.config.ts
+++ b/examples/js-with-babel/jest-esm-isolated.config.ts
@@ -5,7 +5,6 @@ export default {
   displayName: 'js-with-babel',
   ...createJsWithBabelEsmPreset({
     babelConfig: true,
-    tsconfig: 'tsconfig-esm.json',
-    transpilation: true,
+    tsconfig: 'tsconfig-esm-isolated.json',
   }),
 } satisfies Config

--- a/examples/js-with-babel/jest-isolated.config.ts
+++ b/examples/js-with-babel/jest-isolated.config.ts
@@ -5,6 +5,6 @@ export default {
   displayName: 'js-with-babel',
   ...createJsWithBabelPreset({
     babelConfig: true,
-    transpilation: true,
+    tsconfig: 'tsconfig-isolated.json',
   }),
 } satisfies Config

--- a/examples/js-with-babel/package.json
+++ b/examples/js-with-babel/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "test": "jest -c=jest.config.ts --no-cache",
-    "test-transpiler": "jest -c=jest-transpiler.config.ts --no-cache",
+    "test-isolated": "jest -c=jest-isolated.config.ts --no-cache",
     "test-esm": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm.config.ts --no-cache",
-    "test-esm-transpiler": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-transpiler.config.ts --no-cache"
+    "test-esm-isolated": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-isolated.config.ts --no-cache"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",

--- a/examples/js-with-babel/tsconfig-esm-isolated.json
+++ b/examples/js-with-babel/tsconfig-esm-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/js-with-babel/tsconfig-isolated.json
+++ b/examples/js-with-babel/tsconfig-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/js-with-ts/jest-esm-isolated.config.ts
+++ b/examples/js-with-ts/jest-esm-isolated.config.ts
@@ -4,7 +4,6 @@ import { createJsWithTsEsmPreset } from 'ts-jest'
 export default {
   displayName: 'js-with-ts',
   ...createJsWithTsEsmPreset({
-    tsconfig: 'tsconfig-esm.json',
-    transpilation: true,
+    tsconfig: 'tsconfig-esm-isolated.json',
   }),
 } satisfies Config

--- a/examples/js-with-ts/jest-isolated.config.ts
+++ b/examples/js-with-ts/jest-isolated.config.ts
@@ -4,7 +4,7 @@ import { createJsWithTsPreset } from 'ts-jest'
 export default {
   displayName: 'js-with-ts',
   ...createJsWithTsPreset({
-    transpilation: true,
+    tsconfig: 'tsconfig-isolated.json',
   }),
   transformIgnorePatterns: ['!node_modules/(?!lodash-es)'],
 } satisfies Config

--- a/examples/js-with-ts/package.json
+++ b/examples/js-with-ts/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "test": "jest -c=jest.config.ts --no-cache",
-    "test-transpiler": "jest -c=jest-transpiler.config.ts --no-cache",
+    "test-isolated": "jest -c=jest-isolated.config.ts --no-cache",
     "test-esm": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm.config.ts --no-cache",
-    "test-esm-transpiler": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-transpiler.config.ts --no-cache"
+    "test-esm-isolated": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-isolated.config.ts --no-cache"
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.12",

--- a/examples/js-with-ts/tsconfig-esm-isolated.json
+++ b/examples/js-with-ts/tsconfig-esm-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/js-with-ts/tsconfig-isolated.json
+++ b/examples/js-with-ts/tsconfig-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/monorepo-app/jest-esm-isolated.config.ts
+++ b/examples/monorepo-app/jest-esm-isolated.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from 'jest'
+
+export default {
+  projects: [
+    '<rootDir>/type-commonjs/jest-esm-isolated.config.ts',
+    '<rootDir>/type-module/jest-esm-isolated.config.ts',
+  ],
+} satisfies Config

--- a/examples/monorepo-app/jest-esm-transpiler.config.ts
+++ b/examples/monorepo-app/jest-esm-transpiler.config.ts
@@ -1,8 +1,0 @@
-import type { Config } from 'jest'
-
-export default {
-  projects: [
-    '<rootDir>/type-commonjs/jest-esm-transpiler.config.ts',
-    '<rootDir>/type-module/jest-esm-transpiler.config.ts',
-  ],
-} satisfies Config

--- a/examples/monorepo-app/jest-isolated.config.ts
+++ b/examples/monorepo-app/jest-isolated.config.ts
@@ -1,0 +1,5 @@
+import type { Config } from 'jest'
+
+export default {
+  projects: ['<rootDir>/type-commonjs/jest-isolated.config.ts', '<rootDir>/type-module/jest-isolated.config.ts'],
+} satisfies Config

--- a/examples/monorepo-app/jest-transpiler.config.ts
+++ b/examples/monorepo-app/jest-transpiler.config.ts
@@ -1,5 +1,0 @@
-import type { Config } from 'jest'
-
-export default {
-  projects: ['<rootDir>/type-commonjs/jest-transpiler.config.ts', '<rootDir>/type-module/jest-transpiler.config.ts'],
-} satisfies Config

--- a/examples/monorepo-app/package.json
+++ b/examples/monorepo-app/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "build": "tsc -b",
     "test": "jest -c=jest.config.ts --no-cache",
-    "test-transpiler": "jest -c=jest-transpiler.config.ts --no-cache",
+    "test-isolated": "jest -c=jest-isolated.config.ts --no-cache",
     "test-esm": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm.config.ts --no-cache",
-    "test-esm-transpiler": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-transpiler.config.ts --no-cache"
+    "test-esm-isolated": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-isolated.config.ts --no-cache"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/examples/monorepo-app/type-commonjs/jest-esm-isolated.config.ts
+++ b/examples/monorepo-app/type-commonjs/jest-esm-isolated.config.ts
@@ -4,7 +4,6 @@ import { createDefaultEsmPreset } from 'ts-jest'
 export default {
   displayName: 'type-commonjs',
   ...createDefaultEsmPreset({
-    tsconfig: '<rootDir>/tsconfig-esm.json',
-    transpilation: true,
+    tsconfig: '<rootDir>/tsconfig-esm-isolated.json',
   }),
 } satisfies Config

--- a/examples/monorepo-app/type-commonjs/jest-isolated.config.ts
+++ b/examples/monorepo-app/type-commonjs/jest-isolated.config.ts
@@ -2,8 +2,8 @@ import type { Config } from 'jest'
 import { createDefaultPreset } from 'ts-jest'
 
 export default {
-  displayName: 'type-module',
+  displayName: 'type-commonjs',
   ...createDefaultPreset({
-    transpilation: true,
+    tsconfig: '<rootDir>/tsconfig-isolated.json',
   }),
 } satisfies Config

--- a/examples/monorepo-app/type-commonjs/tsconfig-esm-isolated.json
+++ b/examples/monorepo-app/type-commonjs/tsconfig-esm-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/monorepo-app/type-commonjs/tsconfig-isolated.json
+++ b/examples/monorepo-app/type-commonjs/tsconfig-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/monorepo-app/type-module/jest-esm-isolated.config.ts
+++ b/examples/monorepo-app/type-module/jest-esm-isolated.config.ts
@@ -2,9 +2,8 @@ import type { Config } from 'jest'
 import { createDefaultEsmPreset } from 'ts-jest'
 
 export default {
-  displayName: 'ts-only',
+  displayName: 'type-module',
   ...createDefaultEsmPreset({
-    tsconfig: 'tsconfig-esm.json',
-    transpilation: true,
+    tsconfig: '<rootDir>/tsconfig-esm-isolated.json',
   }),
 } satisfies Config

--- a/examples/monorepo-app/type-module/jest-isolated.config.ts
+++ b/examples/monorepo-app/type-module/jest-isolated.config.ts
@@ -2,8 +2,8 @@ import type { Config } from 'jest'
 import { createDefaultPreset } from 'ts-jest'
 
 export default {
-  displayName: 'type-commonjs',
+  displayName: 'type-module',
   ...createDefaultPreset({
-    transpilation: true,
+    tsconfig: '<rootDir>/tsconfig-isolated.json',
   }),
 } satisfies Config

--- a/examples/monorepo-app/type-module/tsconfig-esm-isolated.json
+++ b/examples/monorepo-app/type-module/tsconfig-esm-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/monorepo-app/type-module/tsconfig-isolated.json
+++ b/examples/monorepo-app/type-module/tsconfig-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,10 +12,10 @@
   ],
   "scripts": {
     "test": "npm run test --workspaces",
-    "test-transpiler": "npm run test-transpiler --workspaces",
+    "test-isolated": "npm run test-isolated --workspaces",
     "test-esm": "npm run test-esm --workspaces",
-    "test-esm-transpiler": "npm run test-esm-transpiler --workspaces",
-    "test-all": "npm-run-all test test-transpiler test-esm test-esm-transpiler"
+    "test-esm-isolated": "npm run test-esm-isolated --workspaces",
+    "test-all": "npm-run-all test test-isolated test-esm test-esm-isolated"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"

--- a/examples/react-app/jest-esm-isolated.config.ts
+++ b/examples/react-app/jest-esm-isolated.config.ts
@@ -2,8 +2,7 @@ import type { Config } from 'jest'
 import { createDefaultEsmPreset } from 'ts-jest'
 
 const defaultPreset = createDefaultEsmPreset({
-  tsconfig: 'tsconfig-esm.spec.json',
-  transpilation: true,
+  tsconfig: 'tsconfig-esm-isolated.spec.json',
 })
 
 export default {

--- a/examples/react-app/jest-isolated.config.ts
+++ b/examples/react-app/jest-isolated.config.ts
@@ -2,8 +2,7 @@ import type { Config } from 'jest'
 import { createDefaultPreset } from 'ts-jest'
 
 const defaultPreset = createDefaultPreset({
-  tsconfig: 'tsconfig.spec.json',
-  transpilation: true,
+  tsconfig: 'tsconfig-isolated.spec.json',
 })
 
 export default {

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -6,9 +6,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "test": "jest -c=jest.config.ts --no-cache",
-    "test-transpiler": "jest -c=jest-transpiler.config.ts --no-cache",
+    "test-isolated": "jest -c=jest-isolated.config.ts --no-cache",
     "test-esm": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm.config.ts --no-cache",
-    "test-esm-transpiler": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-transpiler.config.ts --no-cache",
+    "test-esm-isolated": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-isolated.config.ts --no-cache",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/examples/react-app/tsconfig-esm-isolated.spec.json
+++ b/examples/react-app/tsconfig-esm-isolated.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/react-app/tsconfig-isolated.spec.json
+++ b/examples/react-app/tsconfig-isolated.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/ts-only/jest-esm-isolated.config.ts
+++ b/examples/ts-only/jest-esm-isolated.config.ts
@@ -2,9 +2,8 @@ import type { Config } from 'jest'
 import { createDefaultEsmPreset } from 'ts-jest'
 
 export default {
-  displayName: 'type-module',
+  displayName: 'ts-only',
   ...createDefaultEsmPreset({
-    tsconfig: '<rootDir>/tsconfig-esm.json',
-    transpilation: true,
+    tsconfig: 'tsconfig-esm-isolated.json',
   }),
 } satisfies Config

--- a/examples/ts-only/jest-isolated.config.ts
+++ b/examples/ts-only/jest-isolated.config.ts
@@ -4,6 +4,6 @@ import { createDefaultPreset } from 'ts-jest'
 export default {
   displayName: 'ts-only',
   ...createDefaultPreset({
-    transpilation: true,
+    tsconfig: 'tsconfig-isolated.json',
   }),
 } satisfies Config

--- a/examples/ts-only/package.json
+++ b/examples/ts-only/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "test": "jest -c=jest.config.ts --no-cache",
-    "test-transpiler": "jest -c=jest-transpiler.config.ts --no-cache",
+    "test-isolated": "jest -c=jest-isolated.config.ts --no-cache",
     "test-esm": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm.config.ts --no-cache",
-    "test-esm-transpiler": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-transpiler.config.ts --no-cache"
+    "test-esm-isolated": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest -c=jest-esm-isolated.config.ts --no-cache"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/examples/ts-only/tsconfig-esm-isolated.json
+++ b/examples/ts-only/tsconfig-esm-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/examples/ts-only/tsconfig-isolated.json
+++ b/examples/ts-only/tsconfig-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,10 +14,10 @@ export default {
       {
         tsconfig: {
           target: 'ES2015',
+          isolatedModules: true,
           module: 'NodeNext',
           moduleResolution: 'NodeNext',
         },
-        transpilation: true,
       },
     ],
   },

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -193,7 +193,7 @@ export class TsCompiler implements TsCompilerInstance {
   getCompiledOutput(fileContent: string, fileName: string, options: TsJestCompileOptions): CompiledOutput {
     const isEsmMode = this.configSet.useESM && options.supportsStaticESM
     this._compilerOptions = this.fixupCompilerOptionsForModuleKind(this._initialCompilerOptions, isEsmMode)
-    if (isModernNodeModuleKind(this._initialCompilerOptions.module) && !this.configSet.isolatedModules) {
+    if (!this._initialCompilerOptions.isolatedModules && isModernNodeModuleKind(this._initialCompilerOptions.module)) {
       this._logger.warn(Helps.UsingModernNodeResolution)
     }
 

--- a/src/legacy/config/config-set.spec.ts
+++ b/src/legacy/config/config-set.spec.ts
@@ -11,7 +11,7 @@ import type { AstTransformerDesc, TsJestTransformerOptions } from '../../types'
 import { stringify } from '../../utils'
 import * as _backports from '../../utils/backports'
 import { getPackageVersion } from '../../utils/get-package-version'
-import { Deprecations, Errors } from '../../utils/messages'
+import { Deprecations, Errors, interpolate } from '../../utils/messages'
 import { normalizeSlashes } from '../../utils/normalize-slashes'
 import { sha1 } from '../../utils/sha1'
 
@@ -1150,7 +1150,33 @@ describe('config-set', () => {
   describe('isolatedModules', () => {
     const spyFindTsConfigFile = jest.spyOn(ts, 'findConfigFile')
 
-    it('should show warning log when isolatedModules: true is used in transformer options', () => {
+    it('should show warning log when isolatedModules: true is used in transformer options when a tsconfig file path for tests exists', () => {
+      spyFindTsConfigFile.mockReturnValueOnce('foo/tsconfig.json')
+      const logger = testing.createLoggerMock()
+      createConfigSet({
+        logger,
+        jestConfig: {
+          rootDir: 'src',
+          cwd: 'src',
+        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        tsJestConfig: {
+          isolatedModules: true,
+        },
+        resolve: null,
+      })
+
+      expect(logger.target.filteredLines(LogLevels.warn)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(
+            interpolate(Deprecations.IsolatedModulesWithTsconfigPath, {
+              tsconfigFilePath: 'foo/tsconfig.json',
+            }),
+          ),
+        ]),
+      )
+    })
+
+    it('should show warning log when isolatedModules: true is used in transformer options when a tsconfig file path does not exist', () => {
       spyFindTsConfigFile.mockReturnValueOnce(undefined)
       const logger = testing.createLoggerMock()
       createConfigSet({
@@ -1166,7 +1192,7 @@ describe('config-set', () => {
       })
 
       expect(logger.target.filteredLines(LogLevels.warn)).toEqual(
-        expect.arrayContaining([expect.stringContaining(Deprecations.ReplaceIsolatedModulesWithTranspilation)]),
+        expect.arrayContaining([expect.stringContaining(Deprecations.IsolatedModulesWithoutTsconfigPath)]),
       )
     })
   })

--- a/src/legacy/config/config-set.ts
+++ b/src/legacy/config/config-set.ts
@@ -214,9 +214,18 @@ export class ConfigSet {
     this._matchTestFilePath = globsToMatcher(this._matchablePatterns.filter((pattern) => typeof pattern === 'string'))
     // isolatedModules
     if (options.isolatedModules) {
-      this.logger.warn(Deprecations.ReplaceIsolatedModulesWithTranspilation)
+      this.parsedTsConfig.options.isolatedModules = true
+      if (this.tsconfigFilePath) {
+        this.logger.warn(
+          interpolate(Deprecations.IsolatedModulesWithTsconfigPath, {
+            tsconfigFilePath: this.tsconfigFilePath,
+          }),
+        )
+      } else {
+        this.logger.warn(Deprecations.IsolatedModulesWithoutTsconfigPath)
+      }
     }
-    this.isolatedModules = options.isolatedModules ?? options.transpilation ?? false
+    this.isolatedModules = this.parsedTsConfig.options.isolatedModules ?? false
     this._resolveTsCacheDir()
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,16 +77,13 @@ export type TsJestGlobalOptions = Config.TransformerConfig[1] & {
   tsconfig?: boolean | string | RawCompilerOptions | TsConfigCompilerOptionsJson
 
   /**
-   * @deprecated use {@link transpilation} instead
+   * @deprecated use {@link TsConfigCompilerOptionsJson.isolatedModules} instead
+   *
+   * Compiles files as isolated modules (disables some features)
+   *
+   * @default `undefined` (disables transpiling files with {@link _ts.transpileModule})
    */
   isolatedModules?: boolean
-
-  /**
-   * Compiles files using {@link _ts.transpileModule})
-   *
-   * @default `undefined` (disables)
-   */
-  transpilation?: boolean
 
   /**
    * Compiler to use

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -28,7 +28,7 @@ export const enum Errors {
 export const enum Helps {
   FixMissingModule = '{{label}}: `npm i -D {{module}}` (or `yarn add --dev {{module}}`)',
   MigrateConfigUsingCLI = 'Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.',
-  UsingModernNodeResolution = 'Using hybrid module kind (Node16/18/Next) is only supported in "transpilation: true". Please set "transpilation: true" in for `ts-jest` config in your Jest config file, see https://kulshekhar.github.io/ts-jest/docs/getting-started/options/transpilation',
+  UsingModernNodeResolution = 'Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.',
 }
 
 /**
@@ -45,8 +45,11 @@ export const enum Deprecations {
     "    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],\n" +
     '},\n' +
     'See more at https://kulshekhar.github.io/ts-jest/docs/getting-started/presets#advanced',
-  ReplaceIsolatedModulesWithTranspilation = `
-    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "transpilation: true" instead, see https://kulshekhar.github.io/ts-jest/docs/getting-started/options/transpilation
+  IsolatedModulesWithTsconfigPath = `
+    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "isolatedModules: true" in {{tsconfigFilePath}} instead, see https://www.typescriptlang.org/tsconfig/#isolatedModules
+  `,
+  IsolatedModulesWithoutTsconfigPath = `
+    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "isolatedModules: true", see https://www.typescriptlang.org/tsconfig/#isolatedModules
   `,
 }
 

--- a/website/docs/getting-started/options.md
+++ b/website/docs/getting-started/options.md
@@ -41,7 +41,7 @@ All options have default values which should fit most of the projects. Click on 
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------ | ----------------------------- | -------------- |
 | [**`compiler`**][compiler]                                   | [TypeScript module to use as compiler.][compiler]                                    | `string`                      | `"typescript"` |
 | [**`tsconfig`**][tsconfig]                                   | [TypeScript compiler related configuration.][tsconfig]                               | `string`\|`object`\|`boolean` | _auto_         |
-| [**`transpilation`**][transpilation]                         | [Transpile code and disable type-checking][transpilation]                            | `boolean`                     | _disabled_     |
+| [**`isolatedModules`**][isolatedmodules]                     | [Disable type-checking][isolatedmodules]                                             | `boolean`                     | _disabled_     |
 | [**`astTransformers`**][asttransformers]                     | [Custom TypeScript AST transformers][asttransformers]                                | `object`                      | _auto_         |
 | [**`diagnostics`**][diagnostics]                             | [Diagnostics related configuration.][diagnostics]                                    | `boolean`\|`object`           | _enabled_      |
 | [**`babelConfig`**][babelconfig]                             | [Babel(Jest) related configuration.][babelconfig]                                    | `boolean`\|`string`\|`object` | _disabled_     |
@@ -50,7 +50,7 @@ All options have default values which should fit most of the projects. Click on 
 
 [compiler]: options/compiler
 [tsconfig]: options/tsconfig
-[transpilation]: options/transpilation
+[isolatedmodules]: options/isolatedModules
 [asttransformers]: options/astTransformers
 [diagnostics]: options/diagnostics
 [babelconfig]: options/babelConfig

--- a/website/docs/getting-started/options/isolatedModules.md
+++ b/website/docs/getting-started/options/isolatedModules.md
@@ -1,14 +1,20 @@
 ---
-title: transpilation option
+title: isolatedModules option
 ---
 
-By default `ts-jest` uses TypeScript Compiler API aka full `Program` in the context of a project (yours), with full type-checking and features.
-But it can also be used to compile each file separately, which is usually named as `transpilation` like other tools `Babel`, `swc`, `esbuild` etc.
-That's what the `transpilation` option (which defaults to `false`) does.
+:::warning DEPRECATED
 
-You'll lose type-checking ability and all [TypeScript limitations](https://www.typescriptlang.org/tsconfig/#isolatedModules) are applied in trading off for faster test running.
+This page is now **DEPRECATED** and will be removed together with the config option `isolatedModules` in the next major release. Please use `isolatedModules` option in `tsconfig.json` instead.
 
-Here is the example how to use the option
+:::
+
+By default `ts-jest` uses TypeScript compiler in the context of a project (yours), with full type-checking and features.
+But it can also be used to compile each file separately, what TypeScript calls an 'isolated module'.
+That's what the `isolatedModules` option (which defaults to `false`) does.
+
+You'll lose type-checking ability and some features such as `const enum`, but in the case you plan on using Jest with the cache disabled (`jest --no-cache`), your tests will then run much faster.
+
+Here is how to disable type-checking and compile each file as an isolated module:
 
 ### Example
 
@@ -23,7 +29,7 @@ const jestConfig: Config = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        transpilation: true,
+        isolatedModules: true,
       },
     ],
   },
@@ -34,7 +40,7 @@ export default jestConfig
 
 ## Performance
 
-Using `transpilation: false` comes with a cost of performance comparing to `transpilation: true`. There is a way
+Using `isolatedModules: false` comes with a cost of performance comparing to `isolatedModules: true`. There is a way
 to improve the performance when using this mode by changing the value of `include` in `tsconfig` which is used by `ts-jest`.
 The least amount of files which are provided in `include`, the more performance the test run can gain.
 

--- a/website/docs/getting-started/presets.md
+++ b/website/docs/getting-started/presets.md
@@ -30,7 +30,7 @@ Create a configuration to process TypeScript files (`.ts`/`.tsx`).
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -45,7 +45,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -89,7 +89,7 @@ Create a **LEGACY** configuration to process TypeScript files (`.ts`, `.tsx`).
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -104,7 +104,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -129,7 +129,7 @@ export type DefaultPreset = {
 ```ts title="jest.config.ts"
 import { createDefaultLegacyPreset, type JestConfigWithTsJest } from 'ts-jest'
 
-const presetConfig = createDefaultPreset({
+const presetConfig = createDefaultLegacyPreset({
   //...optionsa
 })
 
@@ -148,7 +148,7 @@ Create an ESM configuration to process TypeScript files (`.ts`/`.mts`/`.tsx`/`.m
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -161,7 +161,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -206,7 +206,7 @@ Create a **LEGACY** ESM configuration to process TypeScript files (`.ts`/`.mts`/
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -221,7 +221,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -266,7 +266,7 @@ Create a configuration to process JavaScript/TypeScript files (`.js`/`.jsx`/`.ts
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -281,7 +281,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -325,7 +325,7 @@ Create a **LEGACY** configuration to process JavaScript/TypeScript files (`.js`/
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -338,7 +338,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -382,7 +382,7 @@ Create a ESM configuration to process JavaScript/TypeScript files (`.js`/`.mjs`/
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -397,7 +397,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -441,7 +441,7 @@ Create a **LEGACY** ESM configuration to process JavaScript/TypeScript files (`.
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -454,7 +454,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -498,7 +498,7 @@ Create a configuration to process JavaScript/TypeScript files (`.js`/`.jsx`/`.ts
 
 - `options` (**OPTIONAL**):
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -514,7 +514,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -559,7 +559,7 @@ Create a **LEGACY** configuration to process JavaScript/TypeScript files (`.js`/
 
 - `options` (**OPTIONAL**):
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -573,7 +573,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -618,7 +618,7 @@ Create a ESM configuration to process JavaScript/TypeScript files (`.js`/`.mjs`/
 
 - `options` (**OPTIONAL**):
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -634,7 +634,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -679,7 +679,7 @@ Create a **LEGACY** ESM configuration to process JavaScript/TypeScript files (`.
 
 - `options` (**OPTIONAL**):
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -693,7 +693,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean

--- a/website/versioned_docs/version-29.4/getting-started/options.md
+++ b/website/versioned_docs/version-29.4/getting-started/options.md
@@ -41,7 +41,7 @@ All options have default values which should fit most of the projects. Click on 
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------ | ----------------------------- | -------------- |
 | [**`compiler`**][compiler]                                   | [TypeScript module to use as compiler.][compiler]                                    | `string`                      | `"typescript"` |
 | [**`tsconfig`**][tsconfig]                                   | [TypeScript compiler related configuration.][tsconfig]                               | `string`\|`object`\|`boolean` | _auto_         |
-| [**`transpilation`**][transpilation]                         | [Transpile code and disable type-checking][transpilation]                            | `boolean`                     | _disabled_     |
+| [**`isolatedModules`**][isolatedmodules]                     | [Disable type-checking][isolatedmodules]                                             | `boolean`                     | _disabled_     |
 | [**`astTransformers`**][asttransformers]                     | [Custom TypeScript AST transformers][asttransformers]                                | `object`                      | _auto_         |
 | [**`diagnostics`**][diagnostics]                             | [Diagnostics related configuration.][diagnostics]                                    | `boolean`\|`object`           | _enabled_      |
 | [**`babelConfig`**][babelconfig]                             | [Babel(Jest) related configuration.][babelconfig]                                    | `boolean`\|`string`\|`object` | _disabled_     |
@@ -50,7 +50,7 @@ All options have default values which should fit most of the projects. Click on 
 
 [compiler]: options/compiler
 [tsconfig]: options/tsconfig
-[transpilation]: options/transpilation
+[isolatedmodules]: options/isolatedModules
 [asttransformers]: options/astTransformers
 [diagnostics]: options/diagnostics
 [babelconfig]: options/babelConfig

--- a/website/versioned_docs/version-29.4/getting-started/options/isolatedModules.md
+++ b/website/versioned_docs/version-29.4/getting-started/options/isolatedModules.md
@@ -1,14 +1,20 @@
 ---
-title: transpilation option
+title: isolatedModules option
 ---
 
-By default `ts-jest` uses TypeScript Compiler API aka full `Program` in the context of a project (yours), with full type-checking and features.
-But it can also be used to compile each file separately, which is usually named as `transpilation` like other tools `Babel`, `swc`, `esbuild` etc.
-That's what the `transpilation` option (which defaults to `false`) does.
+:::warning DEPRECATED
 
-You'll lose type-checking ability and all [TypeScript limitations](https://www.typescriptlang.org/tsconfig/#isolatedModules) are applied in trading off for faster test running.
+This page is now **DEPRECATED** and will be removed together with the config option `isolatedModules` in the next major release. Please use `isolatedModules` option in `tsconfig.json` instead.
 
-Here is the example how to use the option
+:::
+
+By default `ts-jest` uses TypeScript compiler in the context of a project (yours), with full type-checking and features.
+But it can also be used to compile each file separately, what TypeScript calls an 'isolated module'.
+That's what the `isolatedModules` option (which defaults to `false`) does.
+
+You'll lose type-checking ability and some features such as `const enum`, but in the case you plan on using Jest with the cache disabled (`jest --no-cache`), your tests will then run much faster.
+
+Here is how to disable type-checking and compile each file as an isolated module:
 
 ### Example
 
@@ -23,7 +29,7 @@ const jestConfig: Config = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        transpilation: true,
+        isolatedModules: true,
       },
     ],
   },
@@ -34,7 +40,7 @@ export default jestConfig
 
 ## Performance
 
-Using `transpilation: false` comes with a cost of performance comparing to `transpilation: true`. There is a way
+Using `isolatedModules: false` comes with a cost of performance comparing to `isolatedModules: true`. There is a way
 to improve the performance when using this mode by changing the value of `include` in `tsconfig` which is used by `ts-jest`.
 The least amount of files which are provided in `include`, the more performance the test run can gain.
 

--- a/website/versioned_docs/version-29.4/getting-started/presets.md
+++ b/website/versioned_docs/version-29.4/getting-started/presets.md
@@ -30,7 +30,7 @@ Create a configuration to process TypeScript files (`.ts`/`.tsx`).
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -45,7 +45,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -89,7 +89,7 @@ Create a **LEGACY** configuration to process TypeScript files (`.ts`, `.tsx`).
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -104,7 +104,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -148,7 +148,7 @@ Create an ESM configuration to process TypeScript files (`.ts`/`.mts`/`.tsx`/`.m
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -161,7 +161,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -206,7 +206,7 @@ Create a **LEGACY** ESM configuration to process TypeScript files (`.ts`/`.mts`/
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -221,7 +221,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -266,7 +266,7 @@ Create a configuration to process JavaScript/TypeScript files (`.js`/`.jsx`/`.ts
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -281,7 +281,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -325,7 +325,7 @@ Create a **LEGACY** configuration to process JavaScript/TypeScript files (`.js`/
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -338,7 +338,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -382,7 +382,7 @@ Create a ESM configuration to process JavaScript/TypeScript files (`.js`/`.mjs`/
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -397,7 +397,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -441,7 +441,7 @@ Create a **LEGACY** ESM configuration to process JavaScript/TypeScript files (`.
 
 - `options` (**OPTIONAL**)
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -454,7 +454,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -498,7 +498,7 @@ Create a configuration to process JavaScript/TypeScript files (`.js`/`.jsx`/`.ts
 
 - `options` (**OPTIONAL**):
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -514,7 +514,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -559,7 +559,7 @@ Create a **LEGACY** configuration to process JavaScript/TypeScript files (`.js`/
 
 - `options` (**OPTIONAL**):
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -573,7 +573,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -618,7 +618,7 @@ Create a ESM configuration to process JavaScript/TypeScript files (`.js`/`.mjs`/
 
 - `options` (**OPTIONAL**):
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -634,7 +634,7 @@ import type { TsConfigJson } from 'type-fest'
 
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | TsConfigJson.CompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean
@@ -679,7 +679,7 @@ Create a **LEGACY** ESM configuration to process JavaScript/TypeScript files (`.
 
 - `options` (**OPTIONAL**):
   - `tsconfig`: see more at [tsconfig options page](./options/tsconfig.md)
-  - `transpilation`: see more at [transpilation options page](./options/transpilation.md)
+  - `isolatedModules`: see more at [isolatedModules options page](./options/isolatedModules.md)
   - `compiler`: see more at [compiler options page](./options/compiler.md)
   - `astTransformers`: see more at [astTransformers options page](./options/astTransformers.md)
   - `diagnostics`: see more at [diagnostics options page](./options/diagnostics.md)
@@ -693,7 +693,7 @@ An object contains Jest's `transform` property:
 ```ts
 interface TsJestTransformerOptions {
   tsconfig?: boolean | string | RawCompilerOptions
-  transpilation?: boolean
+  isolatedModules?: boolean
   astTransformers?: ConfigCustomTransformer
   diagnostics?:
     | boolean


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Closes #5049

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced isolated modules mode across presets and examples.
  - Added options: useESM and stringifyContentPathRegex.
  - New isolated tsconfig files and example configs (CJS/ESM, monorepo, React, Babel, TS-only).

- Documentation
  - Replaced “transpilation” with “isolatedModules” throughout.
  - Added deprecation notices and updated guidance/examples.

- Chores
  - Migrated example/e2e configs to isolated modules; removed legacy transpiler configs.
  - Renamed example scripts to test-isolated/test-esm-isolated.

- Tests
  - Updated test suites and messaging to align with isolated modules behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->