### PR TITLE
feat: add TypeScript 7 project compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,48 @@ jobs:
       - name: Run prettier 💅
         run: npm run lint-prettier-ci
 
+  typescript-compatibility:
+    name: ${{ matrix.name }} compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: TypeScript 4.3
+            packages: typescript@4.3.5
+            test-args: --api-major 4 --compiler-bin tsc
+          - name: TypeScript 5.9
+            packages: typescript@5.9.3
+            test-args: --api-major 5 --compiler-bin tsc
+          - name: TypeScript 6 compatibility API
+            packages: typescript@npm:@typescript/typescript6@6.0.2
+            test-args: --api-major 6 --compiler-bin tsc6
+          - name: TypeScript 7 side-by-side aliases
+            packages: '@typescript/native@npm:typescript@7.0.2 typescript@npm:@typescript/typescript6@6.0.2'
+            test-args: --api-major 6 --compiler-bin tsc --compiler-bin tsc6 --native --check-public-types
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 20
+          fetch-tags: false
+
+      - name: Setup workspace ⚙️
+        uses: ./.github/actions/setup-workspace
+        with:
+          os: ubuntu-latest
+          node-version: 22
+
+      - name: Build with the development compiler 🔧
+        run: npm run build
+
+      - name: Install ${{ matrix.name }} 🔧
+        run: npm install --ignore-scripts --legacy-peer-deps --no-save --package-lock=false ${{ matrix.packages }}
+
+      - name: Run TypeScript compatibility tests 🧪
+        run: node scripts/test-typescript-compatibility.js ${{ matrix.test-args }}
+
   sonar-scan:
     permissions:
       checks: write

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ These instructions will get you setup to use `ts-jest` in your project. For more
 | **Creating config** | `npx ts-jest config:init`      | `yarn ts-jest config:init`           |
 |   **Running tests** | `npm test` or `npx jest`       | `yarn test` or `yarn jest`           |
 
+If your project uses TypeScript 7, follow the [supported side-by-side compiler setup](website/docs/guides/typescript-7.md)
+instead of installing `typescript` directly.
+
 ## Built With
 
 - [TypeScript](https://www.typescriptlang.org/) - JavaScript that scales

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ It supports all features of TypeScript including type-checking. [Read more about
 
 These instructions will get you setup to use `ts-jest` in your project. For more detailed documentation, please check [online documentation](https://kulshekhar.github.io/ts-jest).
 
-|                     | using npm                      | using yarn                           |
-| ------------------: | ------------------------------ | ------------------------------------ |
-|   **Prerequisites** | `npm i -D jest typescript`     | `yarn add --dev jest typescript`     |
-|      **Installing** | `npm i -D ts-jest @types/jest` | `yarn add --dev ts-jest @types/jest` |
-| **Creating config** | `npx ts-jest config:init`      | `yarn ts-jest config:init`           |
-|   **Running tests** | `npm test` or `npx jest`       | `yarn test` or `yarn jest`           |
+|                                      | using npm                      | using yarn                           |
+| -----------------------------------: | ------------------------------ | ------------------------------------ |
+| **Prerequisites (TypeScript 4.3–6)** | `npm i -D jest typescript`     | `yarn add --dev jest typescript`     |
+|                       **Installing** | `npm i -D ts-jest @types/jest` | `yarn add --dev ts-jest @types/jest` |
+|                  **Creating config** | `npx ts-jest config:init`      | `yarn ts-jest config:init`           |
+|                    **Running tests** | `npm test` or `npx jest`       | `yarn test` or `yarn jest`           |
 
 If your project uses TypeScript 7, follow the [supported side-by-side compiler setup](website/docs/guides/typescript-7.md)
 instead of installing `typescript` directly.

--- a/e2e/typescript-compatibility/__tests__/compat.spec.ts
+++ b/e2e/typescript-compatibility/__tests__/compat.spec.ts
@@ -1,0 +1,18 @@
+import { throwMappedError } from '../src/source-map'
+import { transformed } from '../src/transformed'
+
+describe('TypeScript compatibility', () => {
+  it('runs custom transformers', () => {
+    expect(transformed).toBe('__TRANSFORMED__')
+  })
+
+  it('preserves source maps', () => {
+    expect(throwMappedError).toThrow(/mapped failure/)
+
+    try {
+      throwMappedError()
+    } catch (error) {
+      expect((error as Error).stack).toMatch(/source-map\.ts:2:\d+/)
+    }
+  })
+})

--- a/e2e/typescript-compatibility/__tests__/hoist.spec.ts
+++ b/e2e/typescript-compatibility/__tests__/hoist.spec.ts
@@ -1,0 +1,7 @@
+import { dependency } from '../src/dependency'
+
+jest.mock('../src/dependency', () => ({ dependency: 'mocked' }))
+
+it('hoists Jest mocks before imports', () => {
+  expect(dependency).toBe('mocked')
+})

--- a/e2e/typescript-compatibility/jest-compiler-cjs.config.cjs
+++ b/e2e/typescript-compatibility/jest-compiler-cjs.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./jest-config.cjs')({ esm: false, isolatedModules: false })

--- a/e2e/typescript-compatibility/jest-compiler-esm.config.cjs
+++ b/e2e/typescript-compatibility/jest-compiler-esm.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./jest-config.cjs')({ esm: true, isolatedModules: false })

--- a/e2e/typescript-compatibility/jest-config.cjs
+++ b/e2e/typescript-compatibility/jest-config.cjs
@@ -1,0 +1,38 @@
+const path = require('node:path')
+
+const rootDir = __dirname
+const transformerPath = path.join(rootDir, '../../dist')
+const astTransformerPath = path.join(rootDir, 'transformer.cjs')
+
+module.exports = ({ esm, isolatedModules }) => ({
+  rootDir,
+  extensionsToTreatAsEsm: esm ? ['.ts'] : [],
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/__tests__/compat.spec.ts', ...(esm ? [] : ['<rootDir>/__tests__/hoist.spec.ts'])],
+  transform: {
+    '^.+\\.ts$': [
+      transformerPath,
+      {
+        astTransformers: {
+          before: [
+            {
+              path: astTransformerPath,
+              options: { expectProgram: !isolatedModules },
+            },
+          ],
+        },
+        tsconfig: path.join(
+          rootDir,
+          esm
+            ? isolatedModules
+              ? 'tsconfig-esm-isolated.json'
+              : 'tsconfig-esm.json'
+            : isolatedModules
+            ? 'tsconfig-cjs-isolated.json'
+            : 'tsconfig-cjs.json',
+        ),
+        useESM: esm,
+      },
+    ],
+  },
+})

--- a/e2e/typescript-compatibility/jest-explicit-node10.config.cjs
+++ b/e2e/typescript-compatibility/jest-explicit-node10.config.cjs
@@ -1,0 +1,7 @@
+const path = require('node:path')
+
+const config = require('./jest-config.cjs')({ esm: false, isolatedModules: true })
+config.testMatch = ['<rootDir>/__tests__/compat.spec.ts']
+config.transform['^.+\\.ts$'][1].tsconfig = path.join(__dirname, 'tsconfig-cjs-explicit-node10.json')
+
+module.exports = config

--- a/e2e/typescript-compatibility/jest-transpiler-cjs.config.cjs
+++ b/e2e/typescript-compatibility/jest-transpiler-cjs.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./jest-config.cjs')({ esm: false, isolatedModules: true })

--- a/e2e/typescript-compatibility/jest-transpiler-esm.config.cjs
+++ b/e2e/typescript-compatibility/jest-transpiler-esm.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./jest-config.cjs')({ esm: true, isolatedModules: true })

--- a/e2e/typescript-compatibility/public-types.ts
+++ b/e2e/typescript-compatibility/public-types.ts
@@ -1,0 +1,15 @@
+import type ts from 'typescript'
+
+import type { ConfigSet, TsCompiler, TsJestAstTransformer, TsJestTransformerOptions } from '../../dist'
+
+declare const configSet: ConfigSet
+declare const compiler: TsCompiler
+declare const options: TsJestTransformerOptions
+declare const transformer: TsJestAstTransformer
+declare const sourceFile: ts.SourceFile
+
+void configSet
+void compiler
+void options
+void transformer
+void sourceFile

--- a/e2e/typescript-compatibility/src/dependency.ts
+++ b/e2e/typescript-compatibility/src/dependency.ts
@@ -1,0 +1,1 @@
+export const dependency = 'real'

--- a/e2e/typescript-compatibility/src/source-map.ts
+++ b/e2e/typescript-compatibility/src/source-map.ts
@@ -1,0 +1,3 @@
+export function throwMappedError(): never {
+  throw new Error('mapped failure')
+}

--- a/e2e/typescript-compatibility/src/transformed.ts
+++ b/e2e/typescript-compatibility/src/transformed.ts
@@ -1,0 +1,1 @@
+export const transformed = '__ORIGINAL__'

--- a/e2e/typescript-compatibility/transformer.cjs
+++ b/e2e/typescript-compatibility/transformer.cjs
@@ -1,0 +1,23 @@
+const ts = require('typescript')
+
+module.exports = {
+  name: 'typescript-compatibility-transformer',
+  version: 1,
+  factory(compiler, options = {}) {
+    return (context) => (sourceFile) => {
+      if (options.expectProgram && !compiler.program?.getTypeChecker()) {
+        throw new Error('Expected the language-service compiler to expose its TypeScript program')
+      }
+
+      const visitor = (node) => {
+        if (ts.isStringLiteral(node) && node.text === '__ORIGINAL__') {
+          return ts.factory.createStringLiteral('__TRANSFORMED__')
+        }
+
+        return ts.visitEachChild(node, visitor, context)
+      }
+
+      return ts.visitNode(sourceFile, visitor)
+    }
+  },
+}

--- a/e2e/typescript-compatibility/tsconfig-cjs-explicit-node10.json
+++ b/e2e/typescript-compatibility/tsconfig-cjs-explicit-node10.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs-isolated.json",
+  "compilerOptions": {
+    "moduleResolution": "Node10"
+  }
+}

--- a/e2e/typescript-compatibility/tsconfig-cjs-isolated.json
+++ b/e2e/typescript-compatibility/tsconfig-cjs-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/typescript-compatibility/tsconfig-cjs.json
+++ b/e2e/typescript-compatibility/tsconfig-cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "CommonJS",
+    "sourceMap": true,
+    "target": "ES2019",
+    "types": ["jest"]
+  }
+}

--- a/e2e/typescript-compatibility/tsconfig-esm-isolated.json
+++ b/e2e/typescript-compatibility/tsconfig-esm-isolated.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/typescript-compatibility/tsconfig-esm.json
+++ b/e2e/typescript-compatibility/tsconfig-esm.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "sourceMap": true,
+    "target": "ES2019",
+    "types": ["jest"]
+  }
+}

--- a/e2e/typescript-compatibility/tsconfig-public-types.json
+++ b/e2e/typescript-compatibility/tsconfig-public-types.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "target": "ES2020",
+    "types": []
+  },
+  "files": ["public-types.ts"]
+}

--- a/scripts/test-typescript-compatibility.js
+++ b/scripts/test-typescript-compatibility.js
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
+
+const rootDir = path.join(__dirname, '..')
+const fixtureDir = path.join(rootDir, 'e2e/typescript-compatibility')
+const jestBin = path.join(rootDir, 'node_modules/jest/bin/jest.js')
+const args = process.argv.slice(2)
+
+const optionValue = (name) => {
+  const optionIndex = args.indexOf(name)
+
+  return optionIndex === -1 ? undefined : args[optionIndex + 1]
+}
+
+const apiMajor = optionValue('--api-major')
+const compilerBins = args.flatMap((argument, index) => (argument === '--compiler-bin' ? [args[index + 1]] : []))
+const hasNativeCompiler = args.includes('--native')
+const shouldCheckPublicTypes = args.includes('--check-public-types')
+
+if (!apiMajor || compilerBins.length === 0) {
+  throw new Error('Usage: test-typescript-compatibility --api-major <major> --compiler-bin <name> [options]')
+}
+
+const run = (command, commandArgs, options = {}) => {
+  const result = spawnSync(command, commandArgs, {
+    cwd: options.cwd ?? rootDir,
+    env: process.env,
+    stdio: 'inherit',
+  })
+
+  if (result.error) throw result.error
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}
+
+const runExpectingFailure = (command, commandArgs, expectedOutput, options = {}) => {
+  const result = spawnSync(command, commandArgs, {
+    cwd: options.cwd ?? rootDir,
+    encoding: 'utf8',
+    env: process.env,
+  })
+
+  if (result.error) throw result.error
+  assert.notEqual(result.status, 0, `Expected ${command} to fail`)
+  assert.match(`${result.stdout}${result.stderr}`, expectedOutput)
+}
+
+const binPath = (name) =>
+  path.join(rootDir, 'node_modules', '.bin', `${name}${process.platform === 'win32' ? '.cmd' : ''}`)
+
+const compilerModule = require(path.join(rootDir, 'node_modules/typescript'))
+assert.equal(compilerModule.version.split('.')[0], apiMajor, `Expected TypeScript API ${apiMajor}.x`)
+
+run(process.execPath, [jestBin, '--config', 'jest-compiler-cjs.config.cjs', '--runInBand', '--no-cache'], {
+  cwd: fixtureDir,
+})
+run(process.execPath, [jestBin, '--config', 'jest-transpiler-cjs.config.cjs', '--runInBand', '--no-cache'], {
+  cwd: fixtureDir,
+})
+run(
+  process.execPath,
+  [
+    '--experimental-vm-modules',
+    '--no-warnings',
+    jestBin,
+    '--config',
+    'jest-compiler-esm.config.cjs',
+    '--runInBand',
+    '--no-cache',
+  ],
+  { cwd: fixtureDir }
+)
+run(
+  process.execPath,
+  [
+    '--experimental-vm-modules',
+    '--no-warnings',
+    jestBin,
+    '--config',
+    'jest-transpiler-esm.config.cjs',
+    '--runInBand',
+    '--no-cache',
+  ],
+  { cwd: fixtureDir }
+)
+
+for (const compilerBin of compilerBins) {
+  run(binPath(compilerBin), ['--version'])
+  if (shouldCheckPublicTypes) {
+    run(binPath(compilerBin), ['--project', path.join(fixtureDir, 'tsconfig-public-types.json')])
+  }
+}
+
+if (apiMajor === '6') {
+  runExpectingFailure(
+    process.execPath,
+    [jestBin, '--config', 'jest-explicit-node10.config.cjs', '--runInBand', '--no-cache'],
+    /TS5107/,
+    { cwd: fixtureDir }
+  )
+}
+
+if (hasNativeCompiler) {
+  const nativeCompiler = require(require.resolve('@typescript/native', { paths: [rootDir] }))
+  assert.equal(nativeCompiler.version.split('.')[0], '7', 'Expected the native tsc to be TypeScript 7.x')
+
+  const { Importer } = require(path.join(rootDir, 'dist/utils/importer'))
+  assert.throws(
+    () => new Importer().typescript('Testing direct TypeScript 7 usage.', '@typescript/native'),
+    /does not expose the JavaScript compiler API required by ts-jest/
+  )
+}

--- a/scripts/test-typescript-compatibility.js
+++ b/scripts/test-typescript-compatibility.js
@@ -6,20 +6,26 @@ const rootDir = path.join(__dirname, '..')
 const fixtureDir = path.join(rootDir, 'e2e/typescript-compatibility')
 const jestBin = path.join(rootDir, 'node_modules/jest/bin/jest.js')
 const args = process.argv.slice(2)
+const usage = 'Usage: test-typescript-compatibility --api-major <major> --compiler-bin <name> [options]'
 
-const optionValue = (name) => {
-  const optionIndex = args.indexOf(name)
+const optionValues = (name) =>
+  args.flatMap((argument, index) => {
+    if (argument !== name) return []
 
-  return optionIndex === -1 ? undefined : args[optionIndex + 1]
-}
+    const value = args[index + 1]
 
-const apiMajor = optionValue('--api-major')
-const compilerBins = args.flatMap((argument, index) => (argument === '--compiler-bin' ? [args[index + 1]] : []))
+    if (!value || value.startsWith('--')) throw new Error(usage)
+
+    return [value]
+  })
+
+const [apiMajor] = optionValues('--api-major')
+const compilerBins = optionValues('--compiler-bin')
 const hasNativeCompiler = args.includes('--native')
 const shouldCheckPublicTypes = args.includes('--check-public-types')
 
 if (!apiMajor || compilerBins.length === 0) {
-  throw new Error('Usage: test-typescript-compatibility --api-major <major> --compiler-bin <name> [options]')
+  throw new Error(usage)
 }
 
 const run = (command, commandArgs, options = {}) => {

--- a/src/__mocks__/tsconfig-no-module-resolution.json
+++ b/src/__mocks__/tsconfig-no-module-resolution.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "isolatedModules": true,
+    "module": "CommonJS"
+  }
+}

--- a/src/legacy/compiler/ts-compiler.spec.ts
+++ b/src/legacy/compiler/ts-compiler.spec.ts
@@ -326,6 +326,90 @@ describe('TsCompiler', () => {
         }
       })
 
+      test('should ignore TS5107 only when TypeScript 6 sees ts-jest injected Node10 resolution', () => {
+        const compiler = makeCompiler({
+          tsJestConfig: {
+            tsconfig: join(mockFolder, 'tsconfig-no-module-resolution.json'),
+          },
+        })
+        const injectedDefaultDiagnostic: ts.Diagnostic = {
+          category: ts.DiagnosticCategory.Error,
+          code: 5107,
+          messageText: "Option 'moduleResolution=node10' is deprecated.",
+          file: undefined,
+          start: undefined,
+          length: undefined,
+        }
+        const unrelatedDeprecation: ts.Diagnostic = {
+          category: ts.DiagnosticCategory.Error,
+          code: 5101,
+          messageText: "Option 'baseUrl' is deprecated.",
+          file: undefined,
+          start: undefined,
+          length: undefined,
+        }
+        const transpileModule = jest.fn().mockReturnValue({
+          outputText: 'var bar = 1',
+          diagnostics: [injectedDefaultDiagnostic, unrelatedDeprecation],
+        })
+        // @ts-expect-error testing purpose: simulate the TypeScript 6 compatibility package
+        compiler._ts = { ...ts, version: '6.0.0', transpileModule }
+        compiler.configSet.raiseDiagnostics = jest.fn()
+
+        compiler.getCompiledOutput(fileContent, fileName, {
+          depGraphs: new Map(),
+          supportsStaticESM: false,
+          watchMode: false,
+        })
+
+        expect(compiler.configSet.raiseDiagnostics).toHaveBeenCalledWith(
+          [unrelatedDeprecation],
+          fileName,
+          // @ts-expect-error testing purpose
+          compiler._logger,
+        )
+      })
+
+      test('should preserve TS5107 when the user explicitly selects Node10 resolution', () => {
+        const compiler = makeCompiler({
+          tsJestConfig: {
+            tsconfig: {
+              isolatedModules: true,
+              module: 'CommonJS',
+              moduleResolution: 'Node10',
+            },
+          },
+        })
+        const diagnostic: ts.Diagnostic = {
+          category: ts.DiagnosticCategory.Error,
+          code: 5107,
+          messageText: "Option 'moduleResolution=node10' is deprecated.",
+          file: undefined,
+          start: undefined,
+          length: undefined,
+        }
+        // @ts-expect-error testing purpose: simulate the TypeScript 6 compatibility package
+        compiler._ts = {
+          ...ts,
+          version: '6.0.0',
+          transpileModule: jest.fn().mockReturnValue({ outputText: 'var bar = 1', diagnostics: [diagnostic] }),
+        }
+        compiler.configSet.raiseDiagnostics = jest.fn()
+
+        compiler.getCompiledOutput(fileContent, fileName, {
+          depGraphs: new Map(),
+          supportsStaticESM: false,
+          watchMode: false,
+        })
+
+        expect(compiler.configSet.raiseDiagnostics).toHaveBeenCalledWith(
+          [diagnostic],
+          fileName,
+          // @ts-expect-error testing purpose
+          compiler._logger,
+        )
+      })
+
       it('should use tsTranspileModule when Node16/NodeNext is used', () => {
         const compiler = makeCompiler({
           tsJestConfig: {

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -473,12 +473,15 @@ export class TsCompiler implements TsCompilerInstance {
      * This code path should be removed in the next major version to benefit from checking on compiler options
      */
     if (!isModernNodeModuleKind(this._initialCompilerOptions.module)) {
-      return this._ts.transpileModule(fileContent, {
+      const result = this._ts.transpileModule(fileContent, {
         fileName,
         transformers: this._makeTransformers(this.configSet.resolvedTransformers),
         compilerOptions: this._compilerOptions,
         reportDiagnostics: this.configSet.shouldReportDiagnostics(fileName),
       })
+      const diagnostics = this._filterDiagnosticsFromTsJestDefaults(result.diagnostics)
+
+      return diagnostics === result.diagnostics ? result : { ...result, diagnostics }
     }
 
     return tsTranspileModule(fileContent, {
@@ -491,6 +494,27 @@ export class TsCompiler implements TsCompilerInstance {
       compilerOptions: this._initialCompilerOptions,
       reportDiagnostics: fileName ? this.configSet.shouldReportDiagnostics(fileName) : false,
     })
+  }
+
+  /**
+   * TypeScript 6 reports TS5107 when ts-jest's historical default of
+   * `moduleResolution: Node10` is passed to `transpileModule`. The diagnostic
+   * is an implementation detail when ts-jest injected that value, but remains
+   * actionable when the user selected Node10 themselves.
+   */
+  private _filterDiagnosticsFromTsJestDefaults(diagnostics: Diagnostic[] | undefined): Diagnostic[] | undefined {
+    const node10 = this._ts.ModuleResolutionKind.Node10 ?? this._ts.ModuleResolutionKind.NodeJs
+    const tsMajor = parseInt(this._ts.version.split('.')[0], 10)
+    const hasInjectedNode10 =
+      tsMajor >= 6 &&
+      this._initialCompilerOptions.moduleResolution === undefined &&
+      this._compilerOptions.moduleResolution === node10
+
+    if (!hasInjectedNode10 || !diagnostics?.some((diagnostic) => diagnostic.code === 5107)) {
+      return diagnostics
+    }
+
+    return diagnostics.filter((diagnostic) => diagnostic.code !== 5107)
   }
 
   protected _makeTransformers(customTransformers: TsJestAstTransformer): CustomTransformers {

--- a/src/legacy/compiler/ts-compiler.ts
+++ b/src/legacy/compiler/ts-compiler.ts
@@ -503,8 +503,9 @@ export class TsCompiler implements TsCompilerInstance {
    * actionable when the user selected Node10 themselves.
    */
   private _filterDiagnosticsFromTsJestDefaults(diagnostics: Diagnostic[] | undefined): Diagnostic[] | undefined {
-    const node10 = this._ts.ModuleResolutionKind.Node10 ?? this._ts.ModuleResolutionKind.NodeJs
-    const tsMajor = parseInt(this._ts.version.split('.')[0], 10)
+    // `Node10` was exposed as `NodeJs` (with the same value) by older supported TypeScript releases.
+    const node10 = this._ts.ModuleResolutionKind.Node10 ?? 2
+    const tsMajor = Number.parseInt(this._ts.version.split('.')[0], 10)
     const hasInjectedNode10 =
       tsMajor >= 6 &&
       this._initialCompilerOptions.moduleResolution === undefined &&

--- a/src/utils/importer.spec.ts
+++ b/src/utils/importer.spec.ts
@@ -120,9 +120,25 @@ describe('babelJest', () => {
 
 describe('typescript', () => {
   it('should be typescript', () => {
-    modules = {
-      typescript: () => 'typescript',
+    const compilerModule = {
+      createLanguageService: jest.fn(),
+      parseJsonConfigFileContent: jest.fn(),
+      transpileModule: jest.fn(),
+      version: '6.0.0',
     }
-    expect(new Importer().typescript(fakers.importReason(), 'typescript')).toBe('typescript')
+    modules = {
+      typescript: () => compilerModule,
+    }
+    expect(new Importer().typescript(fakers.importReason(), 'typescript')).toBe(compilerModule)
+  })
+
+  it('should fail early when the compiler does not expose the JavaScript compiler API', () => {
+    modules = {
+      typescript: () => ({ version: '7.0.2' }),
+    }
+
+    expect(() => new Importer().typescript(fakers.importReason(), 'typescript')).toThrowErrorMatchingInlineSnapshot(
+      `"The TypeScript compiler "typescript" (version 7.0.2) does not expose the JavaScript compiler API required by ts-jest. To use TypeScript 7 for project type-checking, install it as "@typescript/native" and alias "@typescript/typescript6" as "typescript" for ts-jest."`,
+    )
   })
 })

--- a/src/utils/importer.ts
+++ b/src/utils/importer.ts
@@ -35,7 +35,22 @@ export class Importer {
   }
 
   typescript(why: ImportReasons, which: string): TTypeScript {
-    return this._import(why, which)
+    const compilerModule = this._import<TTypeScript>(why, which)
+    const hasRequiredCompilerApi =
+      typeof compilerModule.createLanguageService === 'function' &&
+      typeof compilerModule.parseJsonConfigFileContent === 'function' &&
+      typeof compilerModule.transpileModule === 'function'
+
+    if (!hasRequiredCompilerApi) {
+      throw new Error(
+        interpolate(Errors.TypeScriptCompilerApiUnavailable, {
+          module: which,
+          version: compilerModule.version ?? 'unknown',
+        }),
+      )
+    }
+
+    return compilerModule
   }
 
   esBuild(why: ImportReasons): TEsBuild {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -5,6 +5,7 @@ import { TsJestDiagnosticCodes } from './diagnostics'
  */
 export const enum Errors {
   LoadingModuleFailed = 'Loading module {{module}} failed with error: {{error}}',
+  TypeScriptCompilerApiUnavailable = 'The TypeScript compiler "{{module}}" (version {{version}}) does not expose the JavaScript compiler API required by ts-jest. To use TypeScript 7 for project type-checking, install it as "@typescript/native" and alias "@typescript/typescript6" as "typescript" for ts-jest.',
   UnableToLoadOneModule = 'Unable to load the module {{module}}. {{reason}} To fix it:\n{{fix}}',
   UnableToLoadAnyModule = 'Unable to load any of these modules: {{module}}. {{reason}}. To fix it:\n{{fix}}',
   UnableToRequireDefinitionFile = 'Unable to require `.d.ts` file for file: {{file}}.\nThis is usually the result of a faulty configuration or import. Make sure there is a `.js`, `.json` or another executable extension available alongside `{{file}}`.',

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -11,6 +11,9 @@ You can install `ts-jest` and dependencies all at once with one of the following
 npm install --save-dev jest typescript ts-jest @types/jest
 ```
 
+If your project uses TypeScript 7, follow the [TypeScript 7 side-by-side setup](../guides/typescript-7.md) instead of
+installing `typescript` directly.
+
 :::tip
 
 Tip: If you get an error with the following `npm` commands such as `npx: command not found`, you can replace `npx XXX` with `node node_modules/.bin/XXX` from the root of your project.

--- a/website/docs/getting-started/options/compiler.md
+++ b/website/docs/getting-started/options/compiler.md
@@ -9,6 +9,9 @@ The loaded version will depend on the one installed in your project.
 
 If you use a custom compiler, such as `ttypescript`, make sure its API is the same as the original TypeScript, at least for what `ts-jest` is using.
 
+TypeScript 7.0's native package does not expose this API and cannot be selected here. See the
+[TypeScript 7 guide](../../guides/typescript-7.md) for the supported side-by-side setup.
+
 ### Example
 
 ```ts title="jest.config.ts"

--- a/website/docs/guides/typescript-7.md
+++ b/website/docs/guides/typescript-7.md
@@ -15,6 +15,10 @@ Install the two compilers under separate package names:
 npm install --save-dev '@typescript/native@npm:typescript@^7.0.2' 'typescript@npm:@typescript/typescript6@^6.0.2'
 ```
 
+If npm reports `ERESOLVE` after replacing `typescript` with TypeScript 7 directly, do not bypass the peer dependency check
+with `--legacy-peer-deps`. Use the aliases above instead: the native package does not provide the compiler API required by
+ts-jest, while the `typescript` alias does.
+
 The equivalent `package.json` configuration is:
 
 ```json

--- a/website/docs/guides/typescript-7.md
+++ b/website/docs/guides/typescript-7.md
@@ -1,0 +1,71 @@
+---
+title: Using TypeScript 7
+---
+
+TypeScript 7.0 ships a native `tsc`, but it does not ship the JavaScript compiler API that `ts-jest` needs for transforms,
+language-service diagnostics, source maps, hoisting, and custom AST transformers. Microsoft provides
+[`@typescript/typescript6`](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6-0)
+for tools that still need that API and recommends installing it alongside TypeScript 7 with npm aliases.
+
+## Installation
+
+Install the two compilers under separate package names:
+
+```bash
+npm install --save-dev '@typescript/native@npm:typescript@^7.0.2' 'typescript@npm:@typescript/typescript6@^6.0.2'
+```
+
+The equivalent `package.json` configuration is:
+
+```json
+{
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
+}
+```
+
+With this layout:
+
+- `npx tsc` runs the native TypeScript 7 compiler for project type-checking and builds.
+- `npx tsc6` runs the TypeScript 6 compatibility compiler when you need to compare results.
+- `ts-jest` imports `typescript`, so it receives the supported TypeScript 6 JavaScript API.
+
+Do not set the ts-jest `compiler` option to `@typescript/native`. TypeScript 7.0 has no compatible JavaScript API, and
+ts-jest will stop early with an actionable configuration error if that package is loaded directly.
+
+## Why ts-jest uses the compatibility API
+
+Calling TypeScript 7 internals or translating between its native protocol and the TypeScript 6 API would create an unstable
+second compiler integration. It would also leave gaps in custom transformers and `Program` access. The side-by-side layout is
+the upstream-supported transition path and keeps one established API on the Jest transform path.
+
+Two alternatives were deliberately rejected:
+
+- ts-jest does not silently fall back to `@typescript/typescript6` when `typescript` resolves to TypeScript 7. ts-jest's
+  public declarations import classic compiler types from `typescript`; a runtime-only fallback would make those declarations
+  inconsistent with the package the user's type checker resolves.
+- ts-jest does not call unstable native APIs or combine TypeScript 7 diagnostics with TypeScript 6 transforms. TypeScript 7.0
+  has no stable programmatic API, and a dual-compiler path would not preserve the existing transformer and `Program` contract.
+
+This has two practical tradeoffs:
+
+- TypeScript 7's native performance applies to `tsc`, not to transforms performed by ts-jest. Jest transform performance is
+  the same as TypeScript 6.
+- TypeScript 7 should be the authoritative project type-check. Diagnostics produced during Jest transforms come from the
+  TypeScript 6 compatibility API and can differ from TypeScript 7. Run `npx tsc --noEmit` separately in local development and
+  CI.
+
+TypeScript 6 reports TS5107 for `moduleResolution: Node10`. ts-jest filters that diagnostic only when it supplied Node10 as
+its own historical default. If your tsconfig explicitly selects Node10, TS5107 is preserved so that you can migrate the
+project configuration. Other TypeScript deprecations are not suppressed.
+
+## Backward compatibility
+
+Projects using TypeScript 4.3 through 6 continue to install `typescript` normally and require no configuration changes. The
+`typescript` alias above exposes version 6, so it also satisfies ts-jest's existing TypeScript peer dependency. This avoids a
+second runtime lookup or version-dependent transform path.
+
+This integration should be reevaluated when TypeScript ships a stable programmatic API for the native compiler. Until then,
+the aliases keep the native compiler and ts-jest's compiler API responsibilities explicit and independently upgradeable.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -27,6 +27,7 @@ module.exports = {
         'guides/mock-es6-class',
         'guides/react-native',
         'guides/troubleshooting',
+        'guides/typescript-7',
         'guides/using-with-monorepo',
       ],
     },


### PR DESCRIPTION
## Summary

- support TypeScript 7 projects through Microsoft's official side-by-side npm aliases
- keep ts-jest on the stable TypeScript 6 JavaScript API while native `tsc` performs TypeScript 7 project checks
- fail early with an actionable message when TypeScript 7 is loaded directly as ts-jest's compiler
- filter TS5107 only when it comes from ts-jest's injected `moduleResolution: Node10` default
- document setup, architecture, tradeoffs, limitations, and rejected alternatives

## User setup

```json
{
  "devDependencies": {
    "@typescript/native": "npm:typescript@^7.0.2",
    "typescript": "npm:@typescript/typescript6@^6.0.2"
  }
}
```

With this arrangement, `npx tsc` is TypeScript 7, `npx tsc6` is the TypeScript 6 compatibility compiler, and ts-jest's existing `typescript` import resolves to the classic TypeScript 6 runtime and declarations.

TypeScript 7 should remain a separate project type-check, for example `npx tsc --noEmit`, while Jest transforms and transform-time diagnostics use the TypeScript 6 compatibility API.

## Architecture and rationale

TypeScript 7.0 does not expose the JavaScript compiler API required for ts-jest's language service, isolated transpilation, custom AST transformers, `Program` access, diagnostics, and source maps. This change follows Microsoft's supported transition layout instead of adding another compiler integration.

No unstable TypeScript 7 API is used. There is no native-diagnostics path, dual-compiler runtime, or automatic fallback lookup.

Automatic fallback from direct `typescript@7` to `@typescript/typescript6` was rejected because ts-jest's public declarations import classic compiler types from `typescript`; a runtime-only fallback would leave those public types inconsistent. Native API/protocol integration was rejected because TypeScript 7.0 has no stable programmatic API and cannot preserve the current transformer and `Program` contracts.

## Backward compatibility

- existing TypeScript 4.3 through 6 compiler paths and public APIs are unchanged
- the `typescript` peer range remains `>=4.3 <7`; the TypeScript 6 alias satisfies it
- CJS and ESM are covered in both LanguageService and isolated-module modes
- source maps, Jest mock hoisting, custom AST transformers, and `Program` access are exercised in the compatibility matrix
- explicit `moduleResolution: Node10` still reports TS5107, and unrelated deprecations remain visible

## Tradeoffs and limitations

- native TypeScript 7 performance benefits project type-checking and builds, not ts-jest transforms; transform performance remains TypeScript 6 performance
- Jest transform diagnostics come from TypeScript 6 and can differ from TypeScript 7, so the native `tsc` check should be authoritative
- the integration should be reevaluated when TypeScript publishes a stable native programmatic API

## Validation

Baseline before implementation:

- `npm run build` — passed
- `npm run test -- --maxWorkers=3` — 20 suites, 355 tests, 136 snapshots passed
- `npm run lint` — 0 errors; one pre-existing unused-disable warning in `website/docusaurus.config.ts`

Final repository validation:

- `npm run build` — passed
- `npm run test -- --maxWorkers=3` — 20 suites, 358 tests, 137 snapshots passed
- `npm run lint` — 0 errors; same pre-existing warning
- `npm run lint-prettier-ci` — passed
- `npm run test-e2e-cjs` — 21 suites, 27 tests passed
- `npm run test-e2e-esm` — 21 suites, 29 tests passed
- `cd website && npm run build` — TypeScript check and Docusaurus production build passed

Compatibility matrix, each exercising CJS/ESM × LanguageService/isolated modules:

- TypeScript 4.3.5 — passed; `tsc` reported 4.3.5
- TypeScript 5.9.3 — passed; `tsc` reported 5.9.3
- `typescript@npm:@typescript/typescript6@6.0.2` — passed; runtime/`tsc6` reported 6.0.3
- official aliases (`@typescript/native@npm:typescript@7.0.2` + `typescript@npm:@typescript/typescript6@6.0.2`) — passed; `tsc` reported 7.0.2 and `tsc6` reported 6.0.3

The alias row additionally passes public declaration consumption with `skipLibCheck: false` under both `tsc` and `tsc6`, verifies the actionable direct-TypeScript-7 error, and proves explicit Node10 still raises TS5107.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TypeScript compatibility e2e coverage, including transformer behavior and source-map preservation checks.
* **Bug Fixes**
  * Improved handling of `moduleResolution: node10` deprecation diagnostics (filtered vs preserved based on explicit configuration).
  * Added a clearer error when the installed TypeScript package lacks the required JavaScript compiler API.
* **Tests**
  * Expanded compatibility testing across CJS/ESM and isolated-module modes, including Jest hoisting verification.
* **Documentation**
  * Added a TypeScript 7 guide and updated installation and `compiler` option guidance.
* **CI**
  * Introduced a TypeScript compatibility job running a build and multi-version Jest matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->