### PR TITLE
fix(transformer): use a consistent comparator in hoist-jest sortStatements

### DIFF
--- a/src/transformers/__snapshots__/hoist-jest.spec.ts.snap
+++ b/src/transformers/__snapshots__/hoist-jest.spec.ts.snap
@@ -74,9 +74,9 @@ console.log(jestBackticks);
 `;
 
 exports[`hoist-jest should hoist correctly when using with @jest/globals 1`] = `
-"import * as JestGlobals from "@jest/globals";
+"import { jest } from "@jest/globals";
 import { jest as aliasedJest } from "@jest/globals";
-import { jest } from "@jest/globals";
+import * as JestGlobals from "@jest/globals";
 // These will all be hoisted above imports
 jest.unmock("react");
 aliasedJest.deepUnmock("../__test_modules__/Unmocked");

--- a/src/transformers/hoist-jest.spec.ts
+++ b/src/transformers/hoist-jest.spec.ts
@@ -188,4 +188,20 @@ describe('hoist-jest', () => {
 
     expect(printer.printFile(transformedSourceFile)).toMatchSnapshot()
   })
+
+  test('should preserve source order across same-category statements', () => {
+    // Pins the inconsistent-comparator regression: under the previous sort,
+    // two `@jest/globals` imports both yielded `-1` from `compare(a, b)` and
+    // `compare(b, a)`, which V8's TimSort resolves by swapping the pair.
+    const code = `
+      import { jest } from '@jest/globals'
+      import { expect } from '@jest/globals'
+      test('foo', () => { expect(1).toBe(1) })
+    `
+    const sourceFile = ts.createSourceFile(__filename, code, ts.ScriptTarget.ES2015)
+    const result = ts.transform(sourceFile, [hoistJest(makeCompiler())])
+    const output = printer.printFile(result.transformed[0])
+
+    expect(output.indexOf('{ jest }')).toBeLessThan(output.indexOf('{ expect }'))
+  })
 })

--- a/src/transformers/hoist-jest.ts
+++ b/src/transformers/hoist-jest.ts
@@ -87,12 +87,17 @@ export function factory({ configSet }: TsCompilerInstance) {
       return statements
     }
 
-    return statements.sort((stmtA, stmtB) =>
-      isJestGlobalImport(stmtA) ||
-      (isHoistableStatement(stmtA) && !isHoistableStatement(stmtB) && !isJestGlobalImport(stmtB))
-        ? -1
-        : 1,
-    )
+    // Return 0 for same-category statements so stable sort preserves source
+    // order, the previous `-1 | 1`-only comparator violated ECMA's consistent
+    // comparison contract and let V8 reorder same-category pairs.
+    const priority = (stmt: _ts.Statement): number => {
+      if (isJestGlobalImport(stmt)) return 0
+      if (isHoistableStatement(stmt)) return 1
+
+      return 2
+    }
+
+    return statements.sort((a, b) => priority(a) - priority(b))
   }
 
   const createVisitor = (ctx: _ts.TransformationContext, _: _ts.SourceFile) => {


### PR DESCRIPTION
## Summary

Closes #4185. Replaces the inconsistent comparator in
`src/transformers/hoist-jest.ts::sortStatements` with a 3-tier priority
comparator.

The previous comparator only ever returned `-1` or `1`, never `0`,
which violates ECMA-262's consistent-comparison contract. For two
statements of the same category (both `@jest/globals` imports, both
hoistable, or both non-special), the comparator returned the same sign
in both directions:

```ts
compare(jestImportA, jestImportB)  // -1 (a comes first)
compare(jestImportB, jestImportA)  // -1 (also a comes first)
```

V8's resolution of this inconsistency differs by version:

| V8 | Symptom |
|---|---|
| Pre-TimSort (Node 10, OP environment) | Free reorder, producing the OP's `class extends class` reversal |
| TimSort (Node 12+) | Stable for "both → 1" cases, but still swaps two same-category items when both directions return -1, so two `@jest/globals` imports still get reversed on Node 24 |

## Fix

```ts
const priority = (stmt: _ts.Statement): number => {
  if (isJestGlobalImport(stmt)) return 0
  if (isHoistableStatement(stmt)) return 1

  return 2
}

return statements.sort((a, b) => priority(a) - priority(b))
```

Same-category pairs return `0`, so the stable sort preserves source order,
which is what the docstring on `sortStatements` already advertises.

## Tests

- **New regression test** (`should preserve source order across same-category statements`) pins the J-J reversal that still fires on modern V8. Verified RED on bare main with `Expected: < 7, Received: 47`. GREEN with the fix.
- **Existing `should hoist correctly when using with @jest/globals` snapshot** had frozen the buggy reversed order of three `@jest/globals` imports. The snapshot update reverses that reversal: the new output preserves source order, matching the fixture as written. Direct evidence the broken comparator was misordering even the project's own test fixture.

## Verification

| Stage | Result |
|---|---|
| `npm test` | 348 / 348 pass |
| `npm run test-e2e-cjs` | 27 / 27 pass |
| `npm run test-e2e-esm` | 29 / 29 pass |
| `npm run lint` | 0 errors |
| `npm run lint-prettier-ci` | clean |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed import statement ordering logic to preserve original source order when imports are in the same category, ensuring consistent and predictable behavior.

* **Tests**
  * Added test coverage to verify source order preservation for same-category import statements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kulshekhar/ts-jest/pull/5307)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->