### PR TITLE
fix(transformer): transpile .mjs node_modules to CJS

### DIFF
--- a/src/legacy/ts-jest-transformer.spec.ts
+++ b/src/legacy/ts-jest-transformer.spec.ts
@@ -414,7 +414,7 @@ describe('TsJestTransformer', () => {
       },
       {
         filePath: 'my-project/node_modules/foo.mjs',
-        expectedResult: `export default foo;`,
+        expectedResult: `exports.default = foo;`,
       },
     ])('should transpile js file from node_modules for CJS', ({ filePath, expectedResult }) => {
       const result = tr.process(
@@ -430,6 +430,20 @@ describe('TsJestTransformer', () => {
       )
 
       expect(omitLeadingWhitespace(result.code)).toContain(expectedResult)
+    })
+
+    it('should transpile .mjs file with import statements from node_modules to CJS without SyntaxError', () => {
+      const result = tr.process(
+        `
+          import { LensList } from "./lens-list.mjs";
+          export default LensList;
+        `,
+        'my-project/node_modules/rettime/build/index.mjs',
+        baseTransformOptions,
+      )
+
+      expect(omitLeadingWhitespace(result.code)).toContain(`require("./lens-list.mjs")`)
+      expect(omitLeadingWhitespace(result.code)).not.toContain('import {')
     })
 
     it('should transpile js file from node_modules for ESM', () => {

--- a/src/legacy/ts-jest-transformer.ts
+++ b/src/legacy/ts-jest-transformer.ts
@@ -235,13 +235,13 @@ export class TsJestTransformer implements SyncTransformer<TsJestTransformerOptio
           compilerOptions: {
             ...configs.parsedTsConfig.options,
             module:
-              transformOptions.supportsStaticESM && transformOptions.transformerConfig.useESM
+              transformOptions.supportsStaticESM && transformOptions.transformerConfig?.useESM
                 ? ts.ModuleKind.ESNext
                 : ts.ModuleKind.CommonJS,
           },
           // .mjs fileName causes ts.transpileModule to preserve ESM syntax even with module: CommonJS
           fileName:
-            transformOptions.supportsStaticESM && transformOptions.transformerConfig.useESM
+            transformOptions.supportsStaticESM && transformOptions.transformerConfig?.useESM
               ? sourcePath
               : sourcePath.replace(/\.mjs$/, '.js'),
         })

--- a/src/legacy/ts-jest-transformer.ts
+++ b/src/legacy/ts-jest-transformer.ts
@@ -239,7 +239,11 @@ export class TsJestTransformer implements SyncTransformer<TsJestTransformerOptio
                 ? ts.ModuleKind.ESNext
                 : ts.ModuleKind.CommonJS,
           },
-          fileName: sourcePath,
+          // TypeScript preserves ESM syntax when fileName ends in .mjs; rename to .js to get CJS output
+          fileName:
+            transformOptions.supportsStaticESM && transformOptions.transformerConfig.useESM
+              ? sourcePath
+              : sourcePath.replace(/\.mjs$/, '.js'),
         })
         result = {
           code: updateOutput(transpiledResult.outputText, sourcePath, transpiledResult.sourceMapText),

--- a/src/legacy/ts-jest-transformer.ts
+++ b/src/legacy/ts-jest-transformer.ts
@@ -239,7 +239,7 @@ export class TsJestTransformer implements SyncTransformer<TsJestTransformerOptio
                 ? ts.ModuleKind.ESNext
                 : ts.ModuleKind.CommonJS,
           },
-          // TypeScript preserves ESM syntax when fileName ends in .mjs; rename to .js to get CJS output
+          // .mjs fileName causes ts.transpileModule to preserve ESM syntax even with module: CommonJS
           fileName:
             transformOptions.supportsStaticESM && transformOptions.transformerConfig.useESM
               ? sourcePath

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -67,10 +67,9 @@ SyntaxError: Cannot use import statement outside a module
 
 ### SOLUTION
 
-One of the node modules hasn't the correct syntax for Jests execution step. It needs to
-be transformed first.
+One of the node modules hasn't the correct syntax for Jest's execution step. It needs to be transformed first.
 
-There is a good chance that the error message shows which module is affected:
+The error message usually shows which module is affected:
 
 ```shell
     SyntaxError: Cannot use import statement outside a module
@@ -78,9 +77,31 @@ There is a good chance that the error message shows which module is affected:
          | ^
 ```
 
-In this case **some-module** is the problem and needs to be transformed.
-By adding the following line to the configuration file it will tell Jest which modules
-shouldnt be ignored during the transformation step:
+#### If the offending files are `.mjs` files
+
+Add a dedicated transform rule for `.mjs` files. ts-jest handles all `.mjs` files in `node_modules` automatically — no need to list individual packages:
+
+```ts title="jest.config.ts"
+import type { Config } from 'jest'
+import { createDefaultPreset } from 'ts-jest'
+
+const presetConfig = createDefaultPreset()
+
+const config: Config = {
+  ...presetConfig,
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transform: {
+    ...presetConfig.transform,
+    '^.+/node_modules/.+\\.mjs$': ['ts-jest', {}],
+  },
+}
+
+export default config
+```
+
+#### If the offending package uses `"type": "module"` in its `package.json`
+
+You need to name each package explicitly in `transformIgnorePatterns`:
 
 ```ts title="jest.config.ts"
 import type { Config } from 'jest'

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -67,7 +67,7 @@ SyntaxError: Cannot use import statement outside a module
 
 ### SOLUTION
 
-One of the node modules hasn't the correct syntax for Jest's execution step. It needs to be transformed first.
+One of the node modules doesn't have the correct syntax for Jest's execution step. It needs to be transformed first.
 
 The error message usually shows which module is affected:
 
@@ -79,7 +79,7 @@ The error message usually shows which module is affected:
 
 #### If the offending files are `.mjs` files
 
-Add a dedicated transform rule for `.mjs` files. ts-jest handles all `.mjs` files in `node_modules` automatically — no need to list individual packages:
+Use when individual files have a `.mjs` extension. Add a dedicated transform rule — ts-jest will transpile all `.mjs` files in `node_modules` to CommonJS without needing to list packages individually:
 
 ```ts title="jest.config.ts"
 import type { Config } from 'jest'
@@ -101,7 +101,7 @@ export default config
 
 #### If the offending package uses `"type": "module"` in its `package.json`
 
-You need to name each package explicitly in `transformIgnorePatterns`:
+Use when a package declares `"type": "module"`, causing its `.js` files to be treated as ESM. Name each affected package explicitly in `transformIgnorePatterns`:
 
 ```ts title="jest.config.ts"
 import type { Config } from 'jest'


### PR DESCRIPTION
## Problem

When a dependency ships `.mjs` files with `import` statements, ts-jest would throw:

```
SyntaxError: Cannot use import statement outside a module
    .../node_modules/rettime/build/index.mjs:23
    import { LensList } from "./lens-list.mjs";
    ^^^^^^
```

This happened because TypeScript's `transpileModule` preserves ESM syntax when the `fileName` parameter ends in `.mjs`, even when `module` is set to `CommonJS`. The filename is used by TypeScript to determine module format, overriding the compiler options.

## Fix

In `processWithTs`, when transpiling a JS file from `node_modules` in CJS mode, rename `.mjs` to `.js` in the `fileName` passed to `ts.transpileModule`. ESM mode is unaffected.

```ts
fileName:
  transformOptions.supportsStaticESM && transformOptions.transformerConfig.useESM
    ? sourcePath
    : sourcePath.replace(/\.mjs$/, '.js'),
```

## Jest configuration

To enable this fix, users configure ts-jest to handle `.mjs` node_modules:

```ts
const config: Config = {
  ...presetConfig,
  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
  transform: {
    ...presetConfig.transform,
    '^.+/node_modules/.+\\.mjs$': ['ts-jest', {}],
  },
}
```

No per-package listing required — the pattern covers all `.mjs` files automatically.

## Changes

- `src/legacy/ts-jest-transformer.ts` — rename `.mjs` → `.js` for CJS transpilation
- `src/legacy/ts-jest-transformer.spec.ts` — fix existing `.mjs`/CJS test expectation; add test for `import` statement case
- `website/docs/guides/troubleshooting.md` — merge `.mjs` guidance into existing "Transform node-module explicitly" section with two sub-solutions

## Test plan

- [ ] Run `npx jest src/legacy/ts-jest-transformer.spec.ts`
- [ ] Verify `.mjs` packages with `import` statements no longer throw `SyntaxError` when using the documented Jest config

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transpilation of `.mjs` files from dependencies to CommonJS when running under environments that require CJS output.

* **Documentation**
  * Enhanced troubleshooting guide with step-by-step guidance for handling `.mjs` files and packages using ECMAScript modules, including example Jest config adjustments.

* **Tests**
  * Added a test ensuring `.mjs` dependencies are transpiled to CJS without SyntaxError and produce require(...) output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kulshekhar/ts-jest/pull/5304)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->