### PR TITLE
refactor: address PR #5285 review feedback

### DIFF
--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -102,46 +102,29 @@ describe('TsCompiler', () => {
     })
   })
 
-  // Closes #4221: `_resolveModuleName` previously invoked
-  // `ts.resolveModuleName` with five arguments, omitting the optional
-  // 7th `resolutionMode` parameter that tells TypeScript whether the
-  // importing file is in CJS or ESM context. That parameter is what
-  // selects `import` vs `require` `exports` conditions for hybrid
-  // packages (the `.d.mts` vs `.d.cts` mismatch reported in the issue).
-  // `tsc` itself derives this via `ts.getImpliedNodeFormatForFile`;
-  // these tests pin that ts-jest mirrors that derivation, with a
-  // graceful fallback for TypeScript versions that predate the helper
-  // (TS < 4.5).
   describe('_resolveModuleName', () => {
     const fileName = join(mockFolder, 'thing.ts')
 
-    /**
-     * Build a TsCompiler with `_ts` replaced by a fresh shallow-copied
-     * proxy of the real TypeScript module. Mutations to the proxy stay
-     * isolated to the compiler instance under test — the underlying `ts`
-     * module is never modified, so test order cannot silently weaken
-     * later tests in this describe block (notably the TS < 4.5
-     * simulation that needs to set `getImpliedNodeFormatForFile` to
-     * `undefined`).
-     */
     function buildCompilerWithResolverSpies(): {
       compiler: TsCompiler
       resolveSpy: jest.Mock
-      getImpliedSpy: jest.Mock | undefined
+      getImpliedSpy: jest.Mock
     } {
+      if (typeof ts.getImpliedNodeFormatForFile !== 'function') {
+        throw new Error(
+          'ts.getImpliedNodeFormatForFile is required for these tests; the dev TypeScript version must be >= 4.5',
+        )
+      }
       const compiler = makeCompiler({ tsJestConfig: baseTsJestConfig })
       const resolveSpy = jest.fn().mockReturnValue({
         resolvedModule: undefined,
         failedLookupLocations: [],
       } as unknown as ts.ResolvedModuleWithFailedLookupLocations)
-      const getImpliedSpy =
-        typeof ts.getImpliedNodeFormatForFile === 'function'
-          ? (jest.fn(ts.getImpliedNodeFormatForFile) as unknown as jest.Mock)
-          : undefined
+      const getImpliedSpy = jest.fn(ts.getImpliedNodeFormatForFile) as unknown as jest.Mock
       const tsProxy = {
         ...ts,
         resolveModuleName: resolveSpy,
-        getImpliedNodeFormatForFile: getImpliedSpy ?? ts.getImpliedNodeFormatForFile,
+        getImpliedNodeFormatForFile: getImpliedSpy,
       } as unknown as typeof ts
       // @ts-expect-error testing purpose: replace the ts reference on this compiler instance only
       compiler._ts = tsProxy
@@ -151,9 +134,6 @@ describe('TsCompiler', () => {
 
     test('passes the resolutionMode argument from getImpliedNodeFormatForFile to resolveModuleName', () => {
       const { compiler, resolveSpy, getImpliedSpy } = buildCompilerWithResolverSpies()
-      // Skip on TypeScript < 4.5 — the helper isn't available there and
-      // the fallback is covered by a separate test below.
-      if (!getImpliedSpy) return
       const fakeMode = ts.ModuleKind.ESNext
       getImpliedSpy.mockReturnValue(fakeMode)
 
@@ -162,24 +142,17 @@ describe('TsCompiler', () => {
 
       expect(resolveSpy).toHaveBeenCalledTimes(1)
       const call = resolveSpy.mock.calls[0]
-      // 7-arg signature: moduleName, containingFile, options, host,
-      // cache, redirectedReference, resolutionMode.
       expect(call).toHaveLength(7)
       expect(call[0]).toBe('lodash')
       expect(call[1]).toBe(fileName)
-      expect(call[5]).toBeUndefined() // redirectedReference
-      expect(call[6]).toBe(fakeMode) // resolutionMode (the bug fix)
+      expect(call[5]).toBeUndefined()
+      expect(call[6]).toBe(fakeMode)
     })
 
     test('calls getImpliedNodeFormatForFile with the importing file, host, and compiler options', () => {
       const { compiler, getImpliedSpy } = buildCompilerWithResolverSpies()
-      if (!getImpliedSpy) return
       getImpliedSpy.mockReturnValue(ts.ModuleKind.ESNext)
-
-      // Reset before the action — TypeScript's language service calls
-      // `getImpliedNodeFormatForFile` internally many times during
-      // compiler construction; we only care about the single call our
-      // `_resolveModuleName` makes for the importing file under test.
+      // Clear calls made by the language service during compiler construction.
       getImpliedSpy.mockClear()
 
       // @ts-expect-error testing purpose: invoking a private method directly
@@ -189,10 +162,7 @@ describe('TsCompiler', () => {
       expect(callsForOurFile).toHaveLength(1)
       const call = callsForOurFile[0]
       expect(call[0]).toBe(fileName)
-      // packageJsonInfoCache is intentionally undefined — ts-jest does not
-      // maintain its own cache for this lookup; TypeScript's resolver does.
       expect(call[1]).toBeUndefined()
-      // host + options are passed through.
       expect(call[2]).toBeDefined()
       expect(call[3]).toBeDefined()
     })
@@ -203,9 +173,6 @@ describe('TsCompiler', () => {
         resolvedModule: undefined,
         failedLookupLocations: [],
       } as unknown as ts.ResolvedModuleWithFailedLookupLocations)
-      // Simulate TS < 4.5 by handing the compiler a ts-like proxy whose
-      // `getImpliedNodeFormatForFile` is `undefined`. The real `ts`
-      // module is untouched — mutations here cannot leak to other tests.
       const tsProxyWithoutHelper = {
         ...ts,
         resolveModuleName: resolveSpy,
@@ -219,10 +186,6 @@ describe('TsCompiler', () => {
 
       expect(resolveSpy).toHaveBeenCalledTimes(1)
       const call = resolveSpy.mock.calls[0]
-      // Still pass 7 arguments so the call shape is consistent across
-      // TypeScript versions; the 7th is `undefined` when the helper is
-      // missing, which TypeScript treats the same as the historical
-      // 5-arg invocation (no mode hint).
       expect(call).toHaveLength(7)
       expect(call[6]).toBeUndefined()
     })
@@ -234,7 +197,6 @@ describe('TsCompiler', () => {
       'derives resolutionMode for explicit %s extension via getImpliedNodeFormatForFile',
       (containingFile, expectedMode) => {
         const { compiler, resolveSpy, getImpliedSpy } = buildCompilerWithResolverSpies()
-        if (!getImpliedSpy) return
         getImpliedSpy.mockReturnValue(expectedMode)
 
         // @ts-expect-error testing purpose

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -601,25 +601,7 @@ export class TsCompiler implements TsCompilerInstance {
   }
 
   /**
-   * Resolve a module specifier the same way `tsc` would for the importing
-   * file. The historical 5-argument call dropped the optional 7th
-   * `resolutionMode` parameter on `ts.resolveModuleName`, which is what
-   * tells TypeScript whether the importing file is in CJS or ESM context
-   * for the purpose of selecting `import` vs `require` `exports`
-   * conditions in hybrid packages — i.e., the `.d.mts` vs `.d.cts`
-   * mismatch tracked in #4221. `tsc` derives that mode via
-   * `ts.getImpliedNodeFormatForFile`; mirror it here so ts-jest's
-   * resolution matches `tsc`.
-   *
-   * `getImpliedNodeFormatForFile` was introduced in TypeScript 4.5. On
-   * older versions (ts-jest's peerDependency range goes back to 4.3) the
-   * helper is `undefined` at runtime; in that case we pass `undefined`
-   * for `resolutionMode`, which TypeScript treats the same as the
-   * historical no-mode behavior — so the fix is strictly additive across
-   * the supported TypeScript range.
-   *
    * @internal
-   * @see https://github.com/kulshekhar/ts-jest/issues/4221
    */
   private _resolveModuleName(
     moduleNameToResolve: string,


### PR DESCRIPTION
## Summary

Pure cleanup PR — addresses the four review comments @ahnpnl left on
#5285 after merge. No behavior change.

#5285 shipped the fix for #4221 (passing `resolutionMode` to
`ts.resolveModuleName`), but the diff was approved + merged before
@ahnpnl's review pass landed. This PR applies that feedback so the
final state in `main` reflects the requested style.

## Changes

| ahnpnl comment | Action |
|---|---|
| `spec.ts:105` — *"the comment block here can be removed, the test should be descriptive"* | Removed the `describe('_resolveModuleName')` preamble. The four test names speak for themselves. |
| `spec.ts:118` — *"This comment block can be removed too"* | Removed the TSDoc on `buildCompilerWithResolverSpies`. |
| `spec.ts:156` — *"Test case shouldn't use `if`. The function to build compiler should ensure the variables are always defined"* | Made `buildCompilerWithResolverSpies` throw if `ts.getImpliedNodeFormatForFile` is unavailable, narrowed `getImpliedSpy` return type to `jest.Mock` (no `\| undefined`), and removed the three `if (!getImpliedSpy) return` early-skips. |
| `ts-compiler.ts:452` — *"We should move this comment to git commit body"* | Stripped the multi-paragraph TSDoc down to the `@internal` convention used by every other private method in `TsCompiler`. The rationale already lives in the merged commit `b557a85`. |

The TS < 4.5 fallback test (test 3) builds its own proxy with
`getImpliedNodeFormatForFile: undefined` directly, so the new
"throw if missing" guard in the shared helper does not affect it.

## Verification

| Stage | Result |
|---|---|
| `npm test` | 346 / 346 passed (20 suites) |
| `npm run test-e2e-cjs` | 27 / 27 passed (21 projects) |
| `npm run test-e2e-esm` | 29 / 29 passed (21 projects) |
| `npm run lint` | 0 errors |
| `npm run lint-prettier-ci` | clean |

## Refs

Follow-up to #5285 (refs #4221).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test coverage for TypeScript 4.5+ module resolution validation.
  * Strengthened test assertions for module resolution parameter handling.

* **Documentation**
  * Updated internal JSDoc comments for better code documentation.

**Note:** This release contains internal testing and documentation improvements with no end-user visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->