### PR TITLE
feat: support TypeScript 7 (native) projects, with an experimental native type-checking engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,10 +77,11 @@
         "@babel/core": ">=7.0.0-beta.0 <8",
         "@jest/transform": "^29.0.0 || ^30.0.0",
         "@jest/types": "^29.0.0 || ^30.0.0",
+        "@typescript/typescript6": ">=6.0.0 <7",
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <7"
+        "typescript": ">=4.3 <8"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -90,6 +91,9 @@
           "optional": true
         },
         "@jest/types": {
+          "optional": true
+        },
+        "@typescript/typescript6": {
           "optional": true
         },
         "babel-jest": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "babel-jest": "^29.0.0 || ^30.0.0",
     "jest": "^29.0.0 || ^30.0.0",
     "jest-util": "^29.0.0 || ^30.0.0",
-    "typescript": ">=4.3 <7"
+    "typescript": ">=4.3 <8",
+    "@typescript/typescript6": ">=6.0.0 <7"
   },
   "peerDependenciesMeta": {
     "@babel/core": {
@@ -87,6 +88,9 @@
       "optional": true
     },
     "jest-util": {
+      "optional": true
+    },
+    "@typescript/typescript6": {
       "optional": true
     }
   },

--- a/src/legacy/compiler/native-diagnostics-service.spec.ts
+++ b/src/legacy/compiler/native-diagnostics-service.spec.ts
@@ -136,44 +136,58 @@ describe('NativeDiagnosticsService', () => {
     diagnosticsByFile = {},
     openFilesResolveToInferredProject = true,
   }: FakeServerSetup = {}) => {
-    const files = new Set(projectFiles)
     const calls = {
       constructed: 0,
       updateSnapshot: [] as unknown[],
       closed: 0,
       disposedSnapshots: 0,
     }
-    const project: NativeProject = {
-      configFileName: tsconfigPath,
-      program: {
-        getSyntacticDiagnostics: (file?: string) =>
-          (file ? diagnosticsByFile[file] ?? [] : []).filter((d) => d.code === 1005),
-        getSemanticDiagnostics: (file?: string) =>
-          (file ? diagnosticsByFile[file] ?? [] : []).filter((d) => d.code !== 1005),
-      },
-    }
-    const makeSnapshot = (): NativeSnapshot => ({
-      getProjects: () => [project],
-      getDefaultProjectForFile: (file: string) => (files.has(file) ? project : undefined),
-      dispose: () => {
-        calls.disposedSnapshots++
-      },
-    })
+    // each server instance mints its own project handle whose program throws once that server is
+    // closed — mirroring the real API, where handles are only valid for the server/snapshot that
+    // produced them. This lets the dispose test catch stale-cache regressions across respawn.
     class FakeApi {
+      private readonly _files = new Set(projectFiles)
+      private _closed = false
+      private readonly _project: NativeProject
       constructor() {
         calls.constructed++
+        const assertAlive = () => {
+          if (this._closed) throw new Error('stale project handle: its server was closed')
+        }
+        this._project = {
+          configFileName: tsconfigPath,
+          program: {
+            getSyntacticDiagnostics: (file?: string) => {
+              assertAlive()
+
+              return (file ? diagnosticsByFile[file] ?? [] : []).filter((d) => d.code === 1005)
+            },
+            getSemanticDiagnostics: (file?: string) => {
+              assertAlive()
+
+              return (file ? diagnosticsByFile[file] ?? [] : []).filter((d) => d.code !== 1005)
+            },
+          },
+        }
       }
       updateSnapshot(params?: unknown): NativeSnapshot {
         calls.updateSnapshot.push(params)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const openFiles: string[] | undefined = (params as any)?.openFiles
         if (openFiles && openFilesResolveToInferredProject) {
-          openFiles.forEach((file) => files.add(file))
+          openFiles.forEach((file) => this._files.add(file))
         }
 
-        return makeSnapshot()
+        return {
+          getProjects: () => [this._project],
+          getDefaultProjectForFile: (file: string) => (this._files.has(file) ? this._project : undefined),
+          dispose: () => {
+            calls.disposedSnapshots++
+          },
+        }
       }
       close(): void {
+        this._closed = true
         calls.closed++
       }
     }
@@ -267,17 +281,31 @@ describe('NativeDiagnosticsService', () => {
     expect(calls.updateSnapshot).toHaveLength(0)
   })
 
-  it('should close the server on dispose', () => {
-    const { service, calls } = createService()
+  it('should close the server on dispose and not reuse any snapshot-scoped state on respawn', () => {
+    const { service, calls } = createService({
+      diagnosticsByFile: {
+        [inProjectFile]: [
+          { fileName: inProjectFile, pos: 2, end: 3, code: 2322, category: ts.DiagnosticCategory.Error, text: 'sem' },
+        ],
+      },
+    })
+    // also populate the openFiles bookkeeping before disposing
+    service.check(orphanFile)
     service.check(inProjectFile)
 
     service.dispose()
 
     expect(calls.closed).toBe(1)
 
-    // and re-spawn cleanly if used again
-    service.check(inProjectFile)
-
+    // re-spawn cleanly: cached project handles from the dead server must not be used…
+    expect(service.check(inProjectFile).map((d) => d.code)).toEqual([2322])
     expect(calls.constructed).toBe(2)
+    // …and files opened on the dead server must be re-opened on the new one
+    expect(service.check(orphanFile)).toEqual([])
+    const openFileCalls = calls.updateSnapshot.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (params) => (params as any)?.openFiles?.includes(orphanFile),
+    )
+    expect(openFileCalls).toHaveLength(2)
   })
 })

--- a/src/legacy/compiler/native-diagnostics-service.spec.ts
+++ b/src/legacy/compiler/native-diagnostics-service.spec.ts
@@ -1,0 +1,283 @@
+import { testing } from 'bs-logger'
+import ts from 'typescript'
+
+import {
+  mapNativeDiagnostics,
+  NativeDiagnostic,
+  NativeDiagnosticsService,
+  NativeProject,
+  NativeSnapshot,
+  probeNativeApi,
+} from './native-diagnostics-service'
+
+const logger = testing.createLoggerMock()
+
+beforeEach(() => {
+  logger.target.clear()
+})
+
+describe('probeNativeApi', () => {
+  it('should report unavailable with the loader error as reason', () => {
+    const result = probeNativeApi(() => {
+      throw new Error("Cannot find module 'typescript/unstable/sync'\nRequire stack: ...")
+    })
+
+    expect(result).toEqual({ available: false, reason: "Cannot find module 'typescript/unstable/sync'" })
+  })
+
+  it('should report unavailable when the module has no API constructor', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = probeNativeApi(() => ({} as any))
+
+    expect(result.available).toBe(false)
+  })
+
+  it('should report available when the module exposes an API constructor', () => {
+    class FakeApi {
+      close(): void {
+        // noop
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = probeNativeApi(() => ({ API: FakeApi } as any))
+
+    expect(result.available).toBe(true)
+  })
+})
+
+describe('mapNativeDiagnostics', () => {
+  const fileName = '/project/src/foo.ts'
+  const fileContent = 'const a: number = "oops"\n'
+  const readFile = (name: string) => (name === fileName ? fileContent : undefined)
+
+  it('should map a plain diagnostic to the classic shape with a real source file', () => {
+    const native: NativeDiagnostic[] = [
+      { fileName, pos: 6, end: 7, code: 2322, category: ts.DiagnosticCategory.Error, text: 'nope' },
+    ]
+    const [mapped] = mapNativeDiagnostics(native, ts, readFile)
+
+    expect(mapped.code).toBe(2322)
+    expect(mapped.category).toBe(ts.DiagnosticCategory.Error)
+    expect(mapped.messageText).toBe('nope')
+    expect(mapped.start).toBe(6)
+    expect(mapped.length).toBe(1)
+    expect(mapped.file?.fileName).toBe(fileName)
+    expect(mapped.file?.text).toBe(fileContent)
+    // the produced diagnostic must be formattable by the classic pretty formatter
+    const formatted = ts.formatDiagnosticsWithColorAndContext([mapped], {
+      getNewLine: () => '\n',
+      getCurrentDirectory: () => '/project',
+      getCanonicalFileName: (path) => path,
+    })
+    expect(formatted).toContain('TS2322')
+  })
+
+  it('should map a message chain recursively', () => {
+    const native: NativeDiagnostic[] = [
+      {
+        fileName,
+        pos: 0,
+        end: 5,
+        code: 2345,
+        category: ts.DiagnosticCategory.Error,
+        text: 'outer',
+        messageChain: [
+          {
+            fileName,
+            pos: 0,
+            end: 5,
+            code: 2322,
+            category: ts.DiagnosticCategory.Message,
+            text: 'inner',
+            messageChain: [
+              { fileName, pos: 0, end: 5, code: 2320, category: ts.DiagnosticCategory.Message, text: 'innermost' },
+            ],
+          },
+        ],
+      },
+    ]
+    const [mapped] = mapNativeDiagnostics(native, ts, readFile)
+    const chain = mapped.messageText as ts.DiagnosticMessageChain
+
+    expect(chain.messageText).toBe('outer')
+    expect(chain.code).toBe(2345)
+    expect(chain.next?.[0].messageText).toBe('inner')
+    expect(chain.next?.[0].next?.[0].messageText).toBe('innermost')
+  })
+
+  it('should map diagnostics without a file or with unreadable file content', () => {
+    const native: NativeDiagnostic[] = [
+      { pos: 0, end: 0, code: 5023, category: ts.DiagnosticCategory.Error, text: 'config error' },
+      { fileName: '/gone.ts', pos: 3, end: 4, code: 2322, category: ts.DiagnosticCategory.Error, text: 'nope' },
+    ]
+    const [noFile, unreadable] = mapNativeDiagnostics(native, ts, readFile)
+
+    expect(noFile.file).toBeUndefined()
+    expect(noFile.start).toBeUndefined()
+    expect(unreadable.file).toBeUndefined()
+    expect(unreadable.start).toBeUndefined()
+    expect(unreadable.code).toBe(2322)
+  })
+})
+
+describe('NativeDiagnosticsService', () => {
+  const tsconfigPath = '/project/tsconfig.json'
+  const inProjectFile = '/project/src/in-project.ts'
+  const orphanFile = '/project/orphan.spec.ts'
+
+  interface FakeServerSetup {
+    projectFiles?: string[]
+    diagnosticsByFile?: Record<string, NativeDiagnostic[]>
+    openFilesResolveToInferredProject?: boolean
+  }
+
+  const createFakeServer = ({
+    projectFiles = [inProjectFile],
+    diagnosticsByFile = {},
+    openFilesResolveToInferredProject = true,
+  }: FakeServerSetup = {}) => {
+    const files = new Set(projectFiles)
+    const calls = {
+      constructed: 0,
+      updateSnapshot: [] as unknown[],
+      closed: 0,
+      disposedSnapshots: 0,
+    }
+    const project: NativeProject = {
+      configFileName: tsconfigPath,
+      program: {
+        getSyntacticDiagnostics: (file?: string) =>
+          (file ? diagnosticsByFile[file] ?? [] : []).filter((d) => d.code === 1005),
+        getSemanticDiagnostics: (file?: string) =>
+          (file ? diagnosticsByFile[file] ?? [] : []).filter((d) => d.code !== 1005),
+      },
+    }
+    const makeSnapshot = (): NativeSnapshot => ({
+      getProjects: () => [project],
+      getDefaultProjectForFile: (file: string) => (files.has(file) ? project : undefined),
+      dispose: () => {
+        calls.disposedSnapshots++
+      },
+    })
+    class FakeApi {
+      constructor() {
+        calls.constructed++
+      }
+      updateSnapshot(params?: unknown): NativeSnapshot {
+        calls.updateSnapshot.push(params)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const openFiles: string[] | undefined = (params as any)?.openFiles
+        if (openFiles && openFilesResolveToInferredProject) {
+          openFiles.forEach((file) => files.add(file))
+        }
+
+        return makeSnapshot()
+      }
+      close(): void {
+        calls.closed++
+      }
+    }
+
+    return { loader: () => ({ API: FakeApi }), calls }
+  }
+
+  const createService = (setup: FakeServerSetup = {}) => {
+    const { loader, calls } = createFakeServer(setup)
+    const service = new NativeDiagnosticsService({
+      ts,
+      logger,
+      cwd: '/project',
+      tsconfigPath,
+      readFile: () => 'const a = 1\n',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      loadApi: loader as any,
+    })
+
+    return { service, calls }
+  }
+
+  it('should lazily spawn the server and open the project on the first check', () => {
+    const { service, calls } = createService()
+
+    expect(calls.constructed).toBe(0)
+
+    service.check(inProjectFile)
+
+    expect(calls.constructed).toBe(1)
+    expect(calls.updateSnapshot[0]).toEqual({ openProjects: [tsconfigPath] })
+
+    service.check(inProjectFile)
+
+    expect(calls.constructed).toBe(1)
+  })
+
+  it('should return mapped syntactic + semantic diagnostics for an in-project file', () => {
+    const { service } = createService({
+      diagnosticsByFile: {
+        [inProjectFile]: [
+          { fileName: inProjectFile, pos: 0, end: 1, code: 1005, category: ts.DiagnosticCategory.Error, text: 'syn' },
+          { fileName: inProjectFile, pos: 2, end: 3, code: 2322, category: ts.DiagnosticCategory.Error, text: 'sem' },
+        ],
+      },
+    })
+    const diagnostics = service.check(inProjectFile)
+
+    expect(diagnostics.map((d) => d.code)).toEqual([1005, 2322])
+    expect(diagnostics.map((d) => d.messageText)).toEqual(['syn', 'sem'])
+  })
+
+  it('should open out-of-project files via openFiles and check them', () => {
+    const { service, calls } = createService({
+      diagnosticsByFile: {
+        [orphanFile]: [
+          { fileName: orphanFile, pos: 0, end: 1, code: 2322, category: ts.DiagnosticCategory.Error, text: 'sem' },
+        ],
+      },
+    })
+    const diagnostics = service.check(orphanFile)
+
+    expect(calls.updateSnapshot[1]).toEqual({ openFiles: [orphanFile] })
+    expect(diagnostics.map((d) => d.code)).toEqual([2322])
+  })
+
+  it('should warn once and return no diagnostics for files no project can resolve', () => {
+    const { service } = createService({ openFilesResolveToInferredProject: false })
+
+    expect(service.check(orphanFile)).toEqual([])
+    expect(service.check(orphanFile)).toEqual([])
+    expect(logger.target.lines.warn).toHaveLength(1)
+  })
+
+  it('should refresh the snapshot (and dispose the previous one) on invalidate', () => {
+    const { service, calls } = createService()
+    service.check(inProjectFile)
+
+    service.invalidate([inProjectFile])
+
+    expect(calls.updateSnapshot[1]).toEqual({ fileChanges: { changed: [inProjectFile] } })
+    expect(calls.disposedSnapshots).toBe(1)
+  })
+
+  it('should do nothing on invalidate before the server was ever spawned', () => {
+    const { service, calls } = createService()
+
+    service.invalidate([inProjectFile])
+
+    expect(calls.constructed).toBe(0)
+    expect(calls.updateSnapshot).toHaveLength(0)
+  })
+
+  it('should close the server on dispose', () => {
+    const { service, calls } = createService()
+    service.check(inProjectFile)
+
+    service.dispose()
+
+    expect(calls.closed).toBe(1)
+
+    // and re-spawn cleanly if used again
+    service.check(inProjectFile)
+
+    expect(calls.constructed).toBe(2)
+  })
+})

--- a/src/legacy/compiler/native-diagnostics-service.ts
+++ b/src/legacy/compiler/native-diagnostics-service.ts
@@ -295,5 +295,11 @@ export class NativeDiagnosticsService {
     }
     this._api = undefined
     this._snapshot = undefined
+    // everything below is scoped to the server that just went away: cached project handles are
+    // only valid within the snapshot that produced them, opened files are opens on the dead
+    // server, and previously unresolvable files may resolve fine on a fresh one
+    this._projectCache.clear()
+    this._openedFiles.clear()
+    this._unresolvableFiles.clear()
   }
 }

--- a/src/legacy/compiler/native-diagnostics-service.ts
+++ b/src/legacy/compiler/native-diagnostics-service.ts
@@ -194,6 +194,11 @@ export class NativeDiagnosticsService {
   private _snapshot: NativeSnapshot | undefined
   private readonly _openedFiles = new Set<string>()
   private readonly _unresolvableFiles = new Set<string>()
+  /**
+   * Default-project lookups round-trip to the server, so resolutions are cached per snapshot
+   * (project handles are only valid within the snapshot that produced them).
+   */
+  private readonly _projectCache = new Map<string, NativeProject>()
   private readonly _logger: Logger
 
   constructor(private readonly _options: NativeDiagnosticsServiceOptions) {
@@ -220,6 +225,7 @@ export class NativeDiagnosticsService {
   private _replaceSnapshot(newSnapshot: NativeSnapshot): NativeSnapshot {
     const previous = this._snapshot
     this._snapshot = newSnapshot
+    this._projectCache.clear()
     /* istanbul ignore next */
     try {
       previous?.dispose()
@@ -232,7 +238,7 @@ export class NativeDiagnosticsService {
 
   private _projectFor(fileName: string): NativeProject | undefined {
     let snapshot = this._ensureSnapshot()
-    let project = snapshot.getDefaultProjectForFile(fileName)
+    let project = this._projectCache.get(fileName) ?? snapshot.getDefaultProjectForFile(fileName)
     if (!project && !this._openedFiles.has(fileName)) {
       // Files outside the tsconfig file list (e.g. specs not covered by `include`) need an
       // explicit open; they resolve to a containing configured project or an inferred project.
@@ -241,6 +247,7 @@ export class NativeDiagnosticsService {
       snapshot = this._replaceSnapshot(this._api!.updateSnapshot({ openFiles: [fileName] }))
       project = snapshot.getDefaultProjectForFile(fileName)
     }
+    if (project) this._projectCache.set(fileName, project)
 
     return project
   }

--- a/src/legacy/compiler/native-diagnostics-service.ts
+++ b/src/legacy/compiler/native-diagnostics-service.ts
@@ -1,0 +1,292 @@
+import type { Logger } from 'bs-logger'
+import type * as _ts from 'typescript'
+
+import type { TTypeScript } from '../../types'
+
+/**
+ * Minimal structural typings for the native TypeScript (7+) synchronous API exposed at
+ * `typescript/unstable/sync`. Kept structural on purpose: the API is officially unstable until
+ * TypeScript 7.1, and ts-jest must build against the TypeScript 6 JS API typings.
+ *
+ * @internal
+ */
+export interface NativeDiagnostic {
+  fileName?: string
+  pos: number
+  end: number
+  code: number
+  category: _ts.DiagnosticCategory
+  text: string
+  messageChain?: readonly NativeDiagnostic[]
+}
+
+/**
+ * @internal
+ */
+export interface NativeProgram {
+  getSyntacticDiagnostics(file?: string): readonly NativeDiagnostic[]
+  getSemanticDiagnostics(file?: string): readonly NativeDiagnostic[]
+}
+
+/**
+ * @internal
+ */
+export interface NativeProject {
+  configFileName: string
+  program: NativeProgram
+}
+
+/**
+ * @internal
+ */
+export interface NativeSnapshot {
+  getProjects(): readonly NativeProject[]
+  getDefaultProjectForFile(file: string): NativeProject | undefined
+  dispose(): void
+}
+
+/**
+ * @internal
+ */
+export interface NativeUpdateSnapshotParams {
+  openProjects?: string[]
+  openFiles?: string[]
+  fileChanges?: { changed?: string[]; deleted?: string[] } | { invalidateAll: true }
+}
+
+/**
+ * @internal
+ */
+export interface NativeApi {
+  updateSnapshot(params?: NativeUpdateSnapshotParams): NativeSnapshot
+  close(): void
+}
+
+/**
+ * @internal
+ */
+export interface NativeApiModule {
+  API: new (options?: { cwd?: string }) => NativeApi
+}
+
+/**
+ * @internal
+ */
+export type NativeApiLoader = () => NativeApiModule
+
+const NATIVE_SYNC_API_SPECIFIER = 'typescript/unstable/sync'
+
+/* istanbul ignore next (exercised via e2e fixtures — requires a native TypeScript install) */
+const defaultLoadNativeApi: NativeApiLoader = () => {
+  const resolved = require.resolve(NATIVE_SYNC_API_SPECIFIER, { paths: [process.cwd(), __dirname] })
+
+  // Node >=20.19 / >=22.12 supports synchronous `require()` of ES modules, which is what the
+  // native API entry point is. On older Node versions this throws `ERR_REQUIRE_ESM`, which the
+  // caller converts into a graceful fallback to the classic engine.
+  return require(resolved) as NativeApiModule
+}
+
+/**
+ * @internal
+ */
+export type NativeApiProbeResult = { available: true; version: string } | { available: false; reason: string }
+
+/**
+ * Cheap availability probe for the native API: resolves and loads the client module but does NOT
+ * spawn the native compiler process.
+ *
+ * @internal
+ */
+export function probeNativeApi(loadApi: NativeApiLoader = defaultLoadNativeApi): NativeApiProbeResult {
+  let mod: NativeApiModule
+  try {
+    mod = loadApi()
+  } catch (e) {
+    return { available: false, reason: (e as Error).message.split('\n')[0] }
+  }
+  if (typeof mod?.API !== 'function') {
+    return { available: false, reason: `'${NATIVE_SYNC_API_SPECIFIER}' resolved but did not expose an API constructor` }
+  }
+  let version = 'unknown'
+  try {
+    version = (
+      require(require.resolve('typescript/package.json', { paths: [process.cwd(), __dirname] })) as { version: string }
+    ).version
+  } catch {
+    // keep 'unknown'
+  }
+
+  return { available: true, version }
+}
+
+/**
+ * Map diagnostics from the native wire shape (`{fileName, pos, end, code, category, text, messageChain}`)
+ * to the classic Strada `ts.Diagnostic` shape (`{file, start, length, code, category, messageText}`), so
+ * the whole existing reporting pipeline (`raiseDiagnostics`, `ignoreCodes`, `warnOnly`, `exclude`,
+ * `formatDiagnostics[WithColorAndContext]`) keeps working untouched.
+ *
+ * `DiagnosticCategory` numeric values are identical on both sides (Warning=0, Error=1, Suggestion=2,
+ * Message=3), so the category passes through as-is.
+ *
+ * @internal
+ */
+export function mapNativeDiagnostics(
+  nativeDiagnostics: readonly NativeDiagnostic[],
+  ts: TTypeScript,
+  readFile: (fileName: string) => string | undefined,
+): _ts.Diagnostic[] {
+  const sourceFileCache = new Map<string, _ts.SourceFile | undefined>()
+  const getSourceFile = (fileName: string | undefined): _ts.SourceFile | undefined => {
+    if (!fileName) return undefined
+    if (!sourceFileCache.has(fileName)) {
+      const content = readFile(fileName)
+      sourceFileCache.set(
+        fileName,
+        content === undefined ? undefined : ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest),
+      )
+    }
+
+    return sourceFileCache.get(fileName)
+  }
+  const toMessageChain = (diagnostic: NativeDiagnostic): _ts.DiagnosticMessageChain => ({
+    messageText: diagnostic.text,
+    category: diagnostic.category,
+    code: diagnostic.code,
+    next: diagnostic.messageChain?.length ? diagnostic.messageChain.map(toMessageChain) : undefined,
+  })
+
+  return nativeDiagnostics.map((diagnostic) => {
+    const file = getSourceFile(diagnostic.fileName)
+
+    return {
+      file,
+      start: file ? diagnostic.pos : undefined,
+      length: file ? diagnostic.end - diagnostic.pos : undefined,
+      code: diagnostic.code,
+      category: diagnostic.category,
+      messageText: diagnostic.messageChain?.length ? toMessageChain(diagnostic) : diagnostic.text,
+    }
+  })
+}
+
+/**
+ * @internal
+ */
+export interface NativeDiagnosticsServiceOptions {
+  ts: TTypeScript
+  logger: Logger
+  cwd: string
+  /** Path of the resolved tsconfig file, when it exists on disk */
+  tsconfigPath: string | undefined
+  readFile: (fileName: string) => string | undefined
+  loadApi?: NativeApiLoader
+}
+
+/**
+ * Per-worker type-checking service backed by the native TypeScript (7+) compiler, spoken to over
+ * the synchronous stdio API. Owns exactly one native server process, spawned lazily on the first
+ * check. JavaScript emit never goes through here — only diagnostics.
+ *
+ * @internal
+ */
+export class NativeDiagnosticsService {
+  private _api: NativeApi | undefined
+  private _snapshot: NativeSnapshot | undefined
+  private readonly _openedFiles = new Set<string>()
+  private readonly _unresolvableFiles = new Set<string>()
+  private readonly _logger: Logger
+
+  constructor(private readonly _options: NativeDiagnosticsServiceOptions) {
+    this._logger = _options.logger.child({ namespace: 'native-diagnostics' })
+  }
+
+  private _ensureSnapshot(): NativeSnapshot {
+    if (!this._api) {
+      const { API } = (this._options.loadApi ?? defaultLoadNativeApi)()
+      this._logger.debug(
+        { tsconfigPath: this._options.tsconfigPath },
+        '_ensureSnapshot(): spawning native TypeScript API server',
+      )
+      this._api = new API({ cwd: this._options.cwd })
+      this._snapshot = this._api.updateSnapshot(
+        this._options.tsconfigPath ? { openProjects: [this._options.tsconfigPath] } : undefined,
+      )
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this._snapshot!
+  }
+
+  private _replaceSnapshot(newSnapshot: NativeSnapshot): NativeSnapshot {
+    const previous = this._snapshot
+    this._snapshot = newSnapshot
+    /* istanbul ignore next */
+    try {
+      previous?.dispose()
+    } catch {
+      // the server may already have released it
+    }
+
+    return newSnapshot
+  }
+
+  private _projectFor(fileName: string): NativeProject | undefined {
+    let snapshot = this._ensureSnapshot()
+    let project = snapshot.getDefaultProjectForFile(fileName)
+    if (!project && !this._openedFiles.has(fileName)) {
+      // Files outside the tsconfig file list (e.g. specs not covered by `include`) need an
+      // explicit open; they resolve to a containing configured project or an inferred project.
+      this._openedFiles.add(fileName)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      snapshot = this._replaceSnapshot(this._api!.updateSnapshot({ openFiles: [fileName] }))
+      project = snapshot.getDefaultProjectForFile(fileName)
+    }
+
+    return project
+  }
+
+  /**
+   * Compute syntactic + semantic diagnostics for one file, mapped to the classic `ts.Diagnostic` shape.
+   */
+  check(fileName: string): _ts.Diagnostic[] {
+    const project = this._projectFor(fileName)
+    if (!project) {
+      if (!this._unresolvableFiles.has(fileName)) {
+        this._unresolvableFiles.add(fileName)
+        this._logger.warn(
+          { fileName },
+          'check(): the native TypeScript API could not resolve a project for this file, skipping type-checking for it',
+        )
+      }
+
+      return []
+    }
+    this._logger.debug({ fileName, project: project.configFileName }, 'check(): computing native diagnostics')
+    const nativeDiagnostics = [
+      ...project.program.getSyntacticDiagnostics(fileName),
+      ...project.program.getSemanticDiagnostics(fileName),
+    ]
+
+    return mapNativeDiagnostics(nativeDiagnostics, this._options.ts, this._options.readFile)
+  }
+
+  /**
+   * Tell the native server that files changed on disk (watch mode), producing a fresh snapshot.
+   */
+  invalidate(changedFiles: string[]): void {
+    if (!this._api) return
+    this._logger.debug({ changedFiles }, 'invalidate(): refreshing native snapshot')
+    this._replaceSnapshot(this._api.updateSnapshot({ fileChanges: { changed: changedFiles } }))
+  }
+
+  dispose(): void {
+    /* istanbul ignore next */
+    try {
+      this._api?.close()
+    } catch {
+      // the server process may already be gone; its stdio channel also kills it on process exit
+    }
+    this._api = undefined
+    this._snapshot = undefined
+  }
+}

--- a/src/legacy/compiler/ts-compiler-native-engine.spec.ts
+++ b/src/legacy/compiler/ts-compiler-native-engine.spec.ts
@@ -1,0 +1,213 @@
+import { join } from 'path'
+
+import ts from 'typescript'
+
+import { makeCompiler } from '../../__helpers__/fakers'
+import type { TsJestTransformerOptions } from '../../types'
+
+import { NativeDiagnosticsService } from './native-diagnostics-service'
+
+jest.mock('./native-diagnostics-service', () => {
+  const actual = jest.requireActual('./native-diagnostics-service')
+
+  return {
+    ...actual,
+    probeNativeApi: jest.fn(() => ({ available: true, version: '7.0.2' })),
+    NativeDiagnosticsService: jest.fn().mockImplementation(() => ({
+      check: jest.fn(() => []),
+      invalidate: jest.fn(),
+      dispose: jest.fn(),
+    })),
+  }
+})
+
+const mockedServiceCtor = jest.mocked(NativeDiagnosticsService)
+
+const mockFolder = join(process.cwd(), 'src', '__mocks__')
+const fileName = join(mockFolder, 'thing.ts')
+const fileContent = 'const x = 1\n'
+
+const typeError: ts.Diagnostic = {
+  file: undefined,
+  start: undefined,
+  length: undefined,
+  code: 2322,
+  category: ts.DiagnosticCategory.Error,
+  messageText: "Type 'string' is not assignable to type 'number'.",
+}
+
+const cjsTsconfig = { module: 'commonjs', target: 'es2015' } as TsJestTransformerOptions['tsconfig']
+
+const createNativeCompiler = (diagnosticsOverrides: Record<string, unknown> = {}) =>
+  makeCompiler({
+    tsJestConfig: {
+      tsconfig: cjsTsconfig,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      diagnostics: { engine: 'native', ...diagnosticsOverrides } as any,
+    },
+  })
+
+const lastServiceInstance = () =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockedServiceCtor.mock.results[mockedServiceCtor.mock.results.length - 1]?.value as any
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('TsCompiler with the native diagnostics engine', () => {
+  it('should not construct a LanguageService and should create the native service instead', () => {
+    const compiler = makeCompiler({
+      tsJestConfig: {
+        tsconfig: join(process.cwd(), 'tsconfig.json'),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        diagnostics: { engine: 'native' } as any,
+      },
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((compiler as any)._languageService).toBeUndefined()
+    expect(mockedServiceCtor).toHaveBeenCalledTimes(1)
+    expect(mockedServiceCtor.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        cwd: expect.any(String),
+        tsconfigPath: expect.stringContaining('tsconfig.json'),
+      }),
+    )
+  })
+
+  it('should pass the discovered tsconfig path to the native service even with inline tsconfig overrides', () => {
+    createNativeCompiler()
+
+    // inline `tsconfig` ts-jest options are overrides on top of the discovered tsconfig file; the
+    // native server loads the project from that file (inline overrides are a documented limitation)
+    expect(mockedServiceCtor.mock.calls[0][0].tsconfigPath).toContain('tsconfig.json')
+  })
+
+  it('should emit through the transpile path and consult the native checker', () => {
+    const compiler = createNativeCompiler()
+    const output = compiler.getCompiledOutput(fileContent, fileName, {
+      depGraphs: new Map(),
+      supportsStaticESM: false,
+      watchMode: false,
+    })
+
+    expect(output.code).toContain('const x = 1')
+    expect(lastServiceInstance().check).toHaveBeenCalledWith(fileName)
+    expect(lastServiceInstance().invalidate).not.toHaveBeenCalled()
+  })
+
+  it('should raise native diagnostics like the language-service path (throwing on type errors)', () => {
+    const compiler = createNativeCompiler()
+    lastServiceInstance().check.mockReturnValue([typeError])
+
+    expect(() =>
+      compiler.getCompiledOutput(fileContent, fileName, {
+        depGraphs: new Map(),
+        supportsStaticESM: false,
+        watchMode: false,
+      }),
+    ).toThrow("Type 'string' is not assignable to type 'number'.")
+  })
+
+  it('should honor diagnostics.ignoreCodes for native diagnostics', () => {
+    const compiler = createNativeCompiler({ ignoreCodes: [2322] })
+    lastServiceInstance().check.mockReturnValue([typeError])
+
+    expect(() =>
+      compiler.getCompiledOutput(fileContent, fileName, {
+        depGraphs: new Map(),
+        supportsStaticESM: false,
+        watchMode: false,
+      }),
+    ).not.toThrow()
+  })
+
+  it('should only warn when diagnostics.warnOnly is enabled', () => {
+    const compiler = createNativeCompiler({ warnOnly: true })
+    lastServiceInstance().check.mockReturnValue([typeError])
+
+    expect(() =>
+      compiler.getCompiledOutput(fileContent, fileName, {
+        depGraphs: new Map(),
+        supportsStaticESM: false,
+        watchMode: false,
+      }),
+    ).not.toThrow()
+  })
+
+  it('should return diagnostics instead of raising in ESM mode, for processAsync to raise', () => {
+    const compiler = makeCompiler({
+      tsJestConfig: {
+        useESM: true,
+        tsconfig: { module: 'esnext', target: 'es2019' } as TsJestTransformerOptions['tsconfig'],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        diagnostics: { engine: 'native' } as any,
+      },
+    })
+    lastServiceInstance().check.mockReturnValue([typeError])
+
+    const output = compiler.getCompiledOutput(fileContent, fileName, {
+      depGraphs: new Map(),
+      supportsStaticESM: true,
+      watchMode: false,
+    })
+
+    expect(output.diagnostics).toEqual([typeError])
+  })
+
+  it('should invalidate the changed file in watch mode before checking', () => {
+    const compiler = createNativeCompiler()
+    compiler.getCompiledOutput(fileContent, fileName, {
+      depGraphs: new Map(),
+      supportsStaticESM: false,
+      watchMode: true,
+    })
+
+    expect(lastServiceInstance().invalidate).toHaveBeenCalledWith([fileName])
+    expect(lastServiceInstance().check).toHaveBeenCalledWith(fileName)
+  })
+
+  it('should re-check importers in watch mode when the changed file has errors and warnOnly is set', () => {
+    const importerFile = join(mockFolder, 'importer.ts')
+    const compiler = createNativeCompiler({ warnOnly: true })
+    lastServiceInstance().check.mockReturnValue([typeError])
+    const depGraphs = new Map([[importerFile, { fileContent: 'import "./thing"', resolvedModuleNames: [fileName] }]])
+
+    compiler.getCompiledOutput(fileContent, fileName, {
+      depGraphs,
+      supportsStaticESM: false,
+      watchMode: true,
+    })
+
+    expect(lastServiceInstance().check).toHaveBeenCalledWith(importerFile)
+  })
+
+  it('should delegate syntactic diagnostics to the native engine instead of the transpiler', () => {
+    const brokenContent = 'const x: = {'
+    // engine compiler + isolated transpile reports the syntax error itself...
+    const compilerEngine = makeCompiler({
+      tsJestConfig: { tsconfig: { ...(cjsTsconfig as object), isolatedModules: true } },
+    })
+
+    expect(() =>
+      compilerEngine.getCompiledOutput(brokenContent, fileName, {
+        depGraphs: new Map(),
+        supportsStaticESM: false,
+        watchMode: false,
+      }),
+    ).toThrow()
+
+    // ...whereas with the native engine the transpiler stays silent and reporting is the checker's job
+    const nativeEngine = createNativeCompiler()
+
+    expect(() =>
+      nativeEngine.getCompiledOutput(brokenContent, fileName, {
+        depGraphs: new Map(),
+        supportsStaticESM: false,
+        watchMode: false,
+      }),
+    ).not.toThrow()
+    expect(lastServiceInstance().check).toHaveBeenCalledWith(fileName)
+  })
+})

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -7,7 +7,6 @@ import ts from 'typescript'
 
 import { createConfigSet, makeCompiler } from '../../__helpers__/fakers'
 import { logTargetMock } from '../../__helpers__/mocks'
-import { tsTranspileModule } from '../../transpilers/typescript/transpile-module'
 import type { DepGraphInfo, TsJestTransformerOptions } from '../../types'
 import { Errors, Helps, interpolate } from '../../utils/messages'
 
@@ -23,16 +22,15 @@ jest.mock('typescript', () => {
     default: actualModule,
   }
 })
+const mockTsTranspileModule = jest.fn()
 jest.mock('../../transpilers/typescript/transpile-module', () => {
   const actualModule = jest.requireActual('../../transpilers/typescript/transpile-module')
 
   return {
     ...actualModule,
-    tsTranspileModule: jest.fn(),
+    createTsTranspileModule: jest.fn(() => mockTsTranspileModule),
   }
 })
-
-const mockTsTranspileModule = jest.mocked(tsTranspileModule)
 
 const mockFolder = join(process.cwd(), 'src', '__mocks__')
 

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -2,7 +2,8 @@ import { basename, normalize } from 'path'
 
 import { LogContexts, Logger, LogLevels } from 'bs-logger'
 import memoize from 'lodash.memoize'
-import ts, {
+import type ts from 'typescript'
+import type {
   Bundle,
   CompilerOptions,
   CustomTransformerFactory,
@@ -23,7 +24,11 @@ import ts, {
 } from 'typescript'
 
 import { JS_JSX_REGEX, LINE_FEED, TS_TSX_REGEX } from '../../constants'
-import { isModernNodeModuleKind, tsTranspileModule } from '../../transpilers/typescript/transpile-module'
+import {
+  createTsTranspileModule,
+  ExtendedTsTranspileModuleFn,
+  isModernNodeModuleKind,
+} from '../../transpilers/typescript/transpile-module'
 import type {
   StringMap,
   TsCompilerInstance,
@@ -39,11 +44,12 @@ import type { ConfigSet } from '../config/config-set'
 import { updateOutput } from './compiler-utils'
 
 const assertCompilerOptionsWithJestTransformMode = (
-  compilerOptions: ts.CompilerOptions,
+  tsModule: TTypeScript,
+  compilerOptions: CompilerOptions,
   isEsmMode: boolean,
   logger: Logger,
 ): void => {
-  if (isEsmMode && compilerOptions.module === ts.ModuleKind.CommonJS) {
+  if (isEsmMode && compilerOptions.module === tsModule.ModuleKind.CommonJS) {
     logger.error(Errors.InvalidModuleKindForEsm)
   }
 }
@@ -93,6 +99,10 @@ export class TsCompiler implements TsCompilerInstance {
    * @internal
    */
   private readonly _moduleResolutionCache: ModuleResolutionCache | undefined
+  /**
+   * @internal
+   */
+  private _tsTranspileModuleFn: ExtendedTsTranspileModuleFn | undefined
 
   program: Program | undefined
 
@@ -453,7 +463,7 @@ export class TsCompiler implements TsCompilerInstance {
     } else {
       this._logger.debug({ fileName }, 'getCompiledOutput(): compiling as isolated module')
 
-      assertCompilerOptionsWithJestTransformMode(this._initialCompilerOptions, isEsmMode, this._logger)
+      assertCompilerOptionsWithJestTransformMode(this._ts, this._initialCompilerOptions, isEsmMode, this._logger)
 
       const result = this._transpileOutput(fileContent, fileName)
       if (result.diagnostics && this.configSet.shouldReportDiagnostics(fileName)) {
@@ -481,7 +491,9 @@ export class TsCompiler implements TsCompilerInstance {
       })
     }
 
-    return tsTranspileModule(fileContent, {
+    this._tsTranspileModuleFn ??= createTsTranspileModule(this._ts)
+
+    return this._tsTranspileModuleFn(fileContent, {
       fileName,
       transformers: (program) => {
         this.program = program

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -42,6 +42,7 @@ import { Errors, Helps, interpolate } from '../../utils/messages'
 import type { ConfigSet } from '../config/config-set'
 
 import { updateOutput } from './compiler-utils'
+import { NativeDiagnosticsService } from './native-diagnostics-service'
 
 const assertCompilerOptionsWithJestTransformMode = (
   tsModule: TTypeScript,
@@ -100,6 +101,13 @@ export class TsCompiler implements TsCompilerInstance {
    */
   private readonly _moduleResolutionCache: ModuleResolutionCache | undefined
   /**
+   * Native (TypeScript 7+) out-of-process type-checker, active when `diagnostics.engine` is `native`.
+   * When set, the LanguageService is never constructed and emit flows through the transpile path.
+   *
+   * @internal
+   */
+  private readonly _nativeDiagnostics: NativeDiagnosticsService | undefined
+  /**
    * @internal
    */
   private _tsTranspileModuleFn: ExtendedTsTranspileModuleFn | undefined
@@ -140,7 +148,18 @@ export class TsCompiler implements TsCompilerInstance {
         this._ts.sys.useCaseSensitiveFileNames ? (x) => x : (x) => x.toLowerCase(),
         this._compilerOptions,
       )
-      this._createLanguageService()
+      if (this.configSet.useNativeDiagnosticsEngine) {
+        this._logger.debug('created new instance of native diagnostics service instead of language service')
+        this._nativeDiagnostics = new NativeDiagnosticsService({
+          ts: this._ts,
+          logger: this._logger,
+          cwd: this.configSet.cwd,
+          tsconfigPath: this.configSet.resolvedTsconfigFilePath,
+          readFile: (fileName) => this._cachedReadFile?.(fileName) ?? this._ts.sys.readFile(fileName),
+        })
+      } else {
+        this._createLanguageService()
+      }
     }
   }
 
@@ -461,13 +480,60 @@ export class TsCompiler implements TsCompilerInstance {
             diagnostics,
           }
     } else {
-      this._logger.debug({ fileName }, 'getCompiledOutput(): compiling as isolated module')
+      this._logger.debug(
+        { fileName },
+        this._nativeDiagnostics
+          ? 'getCompiledOutput(): compiling via transpile path with native engine type-checking'
+          : 'getCompiledOutput(): compiling as isolated module',
+      )
 
       assertCompilerOptionsWithJestTransformMode(this._ts, this._initialCompilerOptions, isEsmMode, this._logger)
 
       const result = this._transpileOutput(fileContent, fileName)
       if (result.diagnostics && this.configSet.shouldReportDiagnostics(fileName)) {
         this.configSet.raiseDiagnostics(result.diagnostics, fileName, this._logger)
+      }
+      if (this._nativeDiagnostics) {
+        if (options.watchMode) {
+          // the file changed on disk: refresh the native snapshot before checking (the equivalent
+          // of the memory-cache update on the language-service path)
+          this._nativeDiagnostics.invalidate([fileName])
+        }
+        const nativeDiagnostics = this.configSet.shouldReportDiagnostics(fileName)
+          ? this._nativeDiagnostics.check(fileName)
+          : []
+        if (isEsmMode) {
+          // mirror the language-service path: in ESM mode diagnostics are returned and raised by `processAsync()`
+          return {
+            code: updateOutput(result.outputText, fileName, result.sourceMapText),
+            diagnostics: nativeDiagnostics,
+          }
+        }
+        if (nativeDiagnostics.length) {
+          this.configSet.raiseDiagnostics(nativeDiagnostics, fileName, this._logger)
+          if (options.watchMode) {
+            this._logger.debug({ fileName }, '_doTypeChecking(): starting watch mode computing diagnostics')
+
+            for (const entry of options.depGraphs.entries()) {
+              const normalizedModuleNames = entry[1].resolvedModuleNames.map((moduleName) => normalize(moduleName))
+              const fileToReTypeCheck = entry[0]
+              if (
+                fileToReTypeCheck !== fileName &&
+                normalizedModuleNames.includes(fileName) &&
+                this.configSet.shouldReportDiagnostics(fileToReTypeCheck)
+              ) {
+                this._logger.debug(
+                  { fileToReTypeCheck },
+                  '_doTypeChecking(): computing diagnostics using native engine',
+                )
+
+                const importedModulesDiagnostics = this._nativeDiagnostics.check(fileToReTypeCheck)
+                // will raise or just warn diagnostics depending on config
+                this.configSet.raiseDiagnostics(importedModulesDiagnostics, fileName, this._logger)
+              }
+            }
+          }
+        }
       }
 
       return {
@@ -477,6 +543,10 @@ export class TsCompiler implements TsCompilerInstance {
   }
 
   protected _transpileOutput(fileContent: string, fileName: string): TranspileOutput {
+    // when the native engine performs type-checking, syntactic diagnostics come from it as well,
+    // so the transpiler should not compute (and duplicate) them
+    const shouldReportTranspileDiagnostics = (targetFileName: string): boolean =>
+      !this._nativeDiagnostics && this.configSet.shouldReportDiagnostics(targetFileName)
     /**
      * @deprecated
      *
@@ -487,7 +557,7 @@ export class TsCompiler implements TsCompilerInstance {
         fileName,
         transformers: this._makeTransformers(this.configSet.resolvedTransformers),
         compilerOptions: this._compilerOptions,
-        reportDiagnostics: this.configSet.shouldReportDiagnostics(fileName),
+        reportDiagnostics: shouldReportTranspileDiagnostics(fileName),
       })
     }
 
@@ -501,7 +571,7 @@ export class TsCompiler implements TsCompilerInstance {
         return this._makeTransformers(this.configSet.resolvedTransformers)
       },
       compilerOptions: this._initialCompilerOptions,
-      reportDiagnostics: fileName ? this.configSet.shouldReportDiagnostics(fileName) : false,
+      reportDiagnostics: fileName ? shouldReportTranspileDiagnostics(fileName) : false,
     })
   }
 

--- a/src/legacy/config/__snapshots__/compiler-api-resolver.spec.ts.snap
+++ b/src/legacy/config/__snapshots__/compiler-api-resolver.spec.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`resolveCompilerApi with an explicit \`compiler\` option should throw an actionable error when the requested module has no JS API, never falling back 1`] = `
+"The \`compiler\` module "some-native-ts" (version 7.0.2) does not expose the TypeScript JS compiler API (\`transpileModule\`/\`createLanguageService\`) that ts-jest uses for emit and AST transforms. If this is native TypeScript 7+, install the official compatibility package alongside it:
+    ↳ \`npm i -D @typescript/typescript6\` (or \`yarn add --dev @typescript/typescript6\`)
+and either remove the \`compiler\` option (ts-jest will detect it automatically) or set \`compiler: "@typescript/typescript6"\`."
+`;
+
+exports[`resolveCompilerApi without a \`compiler\` option should throw an actionable error when \`typescript\` is native v7 and the compat package is missing 1`] = `
+"Your project's \`typescript\` package (version 7.0.2) is the native TypeScript compiler, which does not ship the JS compiler API that ts-jest uses for emit and AST transforms. Install the official compatibility package next to it:
+    ↳ \`npm i -D @typescript/typescript6\` (or \`yarn add --dev @typescript/typescript6\`)
+It is designed to coexist with native TypeScript, and ts-jest will pick it up automatically. Type-checking can still use the fast native compiler via the ts-jest option \`diagnostics: { engine: "native" }\`."
+`;

--- a/src/legacy/config/compiler-api-resolver.spec.ts
+++ b/src/legacy/config/compiler-api-resolver.spec.ts
@@ -1,0 +1,155 @@
+import { testing } from 'bs-logger'
+
+import type { TTypeScript } from '../../types'
+import type { Importer, RequireResult } from '../../utils/importer'
+
+import { hasJsCompilerApi, resolveCompilerApi, TYPESCRIPT6_COMPAT_PACKAGE } from './compiler-api-resolver'
+
+const logger = testing.createLoggerMock()
+
+const jsApiModule = (version: string): TTypeScript =>
+  ({
+    version,
+    transpileModule: () => ({ outputText: '' }),
+    createLanguageService: () => ({}),
+    parseJsonConfigFileContent: () => ({}),
+  } as unknown as TTypeScript)
+
+const nativeV7Module = { version: '7.0.2' }
+
+interface FakeImporterSetup {
+  /** modules resolvable by name; absent name = module not installed */
+  modules?: Record<string, unknown>
+  /** module names which exist but fail while loading */
+  loadErrors?: Record<string, Error>
+}
+
+const fakeImporter = ({ modules = {}, loadErrors = {} }: FakeImporterSetup): Importer => {
+  const tryThese = (moduleName: string): RequireResult<true> | undefined => {
+    if (loadErrors[moduleName]) {
+      return { exists: true, given: moduleName, error: loadErrors[moduleName] }
+    }
+    if (moduleName in modules) {
+      return { exists: true, given: moduleName, exports: modules[moduleName] }
+    }
+
+    return undefined
+  }
+  const typescript = (_why: string, which: string): TTypeScript => {
+    const result = tryThese(which)
+    if (result && !result.error) return result.exports as TTypeScript
+    throw new Error(`Unable to load the module "${which}".`)
+  }
+
+  return { tryThese, typescript } as unknown as Importer
+}
+
+beforeEach(() => {
+  logger.target.clear()
+})
+
+describe('hasJsCompilerApi', () => {
+  it.each([
+    [jsApiModule('5.9.3'), true],
+    [jsApiModule('6.0.3'), true],
+    [nativeV7Module, false],
+    [undefined, false],
+    [null, false],
+    [{}, false],
+    [{ transpileModule: () => ({}) }, false],
+  ])('should feature-probe the JS compiler API surface (%#)', (mod, expected) => {
+    expect(hasJsCompilerApi(mod)).toBe(expected)
+  })
+})
+
+describe('resolveCompilerApi', () => {
+  describe('with an explicit `compiler` option', () => {
+    it('should use the requested module when it has a JS API', () => {
+      const ttsc = jsApiModule('5.9.3')
+      const result = resolveCompilerApi('ttypescript', logger, fakeImporter({ modules: { ttypescript: ttsc } }))
+
+      expect(result.module).toBe(ttsc)
+      expect(result.moduleName).toBe('ttypescript')
+      expect(result.nativeTypeScriptPresent).toBe(false)
+    })
+
+    it('should throw an actionable error when the requested module has no JS API, never falling back', () => {
+      const importer = fakeImporter({
+        modules: { 'some-native-ts': nativeV7Module, [TYPESCRIPT6_COMPAT_PACKAGE]: jsApiModule('6.0.3') },
+      })
+
+      expect(() => resolveCompilerApi('some-native-ts', logger, importer)).toThrowErrorMatchingSnapshot()
+    })
+  })
+
+  describe('without a `compiler` option', () => {
+    it.each([undefined, 'typescript'])(
+      'should use the project `typescript` when it still has the JS API (compiler option: %p)',
+      (compilerOption) => {
+        const ts = jsApiModule('5.9.3')
+        const result = resolveCompilerApi(compilerOption, logger, fakeImporter({ modules: { typescript: ts } }))
+
+        expect(result.module).toBe(ts)
+        expect(result.moduleName).toBe('typescript')
+        expect(result.nativeTypeScriptPresent).toBe(false)
+        expect(result.nativeTypeScriptVersion).toBeUndefined()
+      },
+    )
+
+    it('should fall back to the compat package when `typescript` is native v7', () => {
+      const compat = jsApiModule('6.0.3')
+      const result = resolveCompilerApi(
+        undefined,
+        logger,
+        fakeImporter({ modules: { typescript: nativeV7Module, [TYPESCRIPT6_COMPAT_PACKAGE]: compat } }),
+      )
+
+      expect(result.module).toBe(compat)
+      expect(result.moduleName).toBe(TYPESCRIPT6_COMPAT_PACKAGE)
+      expect(result.nativeTypeScriptPresent).toBe(true)
+      expect(result.nativeTypeScriptVersion).toBe('7.0.2')
+      expect(logger.target.lines.info.last).toContain('@typescript/typescript6')
+    })
+
+    it('should use the compat package quietly when `typescript` is not installed at all', () => {
+      const compat = jsApiModule('6.0.3')
+      const result = resolveCompilerApi(
+        undefined,
+        logger,
+        fakeImporter({ modules: { [TYPESCRIPT6_COMPAT_PACKAGE]: compat } }),
+      )
+
+      expect(result.module).toBe(compat)
+      expect(result.moduleName).toBe(TYPESCRIPT6_COMPAT_PACKAGE)
+      expect(result.nativeTypeScriptPresent).toBe(false)
+      expect(logger.target.lines.info.last).toBeUndefined()
+    })
+
+    it('should throw an actionable error when `typescript` is native v7 and the compat package is missing', () => {
+      const importer = fakeImporter({ modules: { typescript: nativeV7Module } })
+
+      expect(() => resolveCompilerApi(undefined, logger, importer)).toThrowErrorMatchingSnapshot()
+    })
+
+    it('should keep the historical error when no typescript module can be found at all', () => {
+      expect(() => resolveCompilerApi(undefined, logger, fakeImporter({}))).toThrow(
+        'Unable to load the module "typescript".',
+      )
+    })
+
+    it('should ignore a `typescript` module that exists but fails to load and use the compat package', () => {
+      const compat = jsApiModule('6.0.3')
+      const result = resolveCompilerApi(
+        undefined,
+        logger,
+        fakeImporter({
+          modules: { [TYPESCRIPT6_COMPAT_PACKAGE]: compat },
+          loadErrors: { typescript: new Error('boom') },
+        }),
+      )
+
+      expect(result.module).toBe(compat)
+      expect(result.nativeTypeScriptPresent).toBe(false)
+    })
+  })
+})

--- a/src/legacy/config/compiler-api-resolver.ts
+++ b/src/legacy/config/compiler-api-resolver.ts
@@ -1,0 +1,130 @@
+import type { Logger } from 'bs-logger'
+
+import type { TTypeScript } from '../../types'
+import { Importer, importer as defaultImporter } from '../../utils/importer'
+import { Errors, Helps, ImportReasons, interpolate } from '../../utils/messages'
+
+/**
+ * The official compatibility package that re-exports the TypeScript 6.x JS compiler API,
+ * designed by the TypeScript team to be installed alongside native TypeScript 7+.
+ *
+ * @internal
+ */
+export const TYPESCRIPT6_COMPAT_PACKAGE = '@typescript/typescript6'
+
+/**
+ * Feature-probe for the JS compiler API surface ts-jest relies on.
+ *
+ * Native TypeScript 7+ resolves `require('typescript')` to a version-only entry point, so a
+ * semver check is not enough (npm aliases can also make version numbers lie in both directions).
+ *
+ * @internal
+ */
+export function hasJsCompilerApi(mod: unknown): mod is TTypeScript {
+  return (
+    !!mod &&
+    typeof (mod as TTypeScript).transpileModule === 'function' &&
+    typeof (mod as TTypeScript).createLanguageService === 'function' &&
+    typeof (mod as TTypeScript).parseJsonConfigFileContent === 'function'
+  )
+}
+
+/**
+ * @internal
+ */
+export interface ResolvedCompilerApi {
+  module: TTypeScript
+  /** The module specifier the API was loaded from (`typescript`, `@typescript/typescript6`, or the `compiler` option value) */
+  moduleName: string
+  /** `true` when the project's `typescript` package exists but is native TypeScript without a JS API (v7+) */
+  nativeTypeScriptPresent: boolean
+  /** Version of the project's native `typescript` package, when {@link ResolvedCompilerApi.nativeTypeScriptPresent} */
+  nativeTypeScriptVersion: string | undefined
+}
+
+const versionOf = (mod: unknown): string =>
+  (mod as { version?: string } | undefined)?.version ?? /* istanbul ignore next */ 'unknown'
+
+/**
+ * Resolve the module providing the TypeScript JS compiler API for ts-jest internals.
+ *
+ * Resolution order:
+ * 1. an explicit non-default `compiler` option — honored strictly; a module without the JS API is
+ *    an error (never a silent fallback, the user asked for that exact module)
+ * 2. the project's `typescript` package, when it still exposes the JS API (TypeScript <= 6.x)
+ * 3. the official `@typescript/typescript6` compatibility package, when the project's `typescript`
+ *    is native TypeScript 7+ (or missing)
+ * 4. an actionable error explaining how to fix the setup
+ *
+ * @internal
+ */
+export function resolveCompilerApi(
+  compilerOption: string | undefined,
+  logger: Logger,
+  importer: Importer = defaultImporter,
+): ResolvedCompilerApi {
+  // 1) explicit compiler option: strict, no fallback
+  if (compilerOption && compilerOption !== 'typescript') {
+    const mod = importer.typescript(ImportReasons.TsJest, compilerOption)
+    if (!hasJsCompilerApi(mod)) {
+      throw new Error(
+        interpolate(Errors.CompilerModuleWithoutJsApi, { module: compilerOption, version: versionOf(mod) }),
+      )
+    }
+
+    return {
+      module: mod,
+      moduleName: compilerOption,
+      nativeTypeScriptPresent: false,
+      nativeTypeScriptVersion: undefined,
+    }
+  }
+
+  // 2) the project's `typescript`, when it still has the JS API
+  const tsResult = importer.tryThese('typescript')
+  const tsExports: unknown = tsResult && !tsResult.error ? tsResult.exports : undefined
+  if (hasJsCompilerApi(tsExports)) {
+    return {
+      module: tsExports,
+      moduleName: 'typescript',
+      nativeTypeScriptPresent: false,
+      nativeTypeScriptVersion: undefined,
+    }
+  }
+  const nativeTypeScriptPresent = !!tsExports
+  const nativeTypeScriptVersion = nativeTypeScriptPresent ? versionOf(tsExports) : undefined
+
+  // 3) the official compatibility package
+  const compatResult = importer.tryThese(TYPESCRIPT6_COMPAT_PACKAGE)
+  const compatExports: unknown = compatResult && !compatResult.error ? compatResult.exports : undefined
+  if (hasJsCompilerApi(compatExports)) {
+    if (nativeTypeScriptPresent) {
+      logger.info(
+        interpolate(Helps.UsingTypescript6CompatPackage, {
+          version: nativeTypeScriptVersion,
+          compatVersion: versionOf(compatExports),
+        }),
+      )
+    }
+
+    return {
+      module: compatExports,
+      moduleName: TYPESCRIPT6_COMPAT_PACKAGE,
+      nativeTypeScriptPresent,
+      nativeTypeScriptVersion,
+    }
+  }
+
+  // 4) actionable errors
+  if (nativeTypeScriptPresent) {
+    throw new Error(interpolate(Errors.NativeTypeScriptWithoutCompatPackage, { version: nativeTypeScriptVersion }))
+  }
+
+  // `typescript` is missing entirely (or failed loading): keep the historical error message/behavior
+  return {
+    module: importer.typescript(ImportReasons.TsJest, 'typescript'),
+    moduleName: 'typescript',
+    nativeTypeScriptPresent: false,
+    nativeTypeScriptVersion: undefined,
+  }
+}

--- a/src/legacy/config/config-set-native-engine.spec.ts
+++ b/src/legacy/config/config-set-native-engine.spec.ts
@@ -1,0 +1,84 @@
+import { createConfigSet } from '../../__helpers__/fakers'
+import { logTargetMock } from '../../__helpers__/mocks'
+import { probeNativeApi } from '../compiler/native-diagnostics-service'
+
+jest.mock('../compiler/native-diagnostics-service', () => {
+  const actual = jest.requireActual('../compiler/native-diagnostics-service')
+
+  return {
+    ...actual,
+    probeNativeApi: jest.fn(() => ({ available: true, version: '7.0.2' })),
+  }
+})
+
+const mockedProbe = jest.mocked(probeNativeApi)
+const logTarget = logTargetMock()
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  logTarget.clear()
+  mockedProbe.mockReturnValue({ available: true, version: '7.0.2' })
+})
+
+describe('ConfigSet with diagnostics.engine', () => {
+  it('should default to the compiler engine without probing', () => {
+    const configSet = createConfigSet({ tsJestConfig: { diagnostics: true } })
+
+    expect(configSet.useNativeDiagnosticsEngine).toBe(false)
+    expect(mockedProbe).not.toHaveBeenCalled()
+  })
+
+  it('should enable the native engine when requested and the native API is available', () => {
+    const configSet = createConfigSet({ tsJestConfig: { diagnostics: { engine: 'native' } } })
+
+    expect(mockedProbe).toHaveBeenCalledTimes(1)
+    expect(configSet.useNativeDiagnosticsEngine).toBe(true)
+  })
+
+  it('should fall back to the compiler engine with a warning when the native API is unavailable', () => {
+    mockedProbe.mockReturnValue({ available: false, reason: "Cannot find module 'typescript/unstable/sync'" })
+    const configSet = createConfigSet({ tsJestConfig: { diagnostics: { engine: 'native' } } })
+
+    expect(configSet.useNativeDiagnosticsEngine).toBe(false)
+    expect(logTarget.lines.warn.last).toContain('Falling back to `diagnostics.engine: "compiler"`')
+    expect(logTarget.lines.warn.last).toContain("Cannot find module 'typescript/unstable/sync'")
+  })
+
+  it('should ignore the native engine with a warning when isolatedModules disables type-checking', () => {
+    const configSet = createConfigSet({
+      tsJestConfig: { diagnostics: { engine: 'native' }, tsconfig: { isolatedModules: true } },
+    })
+
+    expect(configSet.useNativeDiagnosticsEngine).toBe(false)
+    expect(mockedProbe).not.toHaveBeenCalled()
+    expect(logTarget.lines.warn.last).toContain('isolatedModules')
+  })
+
+  it('should warn on an invalid engine value and use the compiler engine', () => {
+    const configSet = createConfigSet({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tsJestConfig: { diagnostics: { engine: 'turbo' as any } },
+    })
+
+    expect(configSet.useNativeDiagnosticsEngine).toBe(false)
+    expect(mockedProbe).not.toHaveBeenCalled()
+    expect(logTarget.lines.warn.last).toContain('Invalid value for the ts-jest option `diagnostics.engine`')
+  })
+
+  it('should produce a different cacheSuffix when the engine flips', () => {
+    const compilerEngineConfigSet = createConfigSet({ tsJestConfig: { diagnostics: { engine: 'compiler' } } })
+    const nativeEngineConfigSet = createConfigSet({ tsJestConfig: { diagnostics: { engine: 'native' } } })
+
+    expect(compilerEngineConfigSet.useNativeDiagnosticsEngine).toBe(false)
+    expect(nativeEngineConfigSet.useNativeDiagnosticsEngine).toBe(true)
+    expect(nativeEngineConfigSet.cacheSuffix).not.toEqual(compilerEngineConfigSet.cacheSuffix)
+  })
+
+  it('should produce a different cacheSuffix for different native compiler versions', () => {
+    const first = createConfigSet({ tsJestConfig: { diagnostics: { engine: 'native' } } })
+    mockedProbe.mockReturnValue({ available: true, version: '7.1.0' })
+    const second = createConfigSet({ tsJestConfig: { diagnostics: { engine: 'native' } } })
+
+    expect(first.cacheSuffix).not.toEqual(second.cacheSuffix)
+  })
+})

--- a/src/legacy/config/config-set-ts6-compat.spec.ts
+++ b/src/legacy/config/config-set-ts6-compat.spec.ts
@@ -1,0 +1,21 @@
+import * as ts from 'typescript'
+
+import { createConfigSet } from '../../__helpers__/fakers'
+
+jest.mock('typescript', () => {
+  const actualModule = jest.requireActual('typescript') as typeof ts
+
+  return {
+    __esModule: true,
+    ...actualModule,
+    version: '6.0.3',
+  }
+})
+
+describe('ConfigSet with a TypeScript 6.x compiler module', () => {
+  it('should force ignoreDeprecations so 7.0 migration deprecations (e.g. TS5107 for the injected node10 default) never fail in-memory compilation', () => {
+    const configSet = createConfigSet({ tsJestConfig: { tsconfig: { module: 'commonjs' } } })
+
+    expect(configSet.parsedTsConfig.options.ignoreDeprecations).toBe('6.0')
+  })
+})

--- a/src/legacy/config/config-set.spec.ts
+++ b/src/legacy/config/config-set.spec.ts
@@ -483,6 +483,7 @@ describe('config-set', () => {
           sha1(
             stringify({
               version: configSet.compilerModule.version,
+              compilerModuleName: configSet.compilerModuleName,
               digest: configSet.tsJestDigest,
               babelConfig: configSet.babelConfig,
               tsconfig: {

--- a/src/legacy/config/config-set.spec.ts
+++ b/src/legacy/config/config-set.spec.ts
@@ -484,6 +484,9 @@ describe('config-set', () => {
             stringify({
               version: configSet.compilerModule.version,
               compilerModuleName: configSet.compilerModuleName,
+              // @ts-expect-error testing purpose
+              diagnosticsEngine: configSet._diagnostics.engine,
+              nativeCompilerVersion: null,
               digest: configSet.tsJestDigest,
               babelConfig: configSet.babelConfig,
               tsconfig: {

--- a/src/legacy/config/config-set.ts
+++ b/src/legacy/config/config-set.ts
@@ -35,10 +35,11 @@ import { TsCompilerInstance } from '../../types'
 import { rootLogger, stringify, TsJestDiagnosticCodes } from '../../utils'
 import { backportJestConfig } from '../../utils/backports'
 import { importer } from '../../utils/importer'
-import { Deprecations, Errors, ImportReasons, interpolate } from '../../utils/messages'
+import { Deprecations, Errors, Helps, ImportReasons, interpolate } from '../../utils/messages'
 import { normalizeSlashes } from '../../utils/normalize-slashes'
 import { sha1 } from '../../utils/sha1'
 import { TSError } from '../../utils/ts-error'
+import { probeNativeApi } from '../compiler/native-diagnostics-service'
 
 import { resolveCompilerApi } from './compiler-api-resolver'
 
@@ -48,6 +49,7 @@ interface TsJestDiagnosticsCfg {
   exclude: string[]
   throws: boolean
   warnOnly?: boolean
+  engine: 'compiler' | 'native'
 }
 
 /**
@@ -134,6 +136,13 @@ export class ConfigSet {
    * @internal
    */
   readonly nativeTypeScriptVersion: string | undefined
+  /**
+   * Whether type-checking is delegated to the native TypeScript (7+) out-of-process checker.
+   * Resolved from `diagnostics.engine: 'native'` after probing that the native API is actually loadable.
+   *
+   * @internal
+   */
+  useNativeDiagnosticsEngine = false
   readonly isolatedModules: boolean
   readonly cwd: string
   readonly rootDir: string
@@ -163,6 +172,12 @@ export class ConfigSet {
    * @internal
    */
   private _diagnostics!: TsJestDiagnosticsCfg
+  /**
+   * Version of the native TypeScript package backing the native diagnostics engine, when active.
+   *
+   * @internal
+   */
+  private _nativeCompilerVersion: string | undefined
   /**
    * @internal
    */
@@ -253,6 +268,22 @@ export class ConfigSet {
       }
     }
     this.isolatedModules = this.parsedTsConfig.options.isolatedModules ?? false
+    // diagnostics engine (experimental native checker)
+    if (this._diagnostics.engine === 'native') {
+      if (this.isolatedModules) {
+        this.logger.warn(Helps.NativeCheckerIgnoredIsolatedModules)
+        this._diagnostics.engine = 'compiler'
+      } else {
+        const nativeApiProbe = probeNativeApi()
+        if (nativeApiProbe.available) {
+          this.useNativeDiagnosticsEngine = true
+          this._nativeCompilerVersion = nativeApiProbe.version
+        } else {
+          this.logger.warn(interpolate(Helps.NativeCheckerUnavailable, { reason: nativeApiProbe.reason }))
+          this._diagnostics.engine = 'compiler'
+        }
+      }
+    }
     this._resolveTsCacheDir()
   }
 
@@ -319,6 +350,13 @@ export class ConfigSet {
     // diagnostics
     const diagnosticsOpt = options.diagnostics ?? true
     const ignoreList: Array<string | number> = [...IGNORE_DIAGNOSTIC_CODES]
+    const engineOpt = typeof diagnosticsOpt === 'object' ? diagnosticsOpt.engine : undefined
+    let diagnosticsEngine: TsJestDiagnosticsCfg['engine'] = 'compiler'
+    if (engineOpt === 'native' || engineOpt === 'compiler') {
+      diagnosticsEngine = engineOpt
+    } else if (engineOpt !== undefined) {
+      this.logger.warn(interpolate(Helps.InvalidDiagnosticsEngine, { value: JSON.stringify(engineOpt) }))
+    }
     if (typeof diagnosticsOpt === 'object') {
       const { ignoreCodes } = diagnosticsOpt
       if (ignoreCodes) {
@@ -330,6 +368,7 @@ export class ConfigSet {
         exclude: diagnosticsOpt.exclude ?? [],
         ignoreCodes: toDiagnosticCodeList(ignoreList),
         throws: !diagnosticsOpt.warnOnly,
+        engine: diagnosticsEngine,
       }
     } else {
       this._diagnostics = {
@@ -337,6 +376,7 @@ export class ConfigSet {
         exclude: [],
         pretty: true,
         throws: diagnosticsOpt,
+        engine: diagnosticsEngine,
       }
     }
     if (diagnosticsOpt) {
@@ -457,6 +497,8 @@ export class ConfigSet {
       stringify({
         version: this.compilerModule.version,
         compilerModuleName: this.compilerModuleName,
+        diagnosticsEngine: this._diagnostics.engine,
+        nativeCompilerVersion: this._nativeCompilerVersion ?? null,
         digest: this.tsJestDigest,
         babelConfig: this.babelConfig,
         tsconfig: {
@@ -632,6 +674,16 @@ export class ConfigSet {
 
   shouldStringifyContent(filePath: string): boolean {
     return this._stringifyContentRegExp ? this._stringifyContentRegExp.test(filePath) : false
+  }
+
+  /**
+   * Path of the tsconfig file backing {@link ConfigSet.parsedTsConfig}, when it was read from disk.
+   * The native diagnostics engine loads the project from this file.
+   *
+   * @internal
+   */
+  get resolvedTsconfigFilePath(): string | undefined {
+    return this.tsconfigFilePath
   }
 
   raiseDiagnostics(diagnostics: ts.Diagnostic[], filePath?: string, logger = this.logger): void {

--- a/src/legacy/config/config-set.ts
+++ b/src/legacy/config/config-set.ts
@@ -241,6 +241,14 @@ export class ConfigSet {
       'normalized compiler module config via ts-jest option',
     )
 
+    if (parseInt(this.compilerModule.version.split('.')[0], 10) >= 6) {
+      // TypeScript 6.x enforces the 7.0 migration deprecations as hard errors (e.g. TS5107 for
+      // the `moduleResolution=node10` runtime default ts-jest injects on the CJS path). Silence
+      // them for ts-jest's in-memory compilation only — the user's own `tsc` build still
+      // enforces migration. The value is only valid on 6.x+, hence the version gate.
+      this._overriddenCompilerOptions.ignoreDeprecations = '6.0'
+    }
+
     this._setupConfigSet(options)
     this._matchablePatterns = [...this._jestCfg.testMatch, ...this._jestCfg.testRegex].filter(
       (pattern) =>

--- a/src/legacy/config/config-set.ts
+++ b/src/legacy/config/config-set.ts
@@ -40,6 +40,8 @@ import { normalizeSlashes } from '../../utils/normalize-slashes'
 import { sha1 } from '../../utils/sha1'
 import { TSError } from '../../utils/ts-error'
 
+import { resolveCompilerApi } from './compiler-api-resolver'
+
 interface TsJestDiagnosticsCfg {
   pretty: boolean
   ignoreCodes: number[]
@@ -113,6 +115,25 @@ export class ConfigSet {
   readonly tsJestDigest = MY_DIGEST
   readonly logger: Logger
   readonly compilerModule: TTypeScript
+  /**
+   * The module specifier {@link ConfigSet.compilerModule} was resolved from
+   * (`typescript`, `@typescript/typescript6`, or the `compiler` option value).
+   *
+   * @internal
+   */
+  readonly compilerModuleName: string
+  /**
+   * `true` when the project's `typescript` package is native TypeScript (7+) without a JS compiler API.
+   *
+   * @internal
+   */
+  readonly nativeTypeScriptPresent: boolean
+  /**
+   * Version of the project's native `typescript` package, when {@link ConfigSet.nativeTypeScriptPresent}.
+   *
+   * @internal
+   */
+  readonly nativeTypeScriptVersion: string | undefined
   readonly isolatedModules: boolean
   readonly cwd: string
   readonly rootDir: string
@@ -194,9 +215,16 @@ export class ConfigSet {
     const tsJestCfg = this._jestCfg.globals && this._jestCfg.globals['ts-jest']
     const options: TsJestTransformerOptions = tsJestCfg ?? Object.create(null)
     // compiler module
-    this.compilerModule = importer.typescript(ImportReasons.TsJest, options.compiler ?? 'typescript')
+    const resolvedCompilerApi = resolveCompilerApi(options.compiler, this.logger)
+    this.compilerModule = resolvedCompilerApi.module
+    this.compilerModuleName = resolvedCompilerApi.moduleName
+    this.nativeTypeScriptPresent = resolvedCompilerApi.nativeTypeScriptPresent
+    this.nativeTypeScriptVersion = resolvedCompilerApi.nativeTypeScriptVersion
 
-    this.logger.debug({ compilerModule: this.compilerModule }, 'normalized compiler module config via ts-jest option')
+    this.logger.debug(
+      { compilerModule: this.compilerModule, compilerModuleName: this.compilerModuleName },
+      'normalized compiler module config via ts-jest option',
+    )
 
     this._setupConfigSet(options)
     this._matchablePatterns = [...this._jestCfg.testMatch, ...this._jestCfg.testRegex].filter(
@@ -428,6 +456,7 @@ export class ConfigSet {
     this.cacheSuffix = sha1(
       stringify({
         version: this.compilerModule.version,
+        compilerModuleName: this.compilerModuleName,
         digest: this.tsJestDigest,
         babelConfig: this.babelConfig,
         tsconfig: {

--- a/src/legacy/ts-jest-transformer.ts
+++ b/src/legacy/ts-jest-transformer.ts
@@ -3,7 +3,6 @@ import path from 'path'
 
 import type { SyncTransformer, TransformedSource } from '@jest/transform'
 import type { Logger } from 'bs-logger'
-import ts from 'typescript'
 
 import { DECLARATION_TYPE_EXT, JS_JSX_REGEX, TS_TSX_REGEX } from '../constants'
 import type {
@@ -231,6 +230,7 @@ export class TsJestTransformer implements SyncTransformer<TsJestTransformerOptio
       }
     } else if (isJsFile || isTsFile) {
       if (isJsFile && isNodeModule(sourcePath)) {
+        const ts = configs.compilerModule
         const transpiledResult = ts.transpileModule(sourceText, {
           compilerOptions: {
             ...configs.parsedTsConfig.options,

--- a/src/transpilers/typescript/transpile-module.spec.ts
+++ b/src/transpilers/typescript/transpile-module.spec.ts
@@ -7,7 +7,9 @@ import ts from 'typescript'
 import { dedent, omitLeadingWhitespace } from '../../__helpers__/dedent-string'
 import { workspaceRoot } from '../../__helpers__/workspace-root'
 
-import { tsTranspileModule } from './transpile-module'
+import { createTsTranspileModule } from './transpile-module'
+
+const tsTranspileModule = createTsTranspileModule(ts)
 
 jest.mock('fs', () => {
   const fsImpl = jest.requireActual('memfs').fs

--- a/src/transpilers/typescript/transpile-module.ts
+++ b/src/transpilers/typescript/transpile-module.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 
-import ts from 'typescript'
+import type ts from 'typescript'
 
+import type { TTypeScript } from '../../types'
 import { TsJestDiagnosticCodes } from '../../utils'
 
 const barebonesLibContent = `/// <reference no-default-lib="true"/>
@@ -25,34 +26,27 @@ interface Symbol {
     readonly [Symbol.toStringTag]: string;
 }`
 const barebonesLibName = 'lib.d.ts'
-let barebonesLibSourceFile: ts.SourceFile | undefined
 
 const carriageReturnLineFeed = '\r\n'
 const lineFeed = '\n'
-function getNewLineCharacter(options: ts.CompilerOptions): string {
-  switch (options.newLine) {
-    case ts.NewLineKind.CarriageReturnLineFeed:
-      return carriageReturnLineFeed
-    case ts.NewLineKind.LineFeed:
-    default:
-      return lineFeed
-  }
-}
 
 type ExtendedTranspileOptions = Omit<ts.TranspileOptions, 'transformers'> & {
   transformers?: (program: ts.Program) => ts.CustomTransformers
 }
 
-type ExtendedTsTranspileModuleFn = (
+export type ExtendedTsTranspileModuleFn = (
   fileContent: string,
   transpileOptions: ExtendedTranspileOptions,
 ) => ts.TranspileOutput
 
 export const isModernNodeModuleKind = (module: ts.ModuleKind | undefined): boolean => {
+  // Numeric values of `ts.ModuleKind` are stable public API across every supported compiler
+  // module, which keeps this helper free of a value-import of the `typescript` package.
   return module
-    ? [ts.ModuleKind.Node16, /* ModuleKind.Node18 */ 101, /* ModuleKind.Node20 */ 102, ts.ModuleKind.NodeNext].includes(
-        module,
-      )
+    ? [
+        /* ModuleKind.Node16 */ 100, /* ModuleKind.Node18 */ 101, /* ModuleKind.Node20 */ 102,
+        /* ModuleKind.NodeNext */ 199,
+      ].includes(module)
     : false
 }
 
@@ -61,152 +55,170 @@ const shouldCheckProjectPkgJsonContent = (fileName: string, moduleKind: ts.Modul
 }
 
 /**
+ * Create a `transpileModule` implementation bound to the given compiler module.
+ *
  * Copy source code of {@link ts.transpileModule} from {@link https://github.com/microsoft/TypeScript/blob/main/src/services/transpile.ts}
  * with extra modifications:
  * - Remove generation of declaration files
  * - Allow using custom AST transformers with the internal created {@link Program}
+ * - Take the compiler module as a parameter instead of value-importing the `typescript` package,
+ *   so alternative API providers (e.g. `@typescript/typescript6` next to native TypeScript 7+) work
  */
-const transpileWorker: ExtendedTsTranspileModuleFn = (input, transpileOptions) => {
-  if (!barebonesLibSourceFile) {
-    barebonesLibSourceFile = ts.createSourceFile(barebonesLibName, barebonesLibContent, {
-      languageVersion: ts.ScriptTarget.Latest,
-    })
-  }
+export const createTsTranspileModule = (ts: TTypeScript): ExtendedTsTranspileModuleFn => {
+  let barebonesLibSourceFile: ts.SourceFile | undefined
 
-  const diagnostics: ts.Diagnostic[] = []
-
-  const options: ts.CompilerOptions = transpileOptions.compilerOptions
-    ? // @ts-expect-error internal TypeScript API
-      ts.fixupCompilerOptions(transpileOptions.compilerOptions, diagnostics)
-    : {}
-
-  // mix in default options
-  const defaultOptions = ts.getDefaultCompilerOptions()
-  for (const key in defaultOptions) {
-    if (Object.hasOwn(defaultOptions, key) && options[key] === undefined) {
-      options[key] = defaultOptions[key]
+  function getNewLineCharacter(options: ts.CompilerOptions): string {
+    switch (options.newLine) {
+      case ts.NewLineKind.CarriageReturnLineFeed:
+        return carriageReturnLineFeed
+      case ts.NewLineKind.LineFeed:
+      default:
+        return lineFeed
     }
   }
 
-  // @ts-expect-error internal TypeScript API
-  for (const option of ts.transpileOptionValueCompilerOptions) {
-    // Do not set redundant config options if `verbatimModuleSyntax` was supplied.
-    if (options.verbatimModuleSyntax && new Set(['isolatedModules']).has(option.name)) {
-      continue
+  const transpileWorker: ExtendedTsTranspileModuleFn = (input, transpileOptions) => {
+    if (!barebonesLibSourceFile) {
+      barebonesLibSourceFile = ts.createSourceFile(barebonesLibName, barebonesLibContent, {
+        languageVersion: ts.ScriptTarget.Latest,
+      })
     }
 
-    options[option.name] = option.transpileOptionValue
-  }
+    const diagnostics: ts.Diagnostic[] = []
 
-  // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths.
-  options.suppressOutputPathCheck = true
+    const options: ts.CompilerOptions = transpileOptions.compilerOptions
+      ? // @ts-expect-error internal TypeScript API
+        ts.fixupCompilerOptions(transpileOptions.compilerOptions, diagnostics)
+      : {}
 
-  // Filename can be non-ts file.
-  options.allowNonTsExtensions = true
-  options.declaration = false
-  options.declarationMap = false
-
-  const newLine = getNewLineCharacter(options)
-  // if jsx is specified then treat file as .tsx
-  const inputFileName =
-    transpileOptions.fileName ?? (transpileOptions.compilerOptions?.jsx ? 'module.tsx' : 'module.ts')
-  // Create a compilerHost object to allow the compiler to read and write files
-  const compilerHost: ts.CompilerHost = {
-    getSourceFile: (fileName) => {
-      // @ts-expect-error internal TypeScript API
-      if (fileName === ts.normalizePath(inputFileName)) {
-        return sourceFile
+    // mix in default options
+    const defaultOptions = ts.getDefaultCompilerOptions()
+    for (const key in defaultOptions) {
+      if (Object.hasOwn(defaultOptions, key) && options[key] === undefined) {
+        options[key] = defaultOptions[key]
       }
+    }
 
-      // @ts-expect-error internal TypeScript API
-      return fileName === ts.normalizePath(barebonesLibName) ? barebonesLibSourceFile : undefined
-    },
-    writeFile: (name, text) => {
-      if (path.extname(name) === '.map') {
-        sourceMapText = text
-      } else {
-        outputText = text
-      }
-    },
-    getDefaultLibFileName: () => barebonesLibName,
-    useCaseSensitiveFileNames: () => false,
-    getCanonicalFileName: (fileName) => fileName,
-    getCurrentDirectory: () => '',
-    getNewLine: () => newLine,
-    fileExists: (fileName) => {
-      if (shouldCheckProjectPkgJsonContent(fileName, options.module)) {
-        return ts.sys.fileExists(fileName)
-      }
-
-      return fileName === inputFileName
-    },
-    readFile: (fileName) => {
-      if (shouldCheckProjectPkgJsonContent(fileName, options.module)) {
-        return ts.sys.readFile(fileName)
-      }
-
-      return ''
-    },
-    directoryExists: () => true,
-    getDirectories: () => [],
-  }
-
-  const sourceFile = ts.createSourceFile(inputFileName, input, {
-    languageVersion: options.target ?? ts.ScriptTarget.ESNext,
-    impliedNodeFormat: ts.getImpliedNodeFormatForFile(
-      inputFileName,
-      /*packageJsonInfoCache*/ undefined,
-      compilerHost,
-      options,
-    ),
     // @ts-expect-error internal TypeScript API
-    setExternalModuleIndicator: ts.getSetExternalModuleIndicator(options),
-    jsDocParsingMode: transpileOptions.jsDocParsingMode ?? ts.JSDocParsingMode.ParseAll,
-  })
-  if (transpileOptions.moduleName) {
-    sourceFile.moduleName = transpileOptions.moduleName
-  }
+    for (const option of ts.transpileOptionValueCompilerOptions) {
+      // Do not set redundant config options if `verbatimModuleSyntax` was supplied.
+      if (options.verbatimModuleSyntax && new Set(['isolatedModules']).has(option.name)) {
+        continue
+      }
 
-  if (transpileOptions.renamedDependencies) {
-    // @ts-expect-error internal TypeScript API
-    sourceFile.renamedDependencies = new Map(Object.entries(transpileOptions.renamedDependencies))
-  }
+      options[option.name] = option.transpileOptionValue
+    }
 
-  // Output
-  let outputText: string | undefined
-  let sourceMapText: string | undefined
-  const inputs = [inputFileName]
-  const program = ts.createProgram(inputs, options, compilerHost)
+    // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths.
+    options.suppressOutputPathCheck = true
 
-  if (transpileOptions.reportDiagnostics) {
-    diagnostics.push(...program.getSyntacticDiagnostics(sourceFile))
-  }
+    // Filename can be non-ts file.
+    options.allowNonTsExtensions = true
+    options.declaration = false
+    options.declarationMap = false
 
-  diagnostics.push(...program.getOptionsDiagnostics())
+    const newLine = getNewLineCharacter(options)
+    // if jsx is specified then treat file as .tsx
+    const inputFileName =
+      transpileOptions.fileName ?? (transpileOptions.compilerOptions?.jsx ? 'module.tsx' : 'module.ts')
+    // Create a compilerHost object to allow the compiler to read and write files
+    const compilerHost: ts.CompilerHost = {
+      getSourceFile: (fileName) => {
+        // @ts-expect-error internal TypeScript API
+        if (fileName === ts.normalizePath(inputFileName)) {
+          return sourceFile
+        }
 
-  // Emit
-  const result = program.emit(
-    /*targetSourceFile*/ undefined,
-    /*writeFile*/ undefined,
-    /*cancellationToken*/ undefined,
-    /*emitOnlyDtsFiles*/ undefined,
-    transpileOptions.transformers?.(program),
-  )
+        // @ts-expect-error internal TypeScript API
+        return fileName === ts.normalizePath(barebonesLibName) ? barebonesLibSourceFile : undefined
+      },
+      writeFile: (name, text) => {
+        if (path.extname(name) === '.map') {
+          sourceMapText = text
+        } else {
+          outputText = text
+        }
+      },
+      getDefaultLibFileName: () => barebonesLibName,
+      useCaseSensitiveFileNames: () => false,
+      getCanonicalFileName: (fileName) => fileName,
+      getCurrentDirectory: () => '',
+      getNewLine: () => newLine,
+      fileExists: (fileName) => {
+        if (shouldCheckProjectPkgJsonContent(fileName, options.module)) {
+          return ts.sys.fileExists(fileName)
+        }
 
-  diagnostics.push(...result.diagnostics)
+        return fileName === inputFileName
+      },
+      readFile: (fileName) => {
+        if (shouldCheckProjectPkgJsonContent(fileName, options.module)) {
+          return ts.sys.readFile(fileName)
+        }
 
-  if (outputText === undefined) {
-    diagnostics.push({
-      category: ts.DiagnosticCategory.Error,
-      code: TsJestDiagnosticCodes.Generic,
-      messageText: 'No output generated',
-      file: sourceFile,
-      start: 0,
-      length: 0,
+        return ''
+      },
+      directoryExists: () => true,
+      getDirectories: () => [],
+    }
+
+    const sourceFile = ts.createSourceFile(inputFileName, input, {
+      languageVersion: options.target ?? ts.ScriptTarget.ESNext,
+      impliedNodeFormat: ts.getImpliedNodeFormatForFile(
+        inputFileName,
+        /*packageJsonInfoCache*/ undefined,
+        compilerHost,
+        options,
+      ),
+      // @ts-expect-error internal TypeScript API
+      setExternalModuleIndicator: ts.getSetExternalModuleIndicator(options),
+      jsDocParsingMode: transpileOptions.jsDocParsingMode ?? ts.JSDocParsingMode.ParseAll,
     })
+    if (transpileOptions.moduleName) {
+      sourceFile.moduleName = transpileOptions.moduleName
+    }
+
+    if (transpileOptions.renamedDependencies) {
+      // @ts-expect-error internal TypeScript API
+      sourceFile.renamedDependencies = new Map(Object.entries(transpileOptions.renamedDependencies))
+    }
+
+    // Output
+    let outputText: string | undefined
+    let sourceMapText: string | undefined
+    const inputs = [inputFileName]
+    const program = ts.createProgram(inputs, options, compilerHost)
+
+    if (transpileOptions.reportDiagnostics) {
+      diagnostics.push(...program.getSyntacticDiagnostics(sourceFile))
+    }
+
+    diagnostics.push(...program.getOptionsDiagnostics())
+
+    // Emit
+    const result = program.emit(
+      /*targetSourceFile*/ undefined,
+      /*writeFile*/ undefined,
+      /*cancellationToken*/ undefined,
+      /*emitOnlyDtsFiles*/ undefined,
+      transpileOptions.transformers?.(program),
+    )
+
+    diagnostics.push(...result.diagnostics)
+
+    if (outputText === undefined) {
+      diagnostics.push({
+        category: ts.DiagnosticCategory.Error,
+        code: TsJestDiagnosticCodes.Generic,
+        messageText: 'No output generated',
+        file: sourceFile,
+        start: 0,
+        length: 0,
+      })
+    }
+
+    return { outputText: outputText ?? '', diagnostics, sourceMapText }
   }
 
-  return { outputText: outputText ?? '', diagnostics, sourceMapText }
+  return transpileWorker
 }
-
-export const tsTranspileModule = transpileWorker

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,20 @@ export type TsJestGlobalOptions = Config.TransformerConfig[1] & {
          * @default `undefined` (TypeScript errors will be thrown as exceptions)
          */
         warnOnly?: boolean
+        /**
+         * **EXPERIMENTAL**
+         *
+         * Which engine performs type-checking:
+         * - `compiler` (default): the in-process JS TypeScript compiler (LanguageService)
+         * - `native`: the out-of-process native TypeScript compiler (requires the `typescript`
+         *   package to be native TypeScript 7+, and Node.js `require(esm)` support, i.e.
+         *   Node >= 20.19 / >= 22.12). Emit and AST transformers keep running on the JS compiler;
+         *   only diagnostics are delegated. When the native API cannot be loaded ts-jest falls
+         *   back to `compiler` with a warning.
+         *
+         * @default `compiler`
+         */
+        engine?: 'compiler' | 'native'
       }
 
   /**

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -22,6 +22,8 @@ export const enum Errors {
   MissingTransformerName = 'The AST transformer {{file}} must have an `export const name = <your_transformer_name>`',
   MissingTransformerVersion = 'The AST transformer {{file}} must have an `export const version = <your_transformer_version>`',
   InvalidModuleKindForEsm = 'The current compiler option "module" value is not suitable for Jest ESM mode. Please either use ES module kinds or Node16/NodeNext module kinds with "type: module" in package.json',
+  CompilerModuleWithoutJsApi = 'The `compiler` module "{{module}}" (version {{version}}) does not expose the TypeScript JS compiler API (`transpileModule`/`createLanguageService`) that ts-jest uses for emit and AST transforms. If this is native TypeScript 7+, install the official compatibility package alongside it:\n    ↳ `npm i -D @typescript/typescript6` (or `yarn add --dev @typescript/typescript6`)\nand either remove the `compiler` option (ts-jest will detect it automatically) or set `compiler: "@typescript/typescript6"`.',
+  NativeTypeScriptWithoutCompatPackage = 'Your project\'s `typescript` package (version {{version}}) is the native TypeScript compiler, which does not ship the JS compiler API that ts-jest uses for emit and AST transforms. Install the official compatibility package next to it:\n    ↳ `npm i -D @typescript/typescript6` (or `yarn add --dev @typescript/typescript6`)\nIt is designed to coexist with native TypeScript, and ts-jest will pick it up automatically. Type-checking can still use the fast native compiler via the ts-jest option `diagnostics: { engine: "native" }`.',
 }
 
 /**
@@ -29,6 +31,14 @@ export const enum Errors {
  */
 export const Helps = {
   FixMissingModule: '{{label}}: `npm i -D {{module}}` (or `yarn add --dev {{module}}`)',
+  UsingTypescript6CompatPackage:
+    'Your project\'s `typescript` package (version {{version}}) is the native TypeScript compiler without a JS compiler API; ts-jest is using "@typescript/typescript6" (version {{compatVersion}}) for emit and AST transforms instead.',
+  NativeCheckerUnavailable:
+    'The ts-jest option `diagnostics.engine` was set to "native" but the native TypeScript API could not be loaded ({{reason}}). Falling back to `diagnostics.engine: "compiler"`. The native engine requires the `typescript` package to be native TypeScript 7 or later, running on a Node.js version that supports `require()` of ES modules (>=20.19 or >=22.12).',
+  NativeCheckerIgnoredIsolatedModules:
+    'The ts-jest option `diagnostics.engine: "native"` has no effect because `isolatedModules` is enabled and type-checking is skipped entirely.',
+  InvalidDiagnosticsEngine:
+    'Invalid value for the ts-jest option `diagnostics.engine`: {{value}}. Expected "compiler" or "native". Using "compiler".',
   MigrateConfigUsingCLI:
     'Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.',
   UsingModernNodeResolution: `Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json. To disable this message, you can set "diagnostics.ignoreCodes" to include ${TsJestDiagnosticCodes.ModernNodeModule} in your ts-jest config. See more at https://kulshekhar.github.io/ts-jest/docs/getting-started/options/diagnostics`,

--- a/website/docs/getting-started/options/compiler.md
+++ b/website/docs/getting-started/options/compiler.md
@@ -9,6 +9,26 @@ The loaded version will depend on the one installed in your project.
 
 If you use a custom compiler, such as `ttypescript`, make sure its API is the same as the original TypeScript, at least for what `ts-jest` is using.
 
+### Native TypeScript 7+
+
+Native TypeScript (7.0 and later) no longer ships the in-process JS compiler API that `ts-jest` uses for emit and
+AST transforms. When the project's `typescript` package is native TypeScript, `ts-jest` automatically resolves its
+compiler API in this order:
+
+1. an explicit `compiler` option (used strictly — a module without the JS API is an error),
+2. the project's `typescript` package, when it still exposes the JS API (TypeScript 6.x and earlier),
+3. the official [`@typescript/typescript6`](https://www.npmjs.com/package/@typescript/typescript6) compatibility
+   package, published by the TypeScript team to be installed alongside native TypeScript.
+
+In a TypeScript 7+ project, install the compatibility package next to it and `ts-jest` picks it up automatically:
+
+```sh
+npm install --save-dev @typescript/typescript6
+```
+
+Type-checking can additionally use the fast native compiler itself via the experimental
+[`diagnostics: { engine: 'native' }`](./diagnostics) option.
+
 ### Example
 
 ```ts title="jest.config.ts"

--- a/website/docs/getting-started/options/diagnostics.md
+++ b/website/docs/getting-started/options/diagnostics.md
@@ -26,6 +26,14 @@ The `diagnostics` option's value can also accept an object for more advanced con
   similar to `tsconfig` option [exclude](https://www.typescriptlang.org/tsconfig#exclude) with the only difference is that
   in TypeScript, `exclude` will also exclude files from compilation process.
 - **`pretty`**: Enables/disables colorful and pretty output of errors (default: _enabled_).
+- **`engine`** (**experimental**): Which engine performs type-checking (default: `'compiler'`).
+  - `'compiler'`: the in-process JS TypeScript compiler (LanguageService) — the historical behavior.
+  - `'native'`: the out-of-process native TypeScript compiler. Requires the project's `typescript` package to be
+    native TypeScript 7+ and a Node.js version supporting `require()` of ES modules (>= 20.19 / >= 22.12).
+    JavaScript emit, `jest.mock()` hoisting and custom `astTransformers` keep running on the JS compiler pipeline
+    (resolved via [`compiler`](./compiler)); only type-checking is delegated to the native compiler, which spawns
+    one server per Jest worker. When the native API cannot be loaded, `ts-jest` falls back to `'compiler'` with a
+    warning. The native API is officially unstable until TypeScript 7.1, hence the experimental status.
 
 ### Examples
 


### PR DESCRIPTION
## Summary

Native TypeScript 7.0 (GA 2026-07-08) removed the in-process JS compiler API: `require('typescript')` now resolves to a version-only entry point, so ts-jest crashes or fails to install in any project that upgrades (`peerDependencies` previously pinned `<7`). Downstream projects are blocked on ts-jest for their TS7 migrations.

This PR implements Phases 0–2 of the "compat spine + native checker offload" design (RFC attached in the linked notes):

1. **Run in TS7 repos (backwards compatible by construction).** `ConfigSet` resolves its compiler API through a feature-probed chain: explicit `compiler` option (strict) → the project's `typescript` when it still exposes the JS API (≤ 6.x) → the official `@typescript/typescript6` compatibility package → an actionable error. Detection probes `typeof transpileModule === 'function'`, never semver, so npm aliases keep working. Emit, `jest.mock` hoisting, and `astTransformers` are unchanged — for TS 4.3–6.x users every code path is identical (proven below). Three direct `import ts from 'typescript'` leaks that bypassed `compilerModule` are closed; the vendored `transpileModule` fork becomes a factory over the resolved module.

2. **Check with TS7, opt-in (experimental).** `diagnostics: { engine: 'native' }` delegates type-checking to the native compiler through its synchronous stdio API (`typescript/unstable/sync`): one lazily-spawned server per Jest worker, per-file syntactic+semantic diagnostics, `openFiles` fallback for out-of-config specs, watch-mode invalidation via snapshot `fileChanges` wired into the existing depGraphs loop. Native wire diagnostics are mapped to the classic `ts.Diagnostic` shape, so `ignoreCodes` / `warnOnly` / `exclude` / pretty formatting work verbatim. When the engine is active the LanguageService is never constructed; emit flows through the transpile path (hoisting and `astTransformers` keep working). Graceful fallback to `'compiler'` with a warning when the native API is unavailable. The unstable-API exposure is confined to one adapter module, per the 7.1 "new and different API" announcement.

Also fixed along the way: TypeScript 6.x enforces 7.0-migration deprecations as hard errors, so the `moduleResolution=node10` runtime default ts-jest injects failed transpile-mode compilation with `TS5107` under any 6.x compiler — now silenced via a version-gated `ignoreDeprecations: '6.0'` override (the user's own `tsc` build still enforces migration).

## Test plan

- `npm ci && npm run build && npm run lint` — clean (one pre-existing warning).
- Full unit suite: **25 suites / 402 tests / 138 snapshots passing** (47 new tests: resolver matrix, diagnostic mapping, engine fallback/validation, cacheSuffix flips, TsCompiler wiring, TS6 deprecation override).
- **Backwards-compat proof:** the pre-existing test set (new specs excluded) on `typescript ~5.9.3` is byte-identical before vs after: 20 suites / 355 tests / 136 snapshots.
- Fixture project with real `typescript@7.0.2` + `@typescript/typescript6`:
  - zero-config CJS and ESM-preset runs pass;
  - a deliberate `TS2322` fails with **identical formatted output** under both engines, and `ignoreCodes: [2322]` suppresses it under both;
  - `jest.mock` hoisting and a custom `astTransformers` transformer pass under `engine: 'native'`;
  - `TS_JEST_LOG` confirms the native server spawned and checked files (zero fallbacks).
- Benchmark (200-file corpus, `strict`, real libs, via `ConfigSet`+`TsCompiler`): type-checking adds ≈ 2.3 ms/file native vs ≈ 4.4 ms/file LanguageService (~2× faster checking, ~23% faster overall steady state); trade-offs and caveats documented in the implementation notes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Peer range widens to `typescript >=4.3 <8` (loosening), with `@typescript/typescript6` as an optional peer. Defaults are unchanged; the native engine is opt-in and experimental. The one documented behavioral trade-off of opting into `engine: 'native'` is that emit uses the transpile pipeline (same emit semantics as `isolatedModules` mode).

## Other information

- Commit series is structured for review: seam hygiene → compat resolution → native engine → perf → TS6 deprecation fix → docs → lockfile.
- Docs updated: `options/compiler.md` (TypeScript 7 section) and `options/diagnostics.md` (`engine`).
- Follow-ups tracked in the implementation notes: adopt the stable 7.1 API, CI matrix rows (`typescript@6`, `typescript@7`+compat, engine native, nightly `typescript@next`), port the sandbox fixtures into `e2e/`, consider defaulting to the native engine when v7 is detected (next major), upstream asks (batched diagnostics, per-file in-memory emit).

## CI status (triage)

- **PR docs check**: fixed — a bare `<=` in the new compiler.md section parsed as a JSX opener under MDX; reworded, squashed into the docs commit, green on current head.
- **CI (full matrix)**: green on both pushed heads.
- **Audit Codes / osv-scan**: pre-existing failure, unrelated — annotation is `Job outputs exceed 1,048,576 bytes` from the osv reusable PR workflow, while the diff scan found **zero new vulnerabilities** (SARIF results array is empty; the only lockfile change is the root peer stanza). The same failure started on the renovate actions-checkout-digest PR on 2026-07-20, before this branch existed. Separate-PR fix: update the pinned osv-scanner-action reusable workflow (newer versions pass results via artifacts, not job outputs) or clear the outstanding advisories on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental `diagnostics.engine` option to switch type-checking to a native (out-of-process) engine.
  * When native diagnostics aren’t available, automatically falls back to the in-process compiler with warnings.
* **Documentation**
  * Updated docs explaining native diagnostics behavior and how TypeScript “JS compiler API” is resolved (including compatibility via `@typescript/typescript6`).
* **Bug Fixes**
  * Improved detection of supported TypeScript compiler APIs and strengthened cache separation across diagnostics engines.
* **Chores**
  * Broadened `typescript` peer dependency compatibility and introduced an optional TypeScript 6 compatibility peer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Review response (Copilot + CodeRabbit)

- ✅ **Fixed** (ede90f9) — CodeRabbit major: `NativeDiagnosticsService.dispose()` left `_projectCache`/`_openedFiles`/`_unresolvableFiles` populated, so a respawn after dispose could serve project handles bound to the dead server. All snapshot-scoped state is now cleared on dispose.
- ✅ **Adopted** — CodeRabbit nitpick: the spec fake server now mints per-instance project handles that throw once their server is closed; the dispose test was verified to fail against the unfixed code, so it now guards this regression class.
- ⏭️ **Skipped** — CodeRabbit minor (heading `###` → `##` in compiler.md): the option pages consistently use `###` for sections (including the pre-existing `### Example` on the same page and every section of diagnostics.md); changing one heading would break the page hierarchy consistency, and markdownlint is not part of this repo's lint setup.
- ⏭️ **Skipped** — Copilot (watch-mode importer recheck passes `fileName` rather than `fileToReTypeCheck` to `raiseDiagnostics`): this mirrors the pre-existing LanguageService watch loop exactly, which is the point of the native path (engine swap, no behavior change). The cited suppression scenario is already covered: the loop only re-checks files passing `shouldReportDiagnostics(fileToReTypeCheck)`, and per-diagnostic filtering keys on `diagnostic.file.fileName`. Changing the argument only on the native path would make the engines diverge; changing both paths touches pre-existing behavior and belongs in a separate cleanup.