### PR TITLE
fix: rebuild Program when consecutive compiles need different module kinds

### DIFF
--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -1154,6 +1154,86 @@ describe('TsCompiler', () => {
           ),
         )
       })
+
+      describe('cross-compile module kind tracking', () => {
+        const targetFile = join(mockFolder, 'thing.ts')
+        const otherFile = join(mockFolder, 'thing1.ts')
+        const stubbedEmit = {
+          outputFiles: [{ text: sourceMap }, { text: jsOutput }],
+          emitSkipped: false,
+        } as ts.EmitOutput
+
+        function buildCompiler(): TsCompiler {
+          const configSet = createConfigSet({
+            tsJestConfig: {
+              ...baseTsJestConfig,
+              useESM: true,
+              tsconfig: { module: 'ESNext' } as TsConfigJson,
+            },
+          })
+          configSet.parsedTsConfig.fileNames.push(targetFile)
+          const compiler = new TsCompiler(configSet, new Map())
+          // @ts-expect-error testing purpose
+          compiler._languageService.getEmitOutput = jest.fn().mockReturnValue(stubbedEmit)
+          // @ts-expect-error testing purpose
+          compiler.getDiagnostics = jest.fn().mockReturnValue([])
+          // Overwrite the disk-loaded snapshot for `targetFile` so the second
+          // compile's content matches the cache and the content-mismatch bump
+          // path of `_updateMemoryCache` does not fire — leaving the new
+          // module-kind-change tracking as the sole bump trigger under test.
+          // @ts-expect-error testing purpose
+          compiler._fileContentCache.set(targetFile, fileContent)
+          // @ts-expect-error testing purpose
+          compiler._fileVersionCache.set(targetFile, 1)
+
+          return compiler
+        }
+
+        test('should bump project version when consecutive compiles have different module kinds', () => {
+          const compiler = buildCompiler()
+          // First compile: a CJS-context file (supportsStaticESM=false forces
+          // the runtime module kind to CommonJS).
+          compiler.getCompiledOutput('const a = 1', otherFile, {
+            depGraphs: new Map(),
+            supportsStaticESM: false,
+            watchMode: false,
+          })
+          // @ts-expect-error testing purpose
+          const versionAfterFirstCompile = compiler._projectVersion
+
+          // Second compile: the target file in ESM context. Its caches and the
+          // tsconfig file list are seeded so the only bump trigger that can
+          // fire is the new module-kind-change tracking.
+          compiler.getCompiledOutput(fileContent, targetFile, {
+            depGraphs: new Map(),
+            supportsStaticESM: true,
+            watchMode: false,
+          })
+
+          // @ts-expect-error testing purpose
+          expect(compiler._projectVersion).toBeGreaterThan(versionAfterFirstCompile)
+        })
+
+        test('should not bump project version when consecutive compiles share the same module kind', () => {
+          const compiler = buildCompiler()
+          compiler.getCompiledOutput(fileContent, targetFile, {
+            depGraphs: new Map(),
+            supportsStaticESM: true,
+            watchMode: false,
+          })
+          // @ts-expect-error testing purpose
+          const versionAfterFirstCompile = compiler._projectVersion
+
+          compiler.getCompiledOutput(fileContent, targetFile, {
+            depGraphs: new Map(),
+            supportsStaticESM: true,
+            watchMode: false,
+          })
+
+          // @ts-expect-error testing purpose
+          expect(compiler._projectVersion).toBe(versionAfterFirstCompile)
+        })
+      })
     })
   })
 

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -1162,10 +1162,6 @@ describe('TsCompiler', () => {
           outputFiles: [{ text: sourceMap }, { text: jsOutput }],
           emitSkipped: false,
         } as ts.EmitOutput
-        // With `useESM: true` and `tsconfig.module: 'ESNext'`, `supportsStaticESM`
-        // toggles the per-compile module kind: false → CommonJS, true → ESNext.
-        const cjsCompileOptions = { depGraphs: new Map(), supportsStaticESM: false, watchMode: false }
-        const esmCompileOptions = { depGraphs: new Map(), supportsStaticESM: true, watchMode: false }
 
         function buildCompiler(): TsCompiler {
           const configSet = createConfigSet({
@@ -1192,13 +1188,21 @@ describe('TsCompiler', () => {
 
         test('should bump project version when consecutive compiles produce different module kinds', () => {
           const compiler = buildCompiler()
-          compiler.getCompiledOutput('const a = 1', otherFile, cjsCompileOptions)
+          compiler.getCompiledOutput('const a = 1', otherFile, {
+            depGraphs: new Map(),
+            supportsStaticESM: false,
+            watchMode: false,
+          })
           // @ts-expect-error testing purpose
           expect(compiler._compilerOptions.module).toBe(ts.ModuleKind.CommonJS)
           // @ts-expect-error testing purpose
           const versionAfterFirstCompile = compiler._projectVersion
 
-          compiler.getCompiledOutput(fileContent, targetFile, esmCompileOptions)
+          compiler.getCompiledOutput(fileContent, targetFile, {
+            depGraphs: new Map(),
+            supportsStaticESM: true,
+            watchMode: false,
+          })
           // @ts-expect-error testing purpose
           expect(compiler._compilerOptions.module).toBe(ts.ModuleKind.ESNext)
 
@@ -1208,13 +1212,21 @@ describe('TsCompiler', () => {
 
         test('should not bump project version when consecutive compiles share the same module kind', () => {
           const compiler = buildCompiler()
-          compiler.getCompiledOutput(fileContent, targetFile, esmCompileOptions)
+          compiler.getCompiledOutput(fileContent, targetFile, {
+            depGraphs: new Map(),
+            supportsStaticESM: true,
+            watchMode: false,
+          })
           // @ts-expect-error testing purpose
           expect(compiler._compilerOptions.module).toBe(ts.ModuleKind.ESNext)
           // @ts-expect-error testing purpose
           const versionAfterFirstCompile = compiler._projectVersion
 
-          compiler.getCompiledOutput(fileContent, targetFile, esmCompileOptions)
+          compiler.getCompiledOutput(fileContent, targetFile, {
+            depGraphs: new Map(),
+            supportsStaticESM: true,
+            watchMode: false,
+          })
           // @ts-expect-error testing purpose
           expect(compiler._compilerOptions.module).toBe(ts.ModuleKind.ESNext)
 

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -1162,6 +1162,10 @@ describe('TsCompiler', () => {
           outputFiles: [{ text: sourceMap }, { text: jsOutput }],
           emitSkipped: false,
         } as ts.EmitOutput
+        // With `useESM: true` and `tsconfig.module: 'ESNext'`, `supportsStaticESM`
+        // toggles the per-compile module kind: false → CommonJS, true → ESNext.
+        const cjsCompileOptions = { depGraphs: new Map(), supportsStaticESM: false, watchMode: false }
+        const esmCompileOptions = { depGraphs: new Map(), supportsStaticESM: true, watchMode: false }
 
         function buildCompiler(): TsCompiler {
           const configSet = createConfigSet({
@@ -1177,10 +1181,7 @@ describe('TsCompiler', () => {
           compiler._languageService.getEmitOutput = jest.fn().mockReturnValue(stubbedEmit)
           // @ts-expect-error testing purpose
           compiler.getDiagnostics = jest.fn().mockReturnValue([])
-          // Overwrite the disk-loaded snapshot for `targetFile` so the second
-          // compile's content matches the cache and the content-mismatch bump
-          // path of `_updateMemoryCache` does not fire — leaving the new
-          // module-kind-change tracking as the sole bump trigger under test.
+          // Pre-seed so the only bump trigger left is the module-kind-change check.
           // @ts-expect-error testing purpose
           compiler._fileContentCache.set(targetFile, fileContent)
           // @ts-expect-error testing purpose
@@ -1189,26 +1190,17 @@ describe('TsCompiler', () => {
           return compiler
         }
 
-        test('should bump project version when consecutive compiles have different module kinds', () => {
+        test('should bump project version when consecutive compiles produce different module kinds', () => {
           const compiler = buildCompiler()
-          // First compile: a CJS-context file (supportsStaticESM=false forces
-          // the runtime module kind to CommonJS).
-          compiler.getCompiledOutput('const a = 1', otherFile, {
-            depGraphs: new Map(),
-            supportsStaticESM: false,
-            watchMode: false,
-          })
+          compiler.getCompiledOutput('const a = 1', otherFile, cjsCompileOptions)
+          // @ts-expect-error testing purpose
+          expect(compiler._compilerOptions.module).toBe(ts.ModuleKind.CommonJS)
           // @ts-expect-error testing purpose
           const versionAfterFirstCompile = compiler._projectVersion
 
-          // Second compile: the target file in ESM context. Its caches and the
-          // tsconfig file list are seeded so the only bump trigger that can
-          // fire is the new module-kind-change tracking.
-          compiler.getCompiledOutput(fileContent, targetFile, {
-            depGraphs: new Map(),
-            supportsStaticESM: true,
-            watchMode: false,
-          })
+          compiler.getCompiledOutput(fileContent, targetFile, esmCompileOptions)
+          // @ts-expect-error testing purpose
+          expect(compiler._compilerOptions.module).toBe(ts.ModuleKind.ESNext)
 
           // @ts-expect-error testing purpose
           expect(compiler._projectVersion).toBeGreaterThan(versionAfterFirstCompile)
@@ -1216,19 +1208,15 @@ describe('TsCompiler', () => {
 
         test('should not bump project version when consecutive compiles share the same module kind', () => {
           const compiler = buildCompiler()
-          compiler.getCompiledOutput(fileContent, targetFile, {
-            depGraphs: new Map(),
-            supportsStaticESM: true,
-            watchMode: false,
-          })
+          compiler.getCompiledOutput(fileContent, targetFile, esmCompileOptions)
+          // @ts-expect-error testing purpose
+          expect(compiler._compilerOptions.module).toBe(ts.ModuleKind.ESNext)
           // @ts-expect-error testing purpose
           const versionAfterFirstCompile = compiler._projectVersion
 
-          compiler.getCompiledOutput(fileContent, targetFile, {
-            depGraphs: new Map(),
-            supportsStaticESM: true,
-            watchMode: false,
-          })
+          compiler.getCompiledOutput(fileContent, targetFile, esmCompileOptions)
+          // @ts-expect-error testing purpose
+          expect(compiler._compilerOptions.module).toBe(ts.ModuleKind.ESNext)
 
           // @ts-expect-error testing purpose
           expect(compiler._projectVersion).toBe(versionAfterFirstCompile)

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -80,6 +80,10 @@ export class TsCompiler implements TsCompilerInstance {
   /**
    * @internal
    */
+  private _previousCompiledModuleKind: CompilerOptions['module']
+  /**
+   * @internal
+   */
   private _languageService: LanguageService | undefined
   /**
    * @internal
@@ -347,6 +351,11 @@ export class TsCompiler implements TsCompilerInstance {
     this._compilerOptions = this.fixupCompilerOptionsForModuleKind(this._initialCompilerOptions, isEsmMode)
     const moduleKind = this._initialCompilerOptions.module
     const currentModuleKind = this._compilerOptions.module
+    // Without this, a Program rebuilt for one compile's module kind would be
+    // reused on the next compile when that compile expects a different kind.
+    const moduleKindChangedSinceLastCompile =
+      this._previousCompiledModuleKind !== undefined && this._previousCompiledModuleKind !== currentModuleKind
+    this._previousCompiledModuleKind = currentModuleKind
     if (this._languageService) {
       if (JS_JSX_REGEX.test(fileName) && !this._compilerOptions.allowJs) {
         this._logger.warn({ fileName: fileName }, interpolate(Errors.GotJsFileButAllowJsFalse, { path: fileName }))
@@ -359,7 +368,11 @@ export class TsCompiler implements TsCompilerInstance {
       this._logger.debug({ fileName }, 'getCompiledOutput(): compiling using language service')
 
       // Must set memory cache before attempting to compile
-      this._updateMemoryCache(fileContent, fileName, currentModuleKind === moduleKind)
+      this._updateMemoryCache(
+        fileContent,
+        fileName,
+        currentModuleKind === moduleKind && !moduleKindChangedSinceLastCompile,
+      )
       const output: EmitOutput = this._languageService.getEmitOutput(fileName)
       const diagnostics = this.getDiagnostics(fileName)
       if (isModernNodeModuleKind(this._initialCompilerOptions.module)) {


### PR DESCRIPTION
## Summary

Closes #4774. When ts-jest's language-service-mode `TsCompiler` processes two
consecutive files in the same process where the first wants CJS output and
the second wants ESM (or vice versa), the cached Program from the first
compile is reused on the second — emitting the wrong module kind. The
canonical trigger in the field is Jest's mixed transform pipeline: a
CJS-context `globalSetup` file followed by an ESM-context setupFile, which
produces `ReferenceError: exports is not defined` on Linux/WSL/macOS.

Confirmed by @yegorpetrov in #4774 with debugger traces. @ahnpnl outlined the
direction of this fix in the same thread. Windows escaped the bug because
forward/back-slash mismatch between Jest-provided fileNames and
`_parsedTsConfig.fileNames` made `.includes()` return `false` on every
compile, unconditionally bumping the project version.

## Diagnosis (verified end-to-end)

I instrumented `getCompiledOutput` and `getCompilationSettings` and ran
yegorpetrov's repro repo (`yegorpetrov/ts-jest-issue-repro`, `no-eslint`
branch) against current `main`. Two compiles in the same Jest worker process:

```
[TRACE] file=jest.global-setup.ts useESM=true supportsStaticESM=false isEsmMode=false initial.module=7 current.module=1 projectVersion=1
[TRACE] file=jest.setup-files.ts  useESM=true supportsStaticESM=true  isEsmMode=true  initial.module=7 current.module=7 projectVersion=2
```

The setup file's compile does NOT bump `_projectVersion` — file is in
`_parsedTsConfig.fileNames`, content matches cache, and `currentModuleKind ===
moduleKind` is true (both ES2022) — so the language service reuses the CJS
Program built for the globalSetup compile. Result: setup file emits CJS;
Jest's ESM loader sees `exports.__esModule = true` and throws
`ReferenceError: exports is not defined`.

Inspecting the on-disk Jest transform cache for the failing repro confirms
the broken output:

```
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
require(""fs"");
```

## Fix

`getCompiledOutput` now tracks the module kind it last compiled with in
`_previousCompiledModuleKind`. When a subsequent compile's module kind
differs, the call to `_updateMemoryCache` passes `isModuleKindTheSame=false`,
forcing the project-version bump and the language-service Program rebuild
that the existing logic already does for an *initial* tsconfig module-kind
mismatch.

> Note on @ahnpnl's hint: the literal pseudo-code in #4774 was
> `currentModuleKind === moduleKind || previousModuleKind && previousModuleKind !== currentModuleKind`
> as a proposed combined formulation for `isModuleKindTheSame`. Reading that
> literally with OR would still treat the post-transition case as
> ""same"" (because the second clause is true for any change), suppressing
> the bump we want. I implemented what I read as the intended **semantics** —
> ""detect a module-kind change between consecutive compiles and force a
> rebuild when it changes"" — i.e. AND-with-NOT rather than OR. Empirically
> this is what resolves the bug on the repro repo. Happy to refactor if a
> different shape is preferred.

## Why this is safe across the cohort

| Project type | Behavior with patch |
|---|---|
| Pure CJS | `currentModuleKind` stays CommonJS across all compiles → no extra bump → identical to today |
| Pure ESM | `currentModuleKind` stays the user's ES kind across all compiles → identical to today |
| Mixed (the bug) | Module kind oscillates → bumps version on the transition → Program rebuilds with the correct kind |
| Windows | Was bumping unconditionally via the slash-mismatch quirk. The new path also fires; the slash-quirk's extra bump becomes redundant but benign (idempotent re-construction) |
| `isolatedModules: true` | `_languageService` is undefined; the patched code path is gated on it. Unaffected |

## Tests

Two unit tests in `src/legacy/compiler/ts-compiler.spec.ts` under a new
`describe('cross-compile module kind tracking')` block inside the existing
`isolatedModules false` group:

1. **Positive (RED on bare main, GREEN with patch):** asserts that two
   consecutive `getCompiledOutput` calls with different `supportsStaticESM`
   values bump `_projectVersion` between them. Caches and tsconfig file list
   are pre-seeded so the only bump trigger that can fire is the new
   module-kind-change tracking — verified RED on bare main with output
   `Expected: > 2, Received: 2`.

2. **Negative (stability):** asserts that two identical compiles do NOT bump
   `_projectVersion`. Pins the existing same-kind behavior so future
   refactors of this code path can't silently regress it.

## Verification

| Stage | Result |
|---|---|
| `npm test` | 348 / 348 pass (was 346 — 2 added) |
| `npm run test-e2e-cjs` | 27 / 27 pass |
| `npm run test-e2e-esm` | 29 / 29 pass |
| `npm run lint` | 0 errors |
| `npm run lint-prettier-ci` | clean |
| `npm run build` | succeeds |
| External repro `yegorpetrov/ts-jest-issue-repro`, clean cache run 1 | PASS (was FAIL) |
| Same repro, cached run 2 | PASS |
| Same repro, clean cache run 3 | PASS |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests ensuring compilation tracking updates project version when module kind changes and remains stable when it does not.

* **Bug Fixes**
  * Prevented reuse of prior compilation outputs across switches between CommonJS and ES module targets, avoiding stale or incorrect build artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kulshekhar/ts-jest/pull/5287)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->