### PR TITLE
fix: log hybrid module as warning instead of failing tests

### DIFF
--- a/e2e/hybrid-module/__tests__/hybrid-module.spec.ts
+++ b/e2e/hybrid-module/__tests__/hybrid-module.spec.ts
@@ -1,0 +1,5 @@
+describe('hybrid-module', () => {
+  it('should work', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/e2e/hybrid-module/jest-compiler-cjs.config.ts
+++ b/e2e/hybrid-module/jest-compiler-cjs.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'jest'
+import { TS_JS_TRANSFORM_PATTERN } from 'ts-jest'
+
+export default {
+  displayName: 'hybrid-module-compiler-cjs',
+  transform: {
+    [TS_JS_TRANSFORM_PATTERN]: [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        diagnostics: {
+          ignoreCodes: [151002],
+        },
+      },
+    ],
+  },
+} satisfies Config

--- a/e2e/hybrid-module/jest-compiler-esm.config.ts
+++ b/e2e/hybrid-module/jest-compiler-esm.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from 'jest'
+import { TS_JS_TRANSFORM_PATTERN } from 'ts-jest'
+
+export default {
+  displayName: 'hybrid-module-compiler-esm',
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    [TS_JS_TRANSFORM_PATTERN]: [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        useESM: true,
+        diagnostics: {
+          ignoreCodes: [151002],
+        },
+      },
+    ],
+  },
+} satisfies Config

--- a/e2e/hybrid-module/package.json
+++ b/e2e/hybrid-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "hybrid-module",
+  "private": true
+}

--- a/e2e/hybrid-module/tsconfig.spec.json
+++ b/e2e/hybrid-module/tsconfig.spec.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -9,7 +9,6 @@ import { createConfigSet, makeCompiler } from '../../__helpers__/fakers'
 import { logTargetMock } from '../../__helpers__/mocks'
 import { tsTranspileModule } from '../../transpilers/typescript/transpile-module'
 import type { DepGraphInfo, TsJestTransformerOptions } from '../../types'
-import { TsJestDiagnosticCodes } from '../../utils'
 import { Errors, Helps, interpolate } from '../../utils/messages'
 
 import { updateOutput } from './compiler-utils'
@@ -392,17 +391,11 @@ describe('TsCompiler', () => {
         expect(usedCompilerOptions.customConditions).toBeUndefined()
         expect(output).toEqual({
           code: updateOutput(jsOutput, fileName, sourceMap),
-          diagnostics: [
-            {
-              category: ts.DiagnosticCategory.Message,
-              code: TsJestDiagnosticCodes.ModernNodeModule,
-              messageText: Helps.UsingModernNodeResolution,
-              file: undefined,
-              start: undefined,
-              length: undefined,
-            },
-          ],
+          diagnostics: [],
         })
+        expect(logTarget.filteredLines(LogLevels.warn)).toEqual(
+          expect.arrayContaining([expect.stringContaining(Helps.UsingModernNodeResolution)]),
+        )
 
         // @ts-expect-error testing purpose
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -211,14 +211,16 @@ export class TsCompiler implements TsCompilerInstance {
       const output: EmitOutput = this._languageService.getEmitOutput(fileName)
       const diagnostics = this.getDiagnostics(fileName)
       if (isModernNodeModuleKind(this._initialCompilerOptions.module)) {
-        diagnostics.push({
-          category: this._ts.DiagnosticCategory.Message,
-          code: TsJestDiagnosticCodes.ModernNodeModule,
-          messageText: Helps.UsingModernNodeResolution,
-          file: undefined,
-          start: undefined,
-          length: undefined,
-        })
+        this.configSet.raiseDiagnostics([
+          {
+            category: this._ts.DiagnosticCategory.Message,
+            code: TsJestDiagnosticCodes.ModernNodeModule,
+            messageText: Helps.UsingModernNodeResolution,
+            file: undefined,
+            start: undefined,
+            length: undefined,
+          },
+        ])
       }
       if (!isEsmMode && diagnostics.length) {
         this.configSet.raiseDiagnostics(diagnostics, fileName, this._logger)

--- a/src/transpilers/typescript/transpile-module.ts
+++ b/src/transpilers/typescript/transpile-module.ts
@@ -49,7 +49,11 @@ type ExtendedTsTranspileModuleFn = (
 ) => ts.TranspileOutput
 
 export const isModernNodeModuleKind = (module: ts.ModuleKind | undefined): boolean => {
-  return module ? [ts.ModuleKind.Node16, /* ModuleKind.Node18 */ 101, ts.ModuleKind.NodeNext].includes(module) : false
+  return module
+    ? [ts.ModuleKind.Node16, /* ModuleKind.Node18 */ 101, /* ModuleKind.Node20 */ 102, ts.ModuleKind.NodeNext].includes(
+        module,
+      )
+    : false
 }
 
 const shouldCheckProjectPkgJsonContent = (fileName: string, moduleKind: ts.ModuleKind | undefined): boolean => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes #5130 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Node 20 module kind resolution

* **Improvements**
  * Refactored diagnostic handling for more immediate feedback during module resolution

* **Tests**
  * Introduced end-to-end testing infrastructure for module compatibility scenarios
  * Expanded test coverage for module resolution edge cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->