### PR TITLE
chore(release): 29.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [29.4.12](https://github.com/kulshekhar/ts-jest/compare/v29.4.11...v29.4.12) (2026-07-22)
+
+
+### Features
+
+* **compiler:** support TypeScript 7 projects through compatibility aliases ([#5386](https://github.com/kulshekhar/ts-jest/pull/5386))
+
 ## [29.4.11](https://github.com/kulshekhar/ts-jest/compare/v29.4.10...v29.4.11) (2026-05-21)
 
 
@@ -2069,6 +2076,5 @@ For example
 
 <a name="0.0.0"></a>
 # 0.0.0 (2016-08-30)
-
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-jest",
-  "version": "29.4.11",
+  "version": "29.4.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-jest",
-      "version": "29.4.11",
+      "version": "29.4.12",
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-jest",
-  "version": "29.4.11",
+  "version": "29.4.12",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

Prepare the stable `29.4.12` release containing TypeScript 7 project support from #5386.

## Changes

- bump `package.json` and `package-lock.json` to `29.4.12`
- add a curated changelog entry for TypeScript 7 compatibility aliases

## Validation

- post-merge `main` CI: 24/24 jobs passed
- security audit and docs deployment passed
- release lifecycle: 20 suites, 358 tests, and 137 snapshots passed on Node 22 inside the isolated Docker environment
- lockfile audit confirmed that only the package and root version fields changed

## Publication

Merging this PR into `main` with a rebase or squash merge will immediately trigger the tag and npm publication workflows for `v29.4.12`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compiler support for TypeScript 7 projects through compatibility aliases.

* **Chores**
  * Released version 29.4.12 with updated changelog information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->