### PR TITLE
fix(compiler): honour user's moduleResolution instead of forcing Node10

### DIFF
--- a/e2e/tsconfig-cjs.spec.json
+++ b/e2e/tsconfig-cjs.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "moduleResolution": "Node10"
   }
 }

--- a/e2e/tsconfig-esm.spec.json
+++ b/e2e/tsconfig-esm.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "module": "ESNext"
+    "module": "ESNext",
+    "moduleResolution": "Node10"
   }
 }

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -281,40 +281,105 @@ describe('TsCompiler', () => {
 
       test.each([
         {
+          useESM: false,
+          supportsStaticESM: true,
+          moduleValue: 'ESNext',
+          moduleResolutionValue: undefined,
+          expectedModule: ts.ModuleKind.CommonJS,
+          expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Node10,
+        },
+        {
           useESM: true,
           supportsStaticESM: true,
           moduleValue: 'ESNext',
+          moduleResolutionValue: 'Node10',
           expectedModule: ts.ModuleKind.ESNext,
           expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Node10,
         },
         {
           useESM: true,
           supportsStaticESM: false,
           moduleValue: 'ESNext',
+          moduleResolutionValue: 'Node10',
           expectedModule: ts.ModuleKind.CommonJS,
           expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Node10,
         },
         {
           useESM: false,
           supportsStaticESM: true,
           moduleValue: 'ESNext',
+          moduleResolutionValue: 'Node10',
           expectedModule: ts.ModuleKind.CommonJS,
           expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Node10,
+        },
+        {
+          useESM: false,
+          supportsStaticESM: true,
+          moduleValue: 'ESNext',
+          moduleResolutionValue: 'Bundler',
+          expectedModule: ts.ModuleKind.CommonJS,
+          expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Bundler,
+        },
+        {
+          useESM: true,
+          supportsStaticESM: true,
+          moduleValue: 'ESNext',
+          moduleResolutionValue: 'Node16',
+          expectedModule: ts.ModuleKind.ESNext,
+          expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Node16,
+        },
+        {
+          useESM: true,
+          supportsStaticESM: true,
+          moduleValue: 'ESNext',
+          moduleResolutionValue: 'NodeNext',
+          expectedModule: ts.ModuleKind.ESNext,
+          expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.NodeNext,
+        },
+        {
+          useESM: false,
+          supportsStaticESM: true,
+          moduleValue: 'ESNext',
+          moduleResolutionValue: 'Classic',
+          expectedModule: ts.ModuleKind.CommonJS,
+          expectedEsModuleInterop: false,
+          expectedResolution: ts.ModuleResolutionKind.Classic,
         },
       ])(
-        'should compile codes with useESM %p',
-        ({ useESM, supportsStaticESM, moduleValue, expectedModule, expectedEsModuleInterop }) => {
+        'should preserve user-specified moduleResolution %p with useESM %p',
+        ({
+          useESM,
+          supportsStaticESM,
+          moduleValue,
+          moduleResolutionValue,
+          expectedModule,
+          expectedEsModuleInterop,
+          expectedResolution,
+        }) => {
           const configSet = createConfigSet({
             tsJestConfig: {
               ...baseTsJestConfig,
               useESM,
               tsconfig: {
                 module: moduleValue as TsConfigJson.CompilerOptions['module'],
+                moduleResolution: moduleResolutionValue as TsConfigJson.CompilerOptions['moduleResolution'],
                 esModuleInterop: false,
                 customConditions: ['my-condition'],
               },
             },
           })
+          if (moduleResolutionValue === undefined) {
+            // The cwd tsconfig leaks `moduleResolution: Bundler` into the parsed config; clear it
+            // so this row exercises the "user did not specify moduleResolution" fallback path.
+            configSet.parsedTsConfig.options.moduleResolution = undefined
+          }
           const emptyFile = join(mockFolder, 'empty.ts')
           configSet.parsedTsConfig.fileNames.push(emptyFile)
           const compiler = new TsCompiler(configSet, new Map())
@@ -337,7 +402,7 @@ describe('TsCompiler', () => {
 
           expect(usedCompilerOptions.module).toBe(expectedModule)
           expect(usedCompilerOptions.esModuleInterop).toBe(expectedEsModuleInterop)
-          expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Node10)
+          expect(usedCompilerOptions.moduleResolution).toBe(expectedResolution)
           expect(usedCompilerOptions.customConditions).toBeUndefined()
           expect(output).toEqual({
             code: updateOutput(jsOutput, fileName, sourceMap),
@@ -360,6 +425,7 @@ describe('TsCompiler', () => {
             useESM: true,
             tsconfig: {
               module: 'NodeNext',
+              moduleResolution: 'NodeNext',
               esModuleInterop: false,
               customConditions: ['my-condition'],
             },
@@ -387,7 +453,7 @@ describe('TsCompiler', () => {
 
         expect(usedCompilerOptions.module).toBe(ts.ModuleKind.ESNext)
         expect(usedCompilerOptions.esModuleInterop).toBe(true)
-        expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.Node10)
+        expect(usedCompilerOptions.moduleResolution).toBe(ts.ModuleResolutionKind.NodeNext)
         expect(usedCompilerOptions.customConditions).toBeUndefined()
         expect(output).toEqual({
           code: updateOutput(jsOutput, fileName, sourceMap),

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -158,7 +158,15 @@ export class TsCompiler implements TsCompilerInstance {
   }
 
   private fixupCompilerOptionsForModuleKind(compilerOptions: CompilerOptions, isEsm: boolean): CompilerOptions {
-    const moduleResolution = this._ts.ModuleResolutionKind.Node10 ?? this._ts.ModuleResolutionKind.NodeJs
+    /**
+     * Respect the user's explicit `moduleResolution` instead of always overriding to `Node10`. The
+     * historical hardcoded override silently clobbers `bundler` / `node16` / `nodenext` users
+     * (#4198) and emits TS5107 under TypeScript 6.0 because `Node10` is deprecated. Falling back to
+     * `Node10` (or its TS 4.x alias `NodeJs`) only when the user did not specify one preserves the
+     * historical default for unconfigured projects.
+     */
+    const moduleResolution =
+      compilerOptions.moduleResolution ?? this._ts.ModuleResolutionKind.Node10 ?? this._ts.ModuleResolutionKind.NodeJs
     if (!isEsm) {
       return {
         ...compilerOptions,


### PR DESCRIPTION
## Summary

`fixupCompilerOptionsForModuleKind` in `src/legacy/compiler/ts-compiler.ts` hardcoded the override of `moduleResolution` to `Node10`. That override silently clobbers users who explicitly set `bundler` / `node16` / `nodenext` (the OP scenario in #4198) and additionally emits TS5107 under TypeScript 6.0 because `Node10` is deprecated.

This PR replaces the hardcode with a respect-the-user shape:

```ts
const moduleResolution =
  compilerOptions.moduleResolution ??
  this._ts.ModuleResolutionKind.Node10 ??
  this._ts.ModuleResolutionKind.NodeJs
```

- If the user has set `moduleResolution` in their tsconfig, it flows through unchanged.
- If they haven't, the override falls back to `Node10` (or its TS 4.x alias `NodeJs`) — preserving the historical default for unconfigured projects.

## Why this shape (vs. simply switching the default to `Bundler`)

[A previous PR #5273](https://github.com/kulshekhar/ts-jest/pull/5273) tried switching the *default* override to `Bundler` (gated on TypeScript ≥ 6). Reviewer feedback on that PR was that the change was too broad — eliminating the deprecation warning isn't sufficient justification for changing the override choice for everyone, especially when `Bundler` resolution can semantically diverge from Jest's runtime resolver (which is Node10-style through Jest 29). That feedback is what motivated this narrower shape: **don't change the default; just stop overriding what the user explicitly set**. The OP scenario is fixed because their `node16` setting now flows through.

Closing #5273 in favour of this PR.

## Behaviour matrix

| User's `moduleResolution` | Old behaviour | New behaviour |
|---|---|---|
| Unset | Override → `Node10` | Override → `Node10` (unchanged) |
| `node10` | Override → `Node10` | Override → `Node10` (unchanged) |
| `bundler` | Silently overridden to `Node10` | Preserved as `Bundler` |
| `node16` | Silently overridden to `Node10` (causes TS5110 on TS 5+) | Preserved as `Node16` |
| `nodenext` | Silently overridden to `Node10` | Preserved as `NodeNext` |
| `classic` | Silently overridden to `Node10` | Preserved as `Classic` |

## Spec changes

- Extended the existing `'should compile codes with useESM %p'` `test.each` so each row sets `moduleResolution` explicitly and asserts it flows through. Added rows for `Node10`, `Bundler`, `Node16`, `NodeNext`, and `Classic`. The first row passes `moduleResolution: undefined` (with an explicit `parsedTsConfig.options.moduleResolution = undefined` reset to defeat the cwd-tsconfig leak) and asserts the `Node10` fallback.
- Updated the `'should compile codes for ESM mode and show warning with modern Node module'` test to also pin `moduleResolution: 'NodeNext'` so it asserts the new contract end-to-end.

## E2E fixture cleanup (necessary side-effect)

`e2e/tsconfig-cjs.spec.json` and `e2e/tsconfig-esm.spec.json` extend `../tsconfig.base.json` (which has `moduleResolution: NodeNext`) and overrode only `module`. Those fixtures relied on the production override to paper over the resulting incompatibility — without the override, the inherited `NodeNext` clashes with their own `module: CommonJS` / `module: ESNext` and trips TS5110.

I made the two root fixtures self-consistent by pinning `moduleResolution: Node10`, paired with the `module` they already set. No production-source change in this hunk; it only fixes a latent inconsistency that was previously masked.

Other e2e fixtures (transformer-options/, hoist-jest/, transform-js/, etc.) chain through these two roots and inherit the fix automatically — no per-fixture changes needed.

## Test plan

- [x] `npx jest -c=jest.config.ts src/legacy/compiler/ts-compiler.spec.ts` — 40/40 pass.
- [x] `npx jest -c=jest.config.ts` — full unit suite, 279/279 pass across 20 suites.
- [x] `npm run test-e2e-cjs` — 21/21 suites, 27/27 tests pass.
- [x] `npm run test-e2e-esm` — 21/21 suites, 29/29 tests pass.
- [x] `npx tsc -p tsconfig.build.json` — clean build.
- [x] `npx prettier --check` and `npx eslint` clean on the four files this PR touches.

## Compatibility

- Peer range (`typescript >=4.3 <7`) unchanged.
- Behaviour change is **additive**: only takes effect when the user has set `moduleResolution` themselves. Users who haven't are byte-identical to today.
- No public API change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Module resolution configuration is now preserved when explicitly set, preventing the compiler from overwriting user-provided settings.

* **Tests**
  * Extended test coverage for module resolution configuration handling across different resolution strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->