### PR TITLE
feat: nodeModulesTransformPattern

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const TS_JS_TRANSFORM_PATTERN = '^.+\\.[tj]sx?$'
 export const ESM_TS_JS_TRANSFORM_PATTERN = '^.+\\.m?[tj]sx?$'
 export const JS_TRANSFORM_PATTERN = '^.+\\.jsx?$'
 export const ESM_JS_TRANSFORM_PATTERN = '^.+\\.m?jsx?$'
+export const MJS_NODE_MODULES_TRANSFORM = '^.+/node_modules/.+\\.mjs$'
 // `extensionsToTreatAsEsm` will throw error with `.mjs`
 export const TS_EXT_TO_TREAT_AS_ESM = ['.ts', '.tsx', '.mts']
 export const JS_EXT_TO_TREAT_AS_ESM = ['.jsx']

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,7 +1,11 @@
 import { TsJestTransformer } from './legacy/ts-jest-transformer'
 
-import tsJest from '.'
+import tsJest, { nodeModulesTransformPattern } from '.'
 
 test('should create an instance of TsJestTransformer', () => {
   expect(tsJest.createTransformer()).toBeInstanceOf(TsJestTransformer)
+})
+
+it('exports nodeModulesTransformPattern', () => {
+  expect(typeof nodeModulesTransformPattern).toBe('function')
 })

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { TsJestTransformer } from './legacy/ts-jest-transformer'
 
-import tsJest, { nodeModulesTransformPattern } from '.'
+import tsJest, { MJS_NODE_MODULES_TRANSFORM, nodeModulesTransformPattern } from '.'
 
 test('should create an instance of TsJestTransformer', () => {
   expect(tsJest.createTransformer()).toBeInstanceOf(TsJestTransformer)
@@ -8,4 +8,8 @@ test('should create an instance of TsJestTransformer', () => {
 
 it('exports nodeModulesTransformPattern', () => {
   expect(typeof nodeModulesTransformPattern).toBe('function')
+})
+
+it('exports MJS_NODE_MODULES_TRANSFORM', () => {
+  expect(typeof MJS_NODE_MODULES_TRANSFORM).toBe('string')
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -334,6 +334,12 @@ export type JsWithBabelEsmLegacyPreset = {
   }
 }
 
+export interface NodeModulesTransformOptions {
+  typeModulePackages?: boolean
+  packageNames?: string[]
+  nodeModulesPath?: string
+}
+
 declare module '@jest/types' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Config {

--- a/src/types.ts
+++ b/src/types.ts
@@ -336,6 +336,7 @@ export type JsWithBabelEsmLegacyPreset = {
 
 export interface NodeModulesTransformOptions {
   typeModulePackages?: boolean
+  mjsPackages?: boolean
   packageNames?: string[]
   nodeModulesPath?: string
 }

--- a/src/utils/find-type-module-packages.spec.ts
+++ b/src/utils/find-type-module-packages.spec.ts
@@ -1,0 +1,125 @@
+import * as fs from 'fs'
+
+import { vol } from 'memfs'
+
+import { findTypeModulePackages, resetTypeModuleCacheForTesting } from './find-type-module-packages'
+
+jest.mock('fs', () => {
+  const memfsFs = require('memfs').fs
+
+  return {
+    ...memfsFs,
+    readdirSync: jest.fn((...args: Parameters<typeof memfsFs.readdirSync>) => memfsFs.readdirSync(...args)),
+  }
+})
+
+const ROOT = '/project'
+const NM = `${ROOT}/node_modules`
+
+describe('findTypeModulePackages', () => {
+  beforeEach(() => {
+    vol.reset()
+    resetTypeModuleCacheForTesting()
+  })
+
+  afterAll(() => {
+    vol.reset()
+  })
+
+  it('returns empty array when node_modules does not exist', () => {
+    vol.fromJSON({})
+    expect(findTypeModulePackages(ROOT)).toEqual([])
+  })
+
+  it('returns empty array when no packages have type:module', () => {
+    vol.fromJSON({
+      [`${NM}/cjs-pkg/package.json`]: '{"name":"cjs-pkg","main":"index.js"}',
+      [`${NM}/no-type-pkg/package.json`]: '{"name":"no-type-pkg","version":"1.0.0"}',
+    })
+    expect(findTypeModulePackages(ROOT)).toEqual([])
+  })
+
+  it('returns relative folder names of type:module packages', () => {
+    vol.fromJSON({
+      [`${NM}/esm-pkg/package.json`]: '{"name":"esm-pkg","type":"module"}',
+      [`${NM}/cjs-pkg/package.json`]: '{"name":"cjs-pkg"}',
+    })
+    expect(findTypeModulePackages(ROOT)).toEqual(['esm-pkg'])
+  })
+
+  it('uses folder name, not package.json name field', () => {
+    vol.fromJSON({
+      [`${NM}/folder-name/package.json`]: '{"name":"different-name","type":"module"}',
+    })
+    const result = findTypeModulePackages(ROOT)
+    expect(result).toContain('folder-name')
+    expect(result).not.toContain('different-name')
+  })
+
+  it('handles scoped packages', () => {
+    vol.fromJSON({
+      [`${NM}/@scope/esm-scoped/package.json`]: '{"name":"esm-scoped","type":"module"}',
+      [`${NM}/@scope/cjs-scoped/package.json`]: '{"name":"cjs-scoped"}',
+    })
+    expect(findTypeModulePackages(ROOT)).toEqual(['@scope/esm-scoped'])
+  })
+
+  it('skips dot-prefixed entries', () => {
+    vol.fromJSON({
+      [`${NM}/.bin/somefile`]: '',
+      [`${NM}/real-pkg/package.json`]: '{"type":"module"}',
+    })
+    expect(findTypeModulePackages(ROOT)).toEqual(['real-pkg'])
+  })
+
+  it('handles malformed package.json gracefully', () => {
+    vol.fromJSON({
+      [`${NM}/bad-json/package.json`]: 'not valid json',
+      [`${NM}/good-pkg/package.json`]: '{"type":"module"}',
+    })
+    expect(findTypeModulePackages(ROOT)).toEqual(['good-pkg'])
+  })
+
+  it('handles missing package.json gracefully', () => {
+    vol.fromJSON({
+      [`${NM}/no-manifest/index.js`]: '',
+      [`${NM}/esm-pkg/package.json`]: '{"type":"module"}',
+    })
+    expect(findTypeModulePackages(ROOT)).toEqual(['esm-pkg'])
+  })
+
+  it('caches results and skips re-scan on second call', () => {
+    vol.fromJSON({
+      [`${NM}/esm-pkg/package.json`]: '{"type":"module"}',
+    })
+    const readdirSpy = fs.readdirSync as jest.Mock
+    readdirSpy.mockClear()
+    findTypeModulePackages(ROOT)
+    const firstCount = readdirSpy.mock.calls.length
+    findTypeModulePackages(ROOT)
+    expect(readdirSpy.mock.calls.length).toBe(firstCount)
+  })
+
+  it('scans independently for different nodeModulesPath values', () => {
+    const ROOT2 = '/project2'
+    const NM2 = `${ROOT2}/node_modules`
+    vol.fromJSON({
+      [`${NM}/esm-pkg/package.json`]: '{"type":"module"}',
+      [`${NM2}/other-esm/package.json`]: '{"type":"module"}',
+    })
+    expect(findTypeModulePackages(ROOT)).toEqual(['esm-pkg'])
+    expect(findTypeModulePackages(ROOT2)).toEqual(['other-esm'])
+  })
+
+  it('resetTypeModuleCacheForTesting clears cache', () => {
+    vol.fromJSON({
+      [`${NM}/esm-pkg/package.json`]: '{"type":"module"}',
+    })
+    findTypeModulePackages(ROOT)
+    const readdirSpy = fs.readdirSync as jest.Mock
+    readdirSpy.mockClear()
+    resetTypeModuleCacheForTesting()
+    findTypeModulePackages(ROOT)
+    expect(readdirSpy.mock.calls.length).toBeGreaterThan(0)
+  })
+})

--- a/src/utils/find-type-module-packages.ts
+++ b/src/utils/find-type-module-packages.ts
@@ -1,0 +1,64 @@
+import { readdirSync, readFileSync } from 'fs'
+import path from 'path'
+
+const typeModuleCache = new Map<string, string[]>()
+
+function isTypeModulePackage(pkgDir: string): boolean {
+  try {
+    const raw = readFileSync(path.join(pkgDir, 'package.json'), 'utf8')
+    const parsed = JSON.parse(raw) as { type?: string }
+
+    return parsed.type === 'module'
+  } catch {
+    return false
+  }
+}
+
+function listPkgDirs(nodeModulesDir: string): string[] {
+  let entries: string[]
+  try {
+    entries = readdirSync(nodeModulesDir)
+  } catch {
+    return []
+  }
+  const dirs: string[] = []
+  for (const entry of entries) {
+    if (entry.startsWith('.')) continue
+    const full = path.join(nodeModulesDir, entry)
+    if (entry.startsWith('@')) {
+      let scoped: string[] = []
+      try {
+        scoped = readdirSync(full)
+      } catch {
+        continue
+      }
+      for (const sub of scoped) dirs.push(path.join(full, sub))
+    } else {
+      dirs.push(full)
+    }
+  }
+
+  return dirs
+}
+
+export function findTypeModulePackages(nodeModulesPath: string): string[] {
+  const cached = typeModuleCache.get(nodeModulesPath)
+  if (cached) return cached
+  const found = new Set<string>()
+  const topNm = path.join(nodeModulesPath, 'node_modules')
+  for (const dir of listPkgDirs(topNm)) {
+    if (isTypeModulePackage(dir)) {
+      const rel = path.relative(topNm, dir).split(path.sep).join('/')
+      found.add(rel)
+    }
+  }
+  const result = [...found]
+  typeModuleCache.set(nodeModulesPath, result)
+
+  return result
+}
+
+/** @internal */
+export function resetTypeModuleCacheForTesting(): void {
+  typeModuleCache.clear()
+}

--- a/src/utils/find-type-module-packages.ts
+++ b/src/utils/find-type-module-packages.ts
@@ -32,7 +32,9 @@ function listPkgDirs(nodeModulesDir: string): string[] {
       } catch {
         continue
       }
-      for (const sub of scoped) dirs.push(path.join(full, sub))
+      for (const sub of scoped) {
+        if (!sub.startsWith('.')) dirs.push(path.join(full, sub))
+      }
     } else {
       dirs.push(full)
     }
@@ -42,7 +44,8 @@ function listPkgDirs(nodeModulesDir: string): string[] {
 }
 
 export function findTypeModulePackages(nodeModulesPath: string): string[] {
-  const cached = typeModuleCache.get(nodeModulesPath)
+  const key = path.resolve(nodeModulesPath)
+  const cached = typeModuleCache.get(key)
   if (cached) return cached
   const found = new Set<string>()
   const topNm = path.join(nodeModulesPath, 'node_modules')
@@ -53,7 +56,7 @@ export function findTypeModulePackages(nodeModulesPath: string): string[] {
     }
   }
   const result = [...found]
-  typeModuleCache.set(nodeModulesPath, result)
+  typeModuleCache.set(key, result)
 
   return result
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-export * from './find-type-module-packages'
+export { findTypeModulePackages } from './find-type-module-packages'
 export * from './json'
 export * from './node-modules-transform-pattern'
 export * from './jsonable-value'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,6 @@
+export * from './find-type-module-packages'
 export * from './json'
+export * from './node-modules-transform-pattern'
 export * from './jsonable-value'
 export * from './logger'
 export * from './diagnostics'

--- a/src/utils/node-modules-transform-pattern.spec.ts
+++ b/src/utils/node-modules-transform-pattern.spec.ts
@@ -1,5 +1,3 @@
-import * as fs from 'fs'
-
 import { vol } from 'memfs'
 
 import { resetTypeModuleCacheForTesting } from './find-type-module-packages'
@@ -74,14 +72,32 @@ describe('nodeModulesTransformPattern', () => {
     })
   })
 
-  describe('cache', () => {
-    it('only scans once per nodeModulesPath', () => {
-      const readdirSpy = fs.readdirSync as jest.Mock
-      readdirSpy.mockClear()
-      nodeModulesTransformPattern({ typeModulePackages: true, nodeModulesPath: CWD })
-      const firstCount = readdirSpy.mock.calls.length
-      nodeModulesTransformPattern({ typeModulePackages: true, nodeModulesPath: CWD })
-      expect(readdirSpy.mock.calls.length).toBe(firstCount)
+  describe('mjsPackages', () => {
+    it('exempts .mjs files from any package', () => {
+      const re = new RegExp(nodeModulesTransformPattern({ mjsPackages: true }))
+      expect(re.test('/x/node_modules/some-pkg/index.mjs')).toBe(false)
+      expect(re.test('/x/node_modules/some-pkg/index.js')).toBe(true)
+    })
+
+    it('still ignores .js files from packages not otherwise exempted', () => {
+      const re = new RegExp(nodeModulesTransformPattern({ mjsPackages: true }))
+      expect(re.test('/x/node_modules/cjs-pkg/index.js')).toBe(true)
+    })
+
+    it('combines with packageNames', () => {
+      const re = new RegExp(nodeModulesTransformPattern({ mjsPackages: true, packageNames: ['esm-pkg'] }))
+      expect(re.test('/x/node_modules/esm-pkg/index.js')).toBe(false)
+      expect(re.test('/x/node_modules/some-pkg/index.mjs')).toBe(false)
+      expect(re.test('/x/node_modules/cjs-pkg/index.js')).toBe(true)
+    })
+
+    it('combines with typeModulePackages', () => {
+      const re = new RegExp(
+        nodeModulesTransformPattern({ mjsPackages: true, typeModulePackages: true, nodeModulesPath: CWD }),
+      )
+      expect(re.test('/x/node_modules/esm-pkg/index.js')).toBe(false)
+      expect(re.test('/x/node_modules/some-pkg/index.mjs')).toBe(false)
+      expect(re.test('/x/node_modules/cjs-pkg/index.js')).toBe(true)
     })
   })
 })

--- a/src/utils/node-modules-transform-pattern.spec.ts
+++ b/src/utils/node-modules-transform-pattern.spec.ts
@@ -51,6 +51,11 @@ describe('nodeModulesTransformPattern', () => {
       expect(re.test('/repo/node_modules/cjs-pkg/index.js')).toBe(true)
     })
 
+    it('escapes regex metacharacters in package names', () => {
+      const re = new RegExp(nodeModulesTransformPattern({ packageNames: ['zone.js'] }))
+      expect(re.test('/repo/node_modules/zone.js/index.js')).toBe(false)
+      expect(re.test('/repo/node_modules/zonexjs/index.js')).toBe(true)
+    })
   })
 
   describe('typeModulePackages', () => {

--- a/src/utils/node-modules-transform-pattern.spec.ts
+++ b/src/utils/node-modules-transform-pattern.spec.ts
@@ -1,0 +1,82 @@
+import * as fs from 'fs'
+
+import { vol } from 'memfs'
+
+import { resetTypeModuleCacheForTesting } from './find-type-module-packages'
+import { nodeModulesTransformPattern } from './node-modules-transform-pattern'
+
+jest.mock('fs', () => {
+  const memfsFs = require('memfs').fs
+
+  return {
+    ...memfsFs,
+    readdirSync: jest.fn((...args: Parameters<typeof memfsFs.readdirSync>) => memfsFs.readdirSync(...args)),
+  }
+})
+
+const CWD = '/fixture'
+
+const FIXTURE_FS = {
+  [`${CWD}/node_modules/esm-pkg/package.json`]:
+    '{"name":"esm-pkg","version":"1.0.0","type":"module","main":"index.js"}',
+  [`${CWD}/node_modules/esm-pkg/index.js`]: '',
+  [`${CWD}/node_modules/cjs-pkg/package.json`]: '{"name":"cjs-pkg","version":"1.0.0","main":"index.js"}',
+  [`${CWD}/node_modules/cjs-pkg/index.js`]: '',
+  [`${CWD}/node_modules/no-type-pkg/package.json`]: '{"name":"no-type-pkg","version":"1.0.0"}',
+  [`${CWD}/node_modules/parent-pkg/package.json`]: '{"name":"parent-pkg","version":"1.0.0"}',
+  // folder name differs from package.json "name" — the bug this test covers
+  [`${CWD}/node_modules/@scope/esm-scoped/package.json`]: '{"name":"esm-scoped-alias","type":"module"}',
+  [`${CWD}/node_modules/@scope/esm-scoped/index.js`]: '',
+}
+
+describe('nodeModulesTransformPattern', () => {
+  beforeEach(() => {
+    vol.reset()
+    vol.fromJSON(FIXTURE_FS)
+    resetTypeModuleCacheForTesting()
+  })
+
+  afterAll(() => {
+    vol.reset()
+  })
+
+  it('returns plain /node_modules/ with no exemptions', () => {
+    expect(nodeModulesTransformPattern()).toBe('/node_modules/')
+  })
+
+  describe('packageNames', () => {
+    it('exempts named extras', () => {
+      const re = new RegExp(nodeModulesTransformPattern({ packageNames: ['esm-pkg'] }))
+      expect(re.test('/repo/node_modules/esm-pkg/index.js')).toBe(false)
+      expect(re.test('/repo/node_modules/cjs-pkg/index.js')).toBe(true)
+    })
+
+  })
+
+  describe('typeModulePackages', () => {
+    it('finds top-level "type":"module" packages', () => {
+      const re = new RegExp(nodeModulesTransformPattern({ typeModulePackages: true, nodeModulesPath: CWD }))
+      expect(re.test('/x/node_modules/esm-pkg/index.js')).toBe(false)
+      expect(re.test('/x/node_modules/cjs-pkg/index.js')).toBe(true)
+      expect(re.test('/x/node_modules/no-type-pkg/index.js')).toBe(true)
+    })
+
+    it('exempts by folder path, not package.json name, so scoped packages with mismatched names work', () => {
+      const re = new RegExp(nodeModulesTransformPattern({ typeModulePackages: true, nodeModulesPath: CWD }))
+      // folder is @scope/esm-scoped; package.json name is esm-scoped-alias (different)
+      expect(re.test('/x/node_modules/@scope/esm-scoped/index.js')).toBe(false)
+      expect(re.test('/x/node_modules/esm-scoped-alias/index.js')).toBe(true)
+    })
+  })
+
+  describe('cache', () => {
+    it('only scans once per nodeModulesPath', () => {
+      const readdirSpy = fs.readdirSync as jest.Mock
+      readdirSpy.mockClear()
+      nodeModulesTransformPattern({ typeModulePackages: true, nodeModulesPath: CWD })
+      const firstCount = readdirSpy.mock.calls.length
+      nodeModulesTransformPattern({ typeModulePackages: true, nodeModulesPath: CWD })
+      expect(readdirSpy.mock.calls.length).toBe(firstCount)
+    })
+  })
+})

--- a/src/utils/node-modules-transform-pattern.ts
+++ b/src/utils/node-modules-transform-pattern.ts
@@ -2,6 +2,10 @@ import type { NodeModulesTransformOptions } from '../types'
 
 import { findTypeModulePackages } from './find-type-module-packages'
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 /**
  * Build a `transformIgnorePatterns` entry that ignores `node_modules` except for
  * packages whose `package.json` declares `"type": "module"`. Use with the `JsWithTs`
@@ -26,5 +30,7 @@ export function nodeModulesTransformPattern({
   }
   if (!allPackages.size) return '/node_modules/'
 
-  return `/node_modules/(?!(${[...allPackages].join('|')})/)`
+  const escaped = [...allPackages].map(escapeRegex).join('|')
+
+  return `/node_modules/(?!(${escaped})/)`
 }

--- a/src/utils/node-modules-transform-pattern.ts
+++ b/src/utils/node-modules-transform-pattern.ts
@@ -1,0 +1,30 @@
+import type { NodeModulesTransformOptions } from '../types'
+
+import { findTypeModulePackages } from './find-type-module-packages'
+
+/**
+ * Build a `transformIgnorePatterns` entry that ignores `node_modules` except for
+ * packages whose `package.json` declares `"type": "module"`. Use with the `JsWithTs`
+ * presets when you need ESM packages inside `node_modules` to be transformed by ts-jest.
+ *
+ * @param options.typeModulePackages - Scan `node_modules` and exempt packages whose
+ *   `package.json` declares `"type": "module"`. Default `false`.
+ * @param options.packageNames - Additional package names to exempt. Default `[]`.
+ * @param options.nodeModulesPath - Directory to scan from. Default `process.cwd()`.
+ * @returns A regex string suitable for `transformIgnorePatterns`.
+ */
+export function nodeModulesTransformPattern({
+  typeModulePackages = false,
+  packageNames = [],
+  nodeModulesPath = process.cwd(),
+}: NodeModulesTransformOptions = {}): string {
+  const allPackages = new Set<string>(packageNames)
+  if (typeModulePackages) {
+    for (const name of findTypeModulePackages(nodeModulesPath)) {
+      allPackages.add(name)
+    }
+  }
+  if (!allPackages.size) return '/node_modules/'
+
+  return `/node_modules/(?!(${[...allPackages].join('|')})/)`
+}

--- a/src/utils/node-modules-transform-pattern.ts
+++ b/src/utils/node-modules-transform-pattern.ts
@@ -8,8 +8,8 @@ function escapeRegex(value: string): string {
 
 /**
  * Build a `transformIgnorePatterns` entry that ignores `node_modules` except for
- * specified packages and optional file-extension exemptions. Use with the `JsWithTs`
- * presets when you need ESM packages inside `node_modules` to be transformed by ts-jest.
+ * specified packages and optional file-extension exemptions. Use when you need
+ * ESM packages inside `node_modules` to be transformed by ts-jest.
  *
  * @param options.typeModulePackages - Scan `node_modules` and exempt packages whose
  *   `package.json` declares `"type": "module"`. Default `false`.

--- a/src/utils/node-modules-transform-pattern.ts
+++ b/src/utils/node-modules-transform-pattern.ts
@@ -38,7 +38,7 @@ export function nodeModulesTransformPattern({
     parts.push(`(${escaped})/`)
   }
   if (mjsPackages) {
-    parts.push(`.*\\.mjs`)
+    parts.push(`.*\\.mjs$`)
   }
 
   if (!parts.length) return '/node_modules/'

--- a/src/utils/node-modules-transform-pattern.ts
+++ b/src/utils/node-modules-transform-pattern.ts
@@ -8,17 +8,20 @@ function escapeRegex(value: string): string {
 
 /**
  * Build a `transformIgnorePatterns` entry that ignores `node_modules` except for
- * packages whose `package.json` declares `"type": "module"`. Use with the `JsWithTs`
+ * specified packages and optional file-extension exemptions. Use with the `JsWithTs`
  * presets when you need ESM packages inside `node_modules` to be transformed by ts-jest.
  *
  * @param options.typeModulePackages - Scan `node_modules` and exempt packages whose
  *   `package.json` declares `"type": "module"`. Default `false`.
+ * @param options.mjsPackages - Exempt all `.mjs` files inside `node_modules` from
+ *   being ignored, so they are transformed by ts-jest. Default `false`.
  * @param options.packageNames - Additional package names to exempt. Default `[]`.
  * @param options.nodeModulesPath - Directory to scan from. Default `process.cwd()`.
  * @returns A regex string suitable for `transformIgnorePatterns`.
  */
 export function nodeModulesTransformPattern({
   typeModulePackages = false,
+  mjsPackages = false,
   packageNames = [],
   nodeModulesPath = process.cwd(),
 }: NodeModulesTransformOptions = {}): string {
@@ -28,9 +31,17 @@ export function nodeModulesTransformPattern({
       allPackages.add(name)
     }
   }
-  if (!allPackages.size) return '/node_modules/'
 
-  const escaped = [...allPackages].map(escapeRegex).join('|')
+  const parts: string[] = []
+  if (allPackages.size) {
+    const escaped = [...allPackages].map(escapeRegex).join('|')
+    parts.push(`(${escaped})/`)
+  }
+  if (mjsPackages) {
+    parts.push(`.*\\.mjs`)
+  }
 
-  return `/node_modules/(?!(${escaped})/)`
+  if (!parts.length) return '/node_modules/'
+
+  return `/node_modules/(?!${parts.join('|')})`
 }

--- a/website/docs/guides/esm-support.md
+++ b/website/docs/guides/esm-support.md
@@ -139,6 +139,8 @@ correctly.
 To fix that, one can use `moduleNameMapper` in jest config to instruct Jest to load the correct **ESM** files or create a
 custom Jest [resolver](https://jestjs.io/docs/configuration#resolver-string).
 
+For packages inside `node_modules`, see the [Transform node_module packages](./troubleshooting.md#transform-node_module-packages) troubleshooting section.
+
 :::
 
 ### Using ESM presets

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -77,22 +77,24 @@ The error message usually shows which module is affected:
          | ^
 ```
 
+Recommended: Use the `nodeModulesTransformPattern` helper from `ts-jest` to generate the correct `transformIgnorePatterns` entry instead of writing the regex manually.
+
 #### If the offending files are `.mjs` files
 
-Use when individual files have a `.mjs` extension. Add a dedicated transform rule — ts-jest will transpile all `.mjs` files in `node_modules` to CommonJS without needing to list packages individually:
+Use when individual files have a `.mjs` extension. Pass `mjsPackages: true` — ts-jest will transpile all `.mjs` files in `node_modules` to CommonJS without needing to list packages individually:
 
 ```ts title="jest.config.ts"
 import type { Config } from 'jest'
-import { createDefaultPreset } from 'ts-jest'
+import { createDefaultPreset, MJS_NODE_MODULES_TRANSFORM, nodeModulesTransformPattern } from 'ts-jest'
 
 const presetConfig = createDefaultPreset()
 
 const config: Config = {
   ...presetConfig,
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [nodeModulesTransformPattern({ mjsPackages: true })],
   transform: {
     ...presetConfig.transform,
-    '^.+/node_modules/.+\\.mjs$': ['ts-jest', {}],
+    [MJS_NODE_MODULES_TRANSFORM]: ['ts-jest', {}],
   },
 }
 
@@ -101,20 +103,20 @@ export default config
 
 #### If the offending package uses `"type": "module"` in its `package.json`
 
-Use when a package declares `"type": "module"`, causing its `.js` files to be treated as ESM. Name each affected package explicitly in `transformIgnorePatterns`:
+Use when a package declares `"type": "module"`, causing its `.js` files to be treated as ESM. Pass `typeModulePackages: true` to automatically detect all such packages (recommended), or list them explicitly via `packageNames`:
 
 ```ts title="jest.config.ts"
 import type { Config } from 'jest'
+import { nodeModulesTransformPattern } from 'ts-jest'
 
 const config: Config = {
   //...
-  transformIgnorePatterns: ['node_modules/(?!(some-module|another-module))'],
+  // auto-detect all packages with "type": "module"
+  transformIgnorePatterns: [nodeModulesTransformPattern({ typeModulePackages: true })],
 }
 
 export default config
 ```
-
-**some-module** and **another-module** will be transformed.
 
 For more information see [here](https://stackoverflow.com/questions/63389757/jest-unit-test-syntaxerror-cannot-use-import-statement-outside-a-module) and [here](https://stackoverflow.com/questions/52035066/how-to-write-jest-transformignorepatterns).
 

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -136,7 +136,7 @@ export default config
 
 #### Manual resolution
 
-If you need to specify packages manually, you can specify packages to ignore in node_modules with the helper function.
+If you need to specify packages manually, you can use the helper function.
 
 ```ts title="jest.config.ts"
 transformIgnorePatterns: [nodeModulesTransformPattern({ packageNames: ['package-x', 'package-y'] })]

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -59,11 +59,21 @@ export default config
 
 - Check github folder names if its identical to you local folder names. Sometimes github never updates your folder names even if you rename it locally. If this happens rename your folders via github or use this command `git mv <source> <destination>` and commit changes.
 
-## Transform (node)-module explicitly
+## Transform node_module packages
 
 ### PROBLEM
 
+A package inside node_modules throws one of the following errors:
+
+```shell
 SyntaxError: Cannot use import statement outside a module
+```
+
+or
+
+```shell
+SyntaxError: Unexpected token 'export'
+```
 
 ### SOLUTION
 
@@ -77,11 +87,17 @@ The error message usually shows which module is affected:
          | ^
 ```
 
-Recommended: Use the `nodeModulesTransformPattern` helper from `ts-jest` to generate the correct `transformIgnorePatterns` entry instead of writing the regex manually.
+> [!TIP]
+> Use the `nodeModulesTransformPattern` helper from `ts-jest` to generate the correct `transformIgnorePatterns` entry instead of writing the regex manually.
+
+> [!CAUTION]
+> You should only have one entry in `transformIgnorePatterns` for `node_modules`.
 
 #### If the offending files are `.mjs` files
 
-Use when individual files have a `.mjs` extension. Pass `mjsPackages: true` — ts-jest will transpile all `.mjs` files in `node_modules` to CommonJS without needing to list packages individually:
+Use when individual files have a `.mjs` extension. Pass `mjsPackages: true` — ts-jest will transpile all `.mjs` files in `node_modules` to CommonJS without needing to list packages individually.
+
+Removing mjs packages from ignore patters alone isn't enough. You must also ask the transformer to look for mjs files:
 
 ```ts title="jest.config.ts"
 import type { Config } from 'jest'
@@ -103,7 +119,7 @@ export default config
 
 #### If the offending package uses `"type": "module"` in its `package.json`
 
-Use when a package declares `"type": "module"`, causing its `.js` files to be treated as ESM. Pass `typeModulePackages: true` to automatically detect all such packages (recommended), or list them explicitly via `packageNames`:
+Use when a package declares `"type": "module"`, causing its `.js` files to be treated as ESM. Pass `typeModulePackages: true` to automatically detect all such packages:
 
 ```ts title="jest.config.ts"
 import type { Config } from 'jest'
@@ -116,6 +132,14 @@ const config: Config = {
 }
 
 export default config
+```
+
+#### Manual resolution
+
+If you need to specify packages manually, you can specify packages to ignore in node_modules with the helper function. Do not add multiple entries for node_modules to ignore patterns unless you provide a full path.
+
+```ts title="jest.config.ts"
+transformIgnorePatterns: [nodeModulesTransformPattern({ packageNames: ['package-x', 'package-y'] })]
 ```
 
 For more information see [here](https://stackoverflow.com/questions/63389757/jest-unit-test-syntaxerror-cannot-use-import-statement-outside-a-module) and [here](https://stackoverflow.com/questions/52035066/how-to-write-jest-transformignorepatterns).

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -97,7 +97,7 @@ The error message usually shows which module is affected:
 
 Use when individual files have a `.mjs` extension. Pass `mjsPackages: true` — ts-jest will transpile all `.mjs` files in `node_modules` to CommonJS without needing to list packages individually.
 
-Removing mjs packages from ignore patters alone isn't enough. You must also ask the transformer to look for mjs files:
+Removing mjs packages from ignore patterns alone isn't enough. You must also ask the transformer to look for mjs files:
 
 ```ts title="jest.config.ts"
 import type { Config } from 'jest'
@@ -136,7 +136,7 @@ export default config
 
 #### Manual resolution
 
-If you need to specify packages manually, you can specify packages to ignore in node_modules with the helper function. Do not add multiple entries for node_modules to ignore patterns unless you provide a full path.
+If you need to specify packages manually, you can specify packages to ignore in node_modules with the helper function.
 
 ```ts title="jest.config.ts"
 transformIgnorePatterns: [nodeModulesTransformPattern({ packageNames: ['package-x', 'package-y'] })]

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,6 +1,5 @@
 import simplePlantUML from '@akebifiky/remark-simple-plantuml'
 import type * as Presets from '@docusaurus/preset-classic'
-// eslint-disable-next-line import/default
 import npm2yarnPlugin from '@docusaurus/remark-plugin-npm2yarn'
 import type { Config } from '@docusaurus/types'
 import tabBlocksPlugin from 'docusaurus-remark-plugin-tab-blocks'


### PR DESCRIPTION
## Summary

Adds `nodeModulesTransformPattern`, a helper that builds a `transformIgnorePatterns` regex string that skips `node_modules` except for specified ESM packages and file types. Also adds `MJS_NODE_MODULES_TRANSFORM`, a reusable constant for the `.mjs` transform key.

### `nodeModulesTransformPattern` options

- **`typeModulePackages`** — scans `node_modules` and exempts packages whose `package.json` declares `"type": "module"`. Results are cached per `nodeModulesPath`.
- **`mjsPackages`** — exempts all `.mjs` files in `node_modules` from being ignored, so they are transformed.
- **`packageNames`** — manually specify additional package names to exempt without scanning.
- **`nodeModulesPath`** — directory to scan from. Defaults to `process.cwd()`.

Regex metacharacters in package names (e.g. `zone.js`) are escaped. Scoped packages are matched by folder path, not `package.json` name.

### `MJS_NODE_MODULES_TRANSFORM`

Constant (`'^.+/node_modules/.+\\.mjs$'`) added to `constants.ts` alongside the existing transform pattern constants. Pairs with `mjsPackages: true` in the transform map.

### Usage

```ts title="jest.config.ts"
import type { Config } from 'jest'
import { createDefaultPreset, MJS_NODE_MODULES_TRANSFORM, nodeModulesTransformPattern } from 'ts-jest'

const presetConfig = createDefaultPreset()

export default {
  ...presetConfig,
  transformIgnorePatterns: [
    nodeModulesTransformPattern({ typeModulePackages: true, mjsPackages: true }),
  ],
  transform: {
    ...presetConfig.transform,
    [MJS_NODE_MODULES_TRANSFORM]: ['ts-jest', {}],
  },
} satisfies Config
```

### Docs

Updated `website/docs/guides/troubleshooting.md` to recommend `nodeModulesTransformPattern` and `MJS_NODE_MODULES_TRANSFORM` over hand-crafting regex in both the `.mjs` and `"type": "module"` troubleshooting sections.

## Test plan

- Unit tests cover: no exemptions, `packageNames` exemption, regex metacharacter escaping, `typeModulePackages` detection via memfs, scoped packages with mismatched `package.json` names, cache (single scan per `nodeModulesPath`), `mjsPackages` alone, combined with `packageNames`, combined with `typeModulePackages`
- `src/index.spec.ts` verifies both `nodeModulesTransformPattern` and `MJS_NODE_MODULES_TRANSFORM` are exported at the package root