### PR TITLE
fix(compiler): default moduleResolution to Bundler instead of deprecated Node10

### DIFF
--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -286,6 +286,7 @@ describe('TsCompiler', () => {
           moduleValue: 'ESNext',
           expectedModule: ts.ModuleKind.ESNext,
           expectedEsModuleInterop: false,
+          mockTsVersion: '5.9.0',
           expectedResolution: ts.ModuleResolutionKind.Node10,
         },
         {
@@ -294,6 +295,7 @@ describe('TsCompiler', () => {
           moduleValue: 'ESNext',
           expectedModule: ts.ModuleKind.CommonJS,
           expectedEsModuleInterop: false,
+          mockTsVersion: '5.9.0',
           expectedResolution: ts.ModuleResolutionKind.Node10,
         },
         {
@@ -302,6 +304,7 @@ describe('TsCompiler', () => {
           moduleValue: 'ESNext',
           expectedModule: ts.ModuleKind.CommonJS,
           expectedEsModuleInterop: false,
+          mockTsVersion: '5.9.0',
           expectedResolution: ts.ModuleResolutionKind.Node10,
         },
         {

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -337,7 +337,7 @@ describe('TsCompiler', () => {
 
           expect(usedCompilerOptions.module).toBe(expectedModule)
           expect(usedCompilerOptions.esModuleInterop).toBe(expectedEsModuleInterop)
-          expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Bundler)
+          expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Node10)
           expect(usedCompilerOptions.customConditions).toBeUndefined()
           expect(output).toEqual({
             code: updateOutput(jsOutput, fileName, sourceMap),
@@ -387,7 +387,7 @@ describe('TsCompiler', () => {
 
         expect(usedCompilerOptions.module).toBe(ts.ModuleKind.ESNext)
         expect(usedCompilerOptions.esModuleInterop).toBe(true)
-        expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Bundler)
+        expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Node10)
         expect(usedCompilerOptions.customConditions).toBeUndefined()
         expect(output).toEqual({
           code: updateOutput(jsOutput, fileName, sourceMap),

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -405,6 +405,48 @@ describe('TsCompiler', () => {
         expect(compiler._fileContentCache.has(emptyFile)).toBe(true)
       })
 
+      test.each([
+        { version: '6.0.0', expectedResolution: ts.ModuleResolutionKind.Bundler },
+        { version: '6.1.2', expectedResolution: ts.ModuleResolutionKind.Bundler },
+        { version: '6.0.0-dev.20251015', expectedResolution: ts.ModuleResolutionKind.Bundler },
+        { version: '5.9.3', expectedResolution: ts.ModuleResolutionKind.Node10 },
+        { version: '4.7.4', expectedResolution: ts.ModuleResolutionKind.Node10 },
+      ])(
+        'should default moduleResolution to %p for TypeScript $version',
+        ({ version, expectedResolution }) => {
+          const configSet = createConfigSet({ tsJestConfig: baseTsJestConfig })
+          const emptyFile = join(mockFolder, 'empty.ts')
+          configSet.parsedTsConfig.fileNames.push(emptyFile)
+          const compiler = new TsCompiler(configSet, new Map())
+          // @ts-expect-error testing purpose
+          const originalVersion = compiler._ts.version
+          // @ts-expect-error testing purpose
+          compiler._ts.version = version
+          // @ts-expect-error testing purpose
+          compiler._languageService.getEmitOutput = jest.fn().mockReturnValueOnce({
+            outputFiles: [{ text: sourceMap }, { text: jsOutput }],
+            emitSkipped: false,
+          } as ts.EmitOutput)
+          // @ts-expect-error testing purpose
+          compiler.getDiagnostics = jest.fn().mockReturnValue([])
+
+          try {
+            compiler.getCompiledOutput(fileContent, fileName, {
+              depGraphs: new Map(),
+              supportsStaticESM: false,
+              watchMode: false,
+            })
+
+            // @ts-expect-error testing purpose
+            const usedCompilerOptions = compiler._compilerOptions
+            expect(usedCompilerOptions.moduleResolution).toBe(expectedResolution)
+          } finally {
+            // @ts-expect-error testing purpose
+            compiler._ts.version = originalVersion
+          }
+        },
+      )
+
       test('should show a warning message and return original file content for non ts/tsx files if emitSkipped is true', () => {
         const compiler = makeCompiler({
           tsJestConfig: { ...baseTsJestConfig },

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -411,41 +411,38 @@ describe('TsCompiler', () => {
         { version: '6.0.0-dev.20251015', expectedResolution: ts.ModuleResolutionKind.Bundler },
         { version: '5.9.3', expectedResolution: ts.ModuleResolutionKind.Node10 },
         { version: '4.7.4', expectedResolution: ts.ModuleResolutionKind.Node10 },
-      ])(
-        'should default moduleResolution to %p for TypeScript $version',
-        ({ version, expectedResolution }) => {
-          const configSet = createConfigSet({ tsJestConfig: baseTsJestConfig })
-          const emptyFile = join(mockFolder, 'empty.ts')
-          configSet.parsedTsConfig.fileNames.push(emptyFile)
-          const compiler = new TsCompiler(configSet, new Map())
-          // @ts-expect-error testing purpose
-          const originalVersion = compiler._ts.version
-          // @ts-expect-error testing purpose
-          compiler._ts.version = version
-          // @ts-expect-error testing purpose
-          compiler._languageService.getEmitOutput = jest.fn().mockReturnValueOnce({
-            outputFiles: [{ text: sourceMap }, { text: jsOutput }],
-            emitSkipped: false,
-          } as ts.EmitOutput)
-          // @ts-expect-error testing purpose
-          compiler.getDiagnostics = jest.fn().mockReturnValue([])
+      ])('should default moduleResolution to %p for TypeScript $version', ({ version, expectedResolution }) => {
+        const configSet = createConfigSet({ tsJestConfig: baseTsJestConfig })
+        const emptyFile = join(mockFolder, 'empty.ts')
+        configSet.parsedTsConfig.fileNames.push(emptyFile)
+        const compiler = new TsCompiler(configSet, new Map())
+        // @ts-expect-error testing purpose
+        const originalVersion = compiler._ts.version
+        // @ts-expect-error testing purpose
+        compiler._ts.version = version
+        // @ts-expect-error testing purpose
+        compiler._languageService.getEmitOutput = jest.fn().mockReturnValueOnce({
+          outputFiles: [{ text: sourceMap }, { text: jsOutput }],
+          emitSkipped: false,
+        } as ts.EmitOutput)
+        // @ts-expect-error testing purpose
+        compiler.getDiagnostics = jest.fn().mockReturnValue([])
 
-          try {
-            compiler.getCompiledOutput(fileContent, fileName, {
-              depGraphs: new Map(),
-              supportsStaticESM: false,
-              watchMode: false,
-            })
+        try {
+          compiler.getCompiledOutput(fileContent, fileName, {
+            depGraphs: new Map(),
+            supportsStaticESM: false,
+            watchMode: false,
+          })
 
-            // @ts-expect-error testing purpose
-            const usedCompilerOptions = compiler._compilerOptions
-            expect(usedCompilerOptions.moduleResolution).toBe(expectedResolution)
-          } finally {
-            // @ts-expect-error testing purpose
-            compiler._ts.version = originalVersion
-          }
-        },
-      )
+          // @ts-expect-error testing purpose
+          const usedCompilerOptions = compiler._compilerOptions
+          expect(usedCompilerOptions.moduleResolution).toBe(expectedResolution)
+        } finally {
+          // @ts-expect-error testing purpose
+          compiler._ts.version = originalVersion
+        }
+      })
 
       test('should show a warning message and return original file content for non ts/tsx files if emitSkipped is true', () => {
         const compiler = makeCompiler({

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -337,7 +337,7 @@ describe('TsCompiler', () => {
 
           expect(usedCompilerOptions.module).toBe(expectedModule)
           expect(usedCompilerOptions.esModuleInterop).toBe(expectedEsModuleInterop)
-          expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Node10)
+          expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Bundler)
           expect(usedCompilerOptions.customConditions).toBeUndefined()
           expect(output).toEqual({
             code: updateOutput(jsOutput, fileName, sourceMap),
@@ -387,7 +387,7 @@ describe('TsCompiler', () => {
 
         expect(usedCompilerOptions.module).toBe(ts.ModuleKind.ESNext)
         expect(usedCompilerOptions.esModuleInterop).toBe(true)
-        expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Node10)
+        expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Bundler)
         expect(usedCompilerOptions.customConditions).toBeUndefined()
         expect(output).toEqual({
           code: updateOutput(jsOutput, fileName, sourceMap),

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -286,6 +286,7 @@ describe('TsCompiler', () => {
           moduleValue: 'ESNext',
           expectedModule: ts.ModuleKind.ESNext,
           expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Node10,
         },
         {
           useESM: true,
@@ -293,6 +294,7 @@ describe('TsCompiler', () => {
           moduleValue: 'ESNext',
           expectedModule: ts.ModuleKind.CommonJS,
           expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Node10,
         },
         {
           useESM: false,
@@ -300,10 +302,37 @@ describe('TsCompiler', () => {
           moduleValue: 'ESNext',
           expectedModule: ts.ModuleKind.CommonJS,
           expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Node10,
+        },
+        {
+          useESM: false,
+          supportsStaticESM: true,
+          moduleValue: 'ESNext',
+          expectedModule: ts.ModuleKind.CommonJS,
+          expectedEsModuleInterop: false,
+          mockTsVersion: '6.0.0',
+          expectedResolution: ts.ModuleResolutionKind.Bundler,
+        },
+        {
+          useESM: false,
+          supportsStaticESM: true,
+          moduleValue: 'ESNext',
+          expectedModule: ts.ModuleKind.CommonJS,
+          expectedEsModuleInterop: false,
+          mockTsVersion: '6.0.0-dev.20251015',
+          expectedResolution: ts.ModuleResolutionKind.Bundler,
         },
       ])(
         'should compile codes with useESM %p',
-        ({ useESM, supportsStaticESM, moduleValue, expectedModule, expectedEsModuleInterop }) => {
+        ({
+          useESM,
+          supportsStaticESM,
+          moduleValue,
+          expectedModule,
+          expectedEsModuleInterop,
+          mockTsVersion,
+          expectedResolution,
+        }) => {
           const configSet = createConfigSet({
             tsJestConfig: {
               ...baseTsJestConfig,
@@ -319,6 +348,12 @@ describe('TsCompiler', () => {
           configSet.parsedTsConfig.fileNames.push(emptyFile)
           const compiler = new TsCompiler(configSet, new Map())
           // @ts-expect-error testing purpose
+          const originalVersion = compiler._ts.version
+          if (mockTsVersion) {
+            // @ts-expect-error testing purpose
+            compiler._ts.version = mockTsVersion
+          }
+          // @ts-expect-error testing purpose
           compiler._languageService.getEmitOutput = jest.fn().mockReturnValueOnce({
             outputFiles: [{ text: sourceMap }, { text: jsOutput }],
             emitSkipped: false,
@@ -326,30 +361,35 @@ describe('TsCompiler', () => {
           // @ts-expect-error testing purpose
           compiler.getDiagnostics = jest.fn().mockReturnValue([])
 
-          const output = compiler.getCompiledOutput(fileContent, fileName, {
-            depGraphs: new Map(),
-            supportsStaticESM,
-            watchMode: false,
-          })
+          try {
+            const output = compiler.getCompiledOutput(fileContent, fileName, {
+              depGraphs: new Map(),
+              supportsStaticESM,
+              watchMode: false,
+            })
 
-          // @ts-expect-error testing purpose
-          const usedCompilerOptions = compiler._compilerOptions
+            // @ts-expect-error testing purpose
+            const usedCompilerOptions = compiler._compilerOptions
 
-          expect(usedCompilerOptions.module).toBe(expectedModule)
-          expect(usedCompilerOptions.esModuleInterop).toBe(expectedEsModuleInterop)
-          expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Node10)
-          expect(usedCompilerOptions.customConditions).toBeUndefined()
-          expect(output).toEqual({
-            code: updateOutput(jsOutput, fileName, sourceMap),
-            diagnostics: [],
-          })
+            expect(usedCompilerOptions.module).toBe(expectedModule)
+            expect(usedCompilerOptions.esModuleInterop).toBe(expectedEsModuleInterop)
+            expect(usedCompilerOptions.moduleResolution).toBe(expectedResolution)
+            expect(usedCompilerOptions.customConditions).toBeUndefined()
+            expect(output).toEqual({
+              code: updateOutput(jsOutput, fileName, sourceMap),
+              diagnostics: [],
+            })
 
-          // @ts-expect-error testing purpose
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          compiler._languageService!.getSemanticDiagnostics(fileName)
+            // @ts-expect-error testing purpose
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            compiler._languageService!.getSemanticDiagnostics(fileName)
 
-          // @ts-expect-error testing purpose
-          expect(compiler._fileContentCache.has(emptyFile)).toBe(true)
+            // @ts-expect-error testing purpose
+            expect(compiler._fileContentCache.has(emptyFile)).toBe(true)
+          } finally {
+            // @ts-expect-error testing purpose
+            compiler._ts.version = originalVersion
+          }
         },
       )
 
@@ -403,45 +443,6 @@ describe('TsCompiler', () => {
 
         // @ts-expect-error testing purpose
         expect(compiler._fileContentCache.has(emptyFile)).toBe(true)
-      })
-
-      test.each([
-        { version: '6.0.0', expectedResolution: ts.ModuleResolutionKind.Bundler },
-        { version: '6.1.2', expectedResolution: ts.ModuleResolutionKind.Bundler },
-        { version: '6.0.0-dev.20251015', expectedResolution: ts.ModuleResolutionKind.Bundler },
-        { version: '5.9.3', expectedResolution: ts.ModuleResolutionKind.Node10 },
-        { version: '4.7.4', expectedResolution: ts.ModuleResolutionKind.Node10 },
-      ])('should default moduleResolution to %p for TypeScript $version', ({ version, expectedResolution }) => {
-        const configSet = createConfigSet({ tsJestConfig: baseTsJestConfig })
-        const emptyFile = join(mockFolder, 'empty.ts')
-        configSet.parsedTsConfig.fileNames.push(emptyFile)
-        const compiler = new TsCompiler(configSet, new Map())
-        // @ts-expect-error testing purpose
-        const originalVersion = compiler._ts.version
-        // @ts-expect-error testing purpose
-        compiler._ts.version = version
-        // @ts-expect-error testing purpose
-        compiler._languageService.getEmitOutput = jest.fn().mockReturnValueOnce({
-          outputFiles: [{ text: sourceMap }, { text: jsOutput }],
-          emitSkipped: false,
-        } as ts.EmitOutput)
-        // @ts-expect-error testing purpose
-        compiler.getDiagnostics = jest.fn().mockReturnValue([])
-
-        try {
-          compiler.getCompiledOutput(fileContent, fileName, {
-            depGraphs: new Map(),
-            supportsStaticESM: false,
-            watchMode: false,
-          })
-
-          // @ts-expect-error testing purpose
-          const usedCompilerOptions = compiler._compilerOptions
-          expect(usedCompilerOptions.moduleResolution).toBe(expectedResolution)
-        } finally {
-          // @ts-expect-error testing purpose
-          compiler._ts.version = originalVersion
-        }
       })
 
       test('should show a warning message and return original file content for non ts/tsx files if emitSkipped is true', () => {

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -159,15 +159,17 @@ export class TsCompiler implements TsCompilerInstance {
 
   private fixupCompilerOptionsForModuleKind(compilerOptions: CompilerOptions, isEsm: boolean): CompilerOptions {
     /**
-     * `Bundler` is the most permissive resolution kind and is compatible with both `module: CommonJS`
-     * (forced below for the non-ESM path) and `module: ESNext`. `Node10` (and its TS 4.x alias `NodeJs`)
-     * is deprecated in TypeScript 6.0 and emits TS5107 even when the user's tsconfig is on `bundler`.
-     * Falling back through the chain keeps TS 4.x callers working since `Bundler` was added in TS 5.0.
+     * `Node10` is deprecated in TypeScript 6.0 and emits TS5107 on every test file. Switch the
+     * default to `Bundler` only under TS >= 6 — that's the version where `module: commonjs` +
+     * `moduleResolution: bundler` (the combination produced by the non-ESM path below) became
+     * a supported pairing. On TS 5.x and earlier the `Bundler` + `CommonJS` combo errors with
+     * TS5095, so keep the historical `Node10` (or its TS 4.x alias `NodeJs`) fallback there.
      */
+    const tsMajorVersion = parseInt(this._ts.version, 10)
     const moduleResolution =
-      this._ts.ModuleResolutionKind.Bundler ??
-      this._ts.ModuleResolutionKind.Node10 ??
-      this._ts.ModuleResolutionKind.NodeJs
+      tsMajorVersion >= 6
+        ? this._ts.ModuleResolutionKind.Bundler
+        : this._ts.ModuleResolutionKind.Node10 ?? this._ts.ModuleResolutionKind.NodeJs
     if (!isEsm) {
       return {
         ...compilerOptions,

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -158,7 +158,16 @@ export class TsCompiler implements TsCompilerInstance {
   }
 
   private fixupCompilerOptionsForModuleKind(compilerOptions: CompilerOptions, isEsm: boolean): CompilerOptions {
-    const moduleResolution = this._ts.ModuleResolutionKind.Node10 ?? this._ts.ModuleResolutionKind.NodeJs
+    /**
+     * `Bundler` is the most permissive resolution kind and is compatible with both `module: CommonJS`
+     * (forced below for the non-ESM path) and `module: ESNext`. `Node10` (and its TS 4.x alias `NodeJs`)
+     * is deprecated in TypeScript 6.0 and emits TS5107 even when the user's tsconfig is on `bundler`.
+     * Falling back through the chain keeps TS 4.x callers working since `Bundler` was added in TS 5.0.
+     */
+    const moduleResolution =
+      this._ts.ModuleResolutionKind.Bundler ??
+      this._ts.ModuleResolutionKind.Node10 ??
+      this._ts.ModuleResolutionKind.NodeJs
     if (!isEsm) {
       return {
         ...compilerOptions,


### PR DESCRIPTION
## Summary

`fixupCompilerOptionsForModuleKind` in `src/legacy/compiler/ts-compiler.ts` hardcodes the override of `moduleResolution` to `Node10`. Under TypeScript 6.0 this triggers TS5107 (`Option 'moduleResolution=node10' is deprecated`) for every test file, even when the consuming project's tsconfig is on `bundler` or `node16`. Users currently work around it with `diagnostics.ignoreCodes: [5107]`.

This PR switches the override to default to `Bundler` **only on TypeScript 6.0+**, where `module: commonjs` + `moduleResolution: bundler` became an officially supported pairing. On TypeScript 5.x and earlier the historical `Node10` (or its TS 4.x alias `NodeJs`) default is preserved, since `Bundler` + `CommonJS` errors with TS5095 there.

```ts
const tsMajorVersion = parseInt(this._ts.version, 10)
const moduleResolution =
  tsMajorVersion >= 6
    ? this._ts.ModuleResolutionKind.Bundler
    : this._ts.ModuleResolutionKind.Node10 ?? this._ts.ModuleResolutionKind.NodeJs
```

### Why a runtime version check (and not a chain fallback)

The first version of this PR used `Bundler ?? Node10 ?? NodeJs`. It broke ts-jest's own e2e suite under the dev-dep TypeScript 5.9.3:

```
error TS5095: Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later.
```

The failure mode isn't enum availability (`Bundler` has existed from TS 5.0); it's **pairing validity**. ts-jest's non-ESM path forces `module: CommonJS`, and TS 5.x rejects `CommonJS` + `Bundler` regardless of how the value is selected. TS 6.0 lifts that restriction. A version gate is the minimal way to express "use Bundler only where the pairing is supported".

### Behavior matrix

| TS version | Override result | Notes |
|---|---|---|
| 4.x | `NodeJs` | Unchanged — `Node10` is undefined, falls through. |
| 5.x | `Node10` | Unchanged — historical default, no behavior change. |
| 6.0+ | `Bundler` | Fixes TS5107; uses the now-supported `commonjs` + `bundler` pairing. |

### Relationship to #4198

Refs #4198. That issue's stated expectation is *"I would expect that `module` is not changed."* — i.e., `ts-jest` should stop overriding the user's `module` to `CommonJS` in the non-ESM path. **This PR does not do that.** It only changes the *companion* `moduleResolution` override so the override pair is valid (and non-deprecated) under TS 6, eliminating the TS5107 emission that originally led people to file and pile onto #4198 after upgrading TypeScript. Honouring the user's `module` value is a deeper refactor (also affects the language-service path and ESM detection) and is out of scope here.

If the maintainers prefer, happy to change the reference to "Closes" only after a follow-up PR addresses the `module` override; for now leaving as a soft `Refs`.

## Changes

- `src/legacy/compiler/ts-compiler.ts` — version-conditional `moduleResolution` override; updated comment.
- `src/legacy/compiler/ts-compiler.spec.ts` — extended the existing `should compile codes with useESM %p` `test.each` block with TS 6 rows (mocking `_ts.version`) so both branches of the new conditional are covered. No standalone test added.

## Test plan

- [x] `npx jest -c=jest.config.ts src/legacy/compiler/ts-compiler.spec.ts` — 37/37 pass.
- [x] `npx jest -c=jest.config.ts` — full unit suite, 276/276 pass across 20 suites.
- [x] `npm run test-e2e-cjs` — 21/21 suites, 27/27 tests pass (was 10 fail / 11 pass under the chain-fallback approach).
- [x] `npm run test-e2e-esm` — 21/21 suites, 29/29 tests pass.
- [x] `npx tsc -p tsconfig.build.json` — clean build.

## Compatibility

- Peer range (`typescript >=4.3 <7`) unchanged.
- `parseInt(ts.version, 10)` handles all observed version strings: `"5.9.3"`, `"6.0.0"`, `"6.0.0-dev.20251015"` all yield the correct major version.
- No public API change.

## CI note (sonar-scan)

The `sonar-scan` check is failing with `Project not found ... or contact the project administrator to check the permissions of the user the token belongs to`. This is the standard SonarCloud + fork-PR limitation: GitHub Actions does not expose `SONAR_TOKEN` to workflow runs triggered by PRs from forks (security boundary). The first line of that job's log already warns *"Running this GitHub Action without SONAR_TOKEN is not recommended"*. Nothing in this diff causes it; the standard repo-side fix would be to switch the trigger to `pull_request_target` or run Sonar in a maintainer-gated separate workflow.