### PR TITLE
build: remove duplicated typescript eslint deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,6 @@
         "@types/semver": "^7.8.0",
         "@types/yargs": "^17.0.35",
         "@types/yargs-parser": "21.0.3",
-        "@typescript-eslint/eslint-plugin": "^8.68.0",
-        "@typescript-eslint/parser": "^8.68.0",
         "babel-jest": "^30.4.1",
         "conventional-changelog": "^7.2.1",
         "conventional-changelog-angular": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -111,8 +111,6 @@
     "@types/semver": "^7.8.0",
     "@types/yargs": "^17.0.35",
     "@types/yargs-parser": "21.0.3",
-    "@typescript-eslint/eslint-plugin": "^8.68.0",
-    "@typescript-eslint/parser": "^8.68.0",
     "babel-jest": "^30.4.1",
     "conventional-changelog-angular": "^8.3.1",
     "conventional-changelog": "^7.2.1",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Since we have `typescript-eslint`, we don't need `"@typescript-eslint/eslint-plugin"` and `"@typescript-eslint/parser"`

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused TypeScript linting packages from the project’s development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->