### PR TITLE
fix: preserve Bundler on the CJS path under TypeScript >= 6

### DIFF
--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -545,11 +545,11 @@ describe('TsCompiler', () => {
 
       // Closes #4198. Each row is a `moduleResolution` value the user explicitly sets in
       // their tsconfig. The CJS path forces `module: CommonJS`, which TypeScript binds
-      // tightly to a small set of compatible resolutions:
+      // tightly to a small set of compatible resolutions on TS < 6:
       //   - Node10 / Classic: pass through (always valid with CommonJS)
       //   - Node16 / NodeNext: substitute → Node10 (TS5110 forbids them with CommonJS)
-      //   - Bundler: substitute → Node10 (TS5095 forbids CommonJS+Bundler on TS ≤ 5;
-      //     a TS6+ enhancement can pass Bundler through in a follow-up)
+      //   - Bundler: substitute → Node10 (TS5095 forbids CommonJS+Bundler on TS < 6)
+      // The TS >= 6 path is covered separately below.
       test.each([
         { moduleResolutionValue: 'Bundler', expectedKind: ts.ModuleResolutionKind.Node10 },
         { moduleResolutionValue: 'Node16', expectedKind: ts.ModuleResolutionKind.Node10 },
@@ -557,7 +557,7 @@ describe('TsCompiler', () => {
         { moduleResolutionValue: 'Classic', expectedKind: ts.ModuleResolutionKind.Classic },
         { moduleResolutionValue: 'Node10', expectedKind: ts.ModuleResolutionKind.Node10 },
       ])(
-        'should resolve user-supplied moduleResolution %p compatibly for non-ESM compilation',
+        'should resolve user-supplied moduleResolution %p compatibly for non-ESM compilation on TypeScript < 6',
         ({ moduleResolutionValue, expectedKind }) => {
           const configSet = createConfigSet({
             tsJestConfig: {
@@ -571,6 +571,56 @@ describe('TsCompiler', () => {
           const emptyFile = join(mockFolder, 'empty.ts')
           configSet.parsedTsConfig.fileNames.push(emptyFile)
           const compiler = new TsCompiler(configSet, new Map())
+          // @ts-expect-error testing purpose
+          compiler._languageService.getEmitOutput = jest.fn().mockReturnValueOnce({
+            outputFiles: [{ text: sourceMap }, { text: jsOutput }],
+            emitSkipped: false,
+          } as ts.EmitOutput)
+          // @ts-expect-error testing purpose
+          compiler.getDiagnostics = jest.fn().mockReturnValue([])
+
+          compiler.getCompiledOutput(fileContent, fileName, {
+            depGraphs: new Map(),
+            supportsStaticESM: false,
+            watchMode: false,
+          })
+
+          // @ts-expect-error testing purpose
+          const usedCompilerOptions = compiler._compilerOptions
+
+          expect(usedCompilerOptions.moduleResolution).toBe(expectedKind)
+        },
+      )
+
+      // TS 6 relaxed TS5095 to allow `module: CommonJS` paired with
+      // `moduleResolution: Bundler`. The CJS path now honors that: user-supplied
+      // Bundler is preserved instead of substituted to Node10, and Node16/NodeNext
+      // substitute to Bundler (matching the ESM-path substitution above) rather
+      // than Node10. The TS version is simulated by handing the compiler a ts-like
+      // proxy whose `version` reports 6.x; the real `ts` module is untouched.
+      test.each([
+        { moduleResolutionValue: 'Bundler', expectedKind: ts.ModuleResolutionKind.Bundler },
+        { moduleResolutionValue: 'Node16', expectedKind: ts.ModuleResolutionKind.Bundler },
+        { moduleResolutionValue: 'NodeNext', expectedKind: ts.ModuleResolutionKind.Bundler },
+        { moduleResolutionValue: 'Classic', expectedKind: ts.ModuleResolutionKind.Classic },
+        { moduleResolutionValue: 'Node10', expectedKind: ts.ModuleResolutionKind.Node10 },
+      ])(
+        'should resolve user-supplied moduleResolution %p compatibly for non-ESM compilation on TypeScript >= 6',
+        ({ moduleResolutionValue, expectedKind }) => {
+          const configSet = createConfigSet({
+            tsJestConfig: {
+              ...baseTsJestConfig,
+              tsconfig: {
+                module: 'CommonJS',
+                moduleResolution: moduleResolutionValue as TsConfigJson.CompilerOptions['moduleResolution'],
+              },
+            },
+          })
+          const emptyFile = join(mockFolder, 'empty.ts')
+          configSet.parsedTsConfig.fileNames.push(emptyFile)
+          const compiler = new TsCompiler(configSet, new Map())
+          // @ts-expect-error testing purpose: replace the ts reference on this compiler
+          compiler._ts = { ...ts, version: '6.0.0' } as unknown as typeof ts
           // @ts-expect-error testing purpose
           compiler._languageService.getEmitOutput = jest.fn().mockReturnValueOnce({
             outputFiles: [{ text: sourceMap }, { text: jsOutput }],

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -239,11 +239,11 @@ export class TsCompiler implements TsCompilerInstance {
    *     supports.)
    *
    *   - User-supplied Bundler with a non-Bundler-compatible forced module is
-   *     also TS5095 on the supported TS range — substitute Node10. (TypeScript
-   *     6 relaxed this for `module: CommonJS` specifically; that relaxation is
-   *     deliberately not encoded here so behavior stays consistent across the
-   *     full peerDependency range. See `isBundlerCompatibleModuleKind` for the
-   *     follow-up pointer.)
+   *     TS5095, substitute Node10. (TypeScript 6 relaxed this for
+   *     `module: CommonJS` specifically; that relaxation is encoded inside
+   *     `isBundlerCompatibleModuleKind` via a runtime version check, so on
+   *     TS ≥ 6 user-supplied Bundler passes through unchanged on the CJS
+   *     path.)
    *
    *   - Anything else (Node10 / Classic / unset) passes through or falls back
    *     to Node10. These pairings are valid with every forced module kind.
@@ -291,13 +291,12 @@ export class TsCompiler implements TsCompilerInstance {
    * user-supplied-`Bundler` pass-through, so neither path emits an invalid
    * pair when the user has selected a non-ES `module`.
    *
-   * Note: TypeScript 6.0 relaxed this restriction for `module: CommonJS`
-   * specifically (`CommonJS` + `Bundler` is now a valid pair on TS ≥ 6); the
-   * other non-ES module kinds (`AMD` / `UMD` / `System` / `None`) remain
-   * Bundler-incompatible on every TypeScript version. The TS 6 relaxation is
-   * intentionally not encoded here to keep behavior consistent across the full
-   * peerDependency range (`>=4.3 <7`); honoring it can ride in as a follow-up
-   * once the TS 6 baseline lands.
+   * TypeScript 6.0 relaxed TS5095 for `module: CommonJS` specifically
+   * (`CommonJS` + `Bundler` is a valid pair on TS ≥ 6); the other non-ES
+   * module kinds (`AMD` / `UMD` / `System` / `None`) remain Bundler-incompatible
+   * on every TypeScript version. The version is detected at runtime from
+   * `this._ts.version` so the function stays correct across the full
+   * peerDependency range (`>=4.3 <7`).
    *
    * @see https://www.typescriptlang.org/tsconfig/#moduleResolution
    */
@@ -311,6 +310,13 @@ export class TsCompiler implements TsCompilerInstance {
     // TypeScript versions the property is `undefined` at runtime.
     if (M.Preserve !== undefined && moduleKind === M.Preserve) {
       return true
+    }
+
+    // TS 6 made `CommonJS` + `Bundler` a valid pair.
+    if (moduleKind === M.CommonJS) {
+      const tsMajor = parseInt(this._ts.version.split('.')[0], 10)
+
+      return tsMajor >= 6
     }
 
     return false


### PR DESCRIPTION
## Summary

Follow-up to #5280, which closed #4198 but deliberately scoped out this
scenario to keep its change tied to a single release line. Addresses the
gap @H-Weisner flagged in
https://github.com/kulshekhar/ts-jest/issues/4198#issuecomment-4486963317.

TypeScript 6 relaxed TS5095 to allow `module: CommonJS` paired with
`moduleResolution: bundler`, but ts-jest still treated that pair as
incompatible on the CJS path, silently substituting user-set Bundler to
Node10 even on TS 6+.

## Fix

Detect the TypeScript major version at runtime in
`isBundlerCompatibleModuleKind` and treat `CommonJS` as Bundler-compatible
when the version is `>= 6`. The version is read from `this._ts.version`
rather than gated by the peerDependency floor, so the function stays correct
across the full range (`>=4.3 <7`).

```ts
if (moduleKind === M.CommonJS) {
  const tsMajor = parseInt(this._ts.version.split('.')[0], 10)

  return tsMajor >= 6
}
```

Other non-ES module kinds (`AMD` / `UMD` / `System` / `None`) remain
Bundler-incompatible on every TypeScript version, matching TypeScript's
own rules.

## Behavior matrix

| `module` | user-set `moduleResolution` | TS < 6 (unchanged) | TS >= 6 (new) |
|---|---|---|---|
| CommonJS | Bundler | substitute to Node10 | **pass through Bundler** |
| CommonJS | Node16 / NodeNext | substitute to Node10 | substitute to Bundler |
| CommonJS | Node10 / Classic | pass through | pass through |
| ESNext (ESM path) | any | unchanged | unchanged |

The Node16/NodeNext side effect mirrors the existing ESM-path substitution
to Bundler. Bundler is a closer semantic match for users who explicitly
selected Node-aware modern resolution than Node10, and the pair is valid
under TS 6.

## Tests

The existing parameterized CJS-path test stays as the TS < 6 case (dev
TypeScript is 5.9.3). A new sibling test block covers the TS >= 6 path by
handing the compiler a ts-like proxy whose `version` reports `6.0.0`, then
asserting that user-supplied moduleResolution values resolve the new way.

- Verified RED on bare main: 3 of 5 new rows fail with `Expected: 100 (Bundler), Received: 2 (Node10)`.
- GREEN with the fix.

## Verification

| Stage | Result |
|---|---|
| `npm test` | 355 / 355 pass |
| `npm run test-e2e-cjs` | 27 / 27 pass |
| `npm run test-e2e-esm` | 29 / 29 pass |
| `npm run lint` | 0 errors |
| `npm run lint-prettier-ci` | clean |
| `npm run build` | succeeds |
| Real TS 6.0.3 smoke (built dist) | `moduleResolution = Bundler` preserved with `module: CommonJS` |

## Refs

- Refs #4198
- Follow-up to #5280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript 6+ compatibility for module resolution configurations in CommonJS environments.

* **Tests**
  * Enhanced test coverage for module resolution compatibility across TypeScript versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->